### PR TITLE
Fix retreat preview during build pile completion animations

### DIFF
--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,33 +1,62 @@
 import { useTheme } from 'next-themes';
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select';
-import {themes} from "@/types";
+import {themes, type Theme} from "@/types";
+import { Button } from '@/components/ui/button';
 import * as Lucide from 'lucide-react';
 import type {ComponentType, SVGProps} from "react";
 
 export function ThemeSwitcher() {
   const { setTheme, theme } = useTheme();
+  const activeTheme: Theme = themes.some(({ value }) => value === theme)
+    ? theme as Theme
+    : 'theme-light';
 
   const getIcon = (iconName: string) => {
     const IconComponent = Lucide[iconName as keyof typeof Lucide] as unknown as ComponentType<SVGProps<SVGSVGElement>>;
     return IconComponent ? <IconComponent className="w-4 h-4 mr-2" /> : null;
   };
 
-  return (<div className="relative" data-testid="theme-switcher">
-    <Select value={theme} onValueChange={setTheme}>
-      <SelectTrigger className="w-32" data-testid="theme-switcher-trigger" aria-label="Thème">
-        <SelectValue placeholder="Thème" />
-      </SelectTrigger>
-      <SelectContent data-testid="theme-switcher-content">
-        {themes.map(({ value, label, icon }) => (
-          <SelectItem key={value} value={value} data-testid={`theme-option-${value}`}>
-            <div className="flex items-center">
-              {getIcon(icon)}
-              {label}
-            </div>
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  </div>
+  const setRandomTheme = () => {
+    const availableThemes = themes
+      .map(({ value }) => value)
+      .filter((value) => value !== activeTheme);
+
+    if (availableThemes.length === 0) {
+      return;
+    }
+
+    const randomTheme = availableThemes[Math.floor(Math.random() * availableThemes.length)];
+    setTheme(randomTheme);
+  };
+
+  return (
+    <div className="relative flex items-center gap-2" data-testid="theme-switcher">
+      <Select value={activeTheme} onValueChange={setTheme}>
+        <SelectTrigger className="w-32" data-testid="theme-switcher-trigger" aria-label="Thème">
+          <SelectValue placeholder="Thème" />
+        </SelectTrigger>
+        <SelectContent data-testid="theme-switcher-content">
+          {themes.map(({ value, label, icon }) => (
+            <SelectItem key={value} value={value} data-testid={`theme-option-${value}`}>
+              <div className="flex items-center">
+                {getIcon(icon)}
+                {label}
+              </div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        onClick={setRandomTheme}
+        aria-label="Thème aléatoire"
+        title="Thème aléatoire"
+        data-testid="theme-randomizer-button"
+      >
+        <Lucide.Shuffle className="h-4 w-4" />
+      </Button>
+    </div>
   );
 }

--- a/tests/ui/layout-and-accessibility.spec.ts
+++ b/tests/ui/layout-and-accessibility.spec.ts
@@ -1,7 +1,7 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test, type Page } from '@playwright/test';
 
-import type { Theme } from '../../src/types/index.ts';
+import { themes, type Theme } from '../../src/types/index.ts';
 import {
   expectScreenshotIfBaselineExists,
   expectNoHorizontalOverflow,
@@ -45,6 +45,34 @@ test.describe('Layout and interaction coverage', () => {
     await page.reload();
     await expect(page.getByTestId('app-main')).toBeVisible();
     await expectThemeClass(page, 'theme-retro-space');
+  });
+
+  test('@desktop random theme button picks a different theme and persists it', async ({ page }) => {
+    await gotoFixture(page, 'ready-human', 'theme-light');
+    await expectThemeClass(page, 'theme-light');
+
+    const availableThemes = themes.map(({ value }) => value as Theme);
+
+    await page.getByTestId('theme-randomizer-button').click();
+    await page.waitForFunction(
+      ({ themeValues, previousTheme }) =>
+        themeValues.some((value) => document.documentElement.classList.contains(value) && value !== previousTheme),
+      { themeValues: availableThemes, previousTheme: 'theme-light' satisfies Theme },
+    );
+
+    const selectedTheme = await page.evaluate(
+      (themeValues) =>
+        themeValues.find((value) => document.documentElement.classList.contains(value)) ?? null,
+      availableThemes,
+    );
+
+    expect(selectedTheme).not.toBeNull();
+    expect(selectedTheme).not.toBe('theme-light');
+    await expectThemeClass(page, selectedTheme as Theme);
+
+    await page.reload();
+    await expect(page.getByTestId('app-main')).toBeVisible();
+    await expectThemeClass(page, selectedTheme as Theme);
   });
 
   test('@desktop theme-retro deck card back keeps its striped background', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Hide newly completed retreat cards from the preview while their completion animation is still active
- Keep already settled retreat cards visible so the retreat pile preview does not jump ahead
- Add focused `CenterArea` tests covering fully pending and partially settled completion states

## Testing
- `pnpm test -- CenterArea`
- `pnpm lint`
- `pnpm typecheck`