### PR TITLE
feat(web): replace CSS transitions with WAAPI, add Skip-Bo morph

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,12 @@
   "permissions": {
     "allow": [
       "Bash(pnpm *)",
-      "Bash(xxd)"
+      "Bash(xxd)",
+      "Bash(gh run *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(grep -r \"transform\\\\|transition\\\\|animation\\\\|keyframe\" /Users/pierreluc/Development/skip-bo/apps/web/src/themes/*.css)"
     ]
   }
 }

--- a/apps/web/src/components/AnimatedCard.tsx
+++ b/apps/web/src/components/AnimatedCard.tsx
@@ -59,6 +59,7 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({ animation }) => {
 
     // Guard for environments without WAAPI (e.g. jsdom in unit tests)
     if (typeof el.animate !== 'function') {
+      markAnimationStarted(animation.id);
       const fallback = setTimeout(() => removeAnimation(animation.id), duration);
       return () => clearTimeout(fallback);
     }
@@ -109,6 +110,8 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({ animation }) => {
       firstHalfAnim?.cancel();
       secondHalfRef.current?.cancel();
     };
+    // animation and its derivatives are stable for the lifetime of this component:
+    // the parent always mounts a new AnimatedCard per animation.id.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isVisible]);
 

--- a/apps/web/src/components/AnimatedCard.tsx
+++ b/apps/web/src/components/AnimatedCard.tsx
@@ -1,108 +1,147 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Card } from '@/components/Card';
 import type { CardAnimationData } from '@/contexts/CardAnimationContext';
+import { useCardAnimation } from '@/contexts/useCardAnimation';
 import { cn } from '@/lib/utils';
 
 interface AnimatedCardProps {
   animation: CardAnimationData;
 }
 
-export const AnimatedCard: React.FC<AnimatedCardProps> = ({ 
-  animation
-}) => {
-  const [isAnimating, setIsAnimating] = useState(false);
+export const AnimatedCard: React.FC<AnimatedCardProps> = ({ animation }) => {
+  const { removeAnimation, markAnimationStarted } = useCardAnimation();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const flipRef = useRef<HTMLDivElement>(null);
+  // Card is invisible during the initial delay — same UX as before
   const [isVisible, setIsVisible] = useState(animation.initialDelay === 0);
-  const [isRevealed, setIsRevealed] = useState<boolean>(animation.sourceRevealed);
+  // For flip animations: tracks which face is currently showing
+  const [isRevealed, setIsRevealed] = useState(animation.sourceRevealed);
   const needsFlip = animation.sourceRevealed !== animation.targetRevealed;
+  // Tracks the second-half flip animation so the cleanup can cancel it
+  const secondHalfRef = useRef<Animation | undefined>(undefined);
 
+  // Effect 1: wait out the initial delay before showing the card
   useEffect(() => {
-    let startTimer = 0 as unknown as number;
-    let flipTimer: NodeJS.Timeout | undefined;
+    if (animation.initialDelay === 0) return;
+    const timeout = setTimeout(() => setIsVisible(true), animation.initialDelay);
+    return () => clearTimeout(timeout);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [animation.id]);
 
-    const startedTimeout = setTimeout(() => {
-      setIsVisible(true);
+  // Effect 2: start WAAPI once the card element is actually in the DOM.
+  // useLayoutEffect fires synchronously after React commits the render, so
+  // rootRef.current is guaranteed to be set here — even for delayed cards.
+  useLayoutEffect(() => {
+    if (!isVisible) return;
 
-      // Start animation on next frame to ensure initial position is set
-      startTimer = requestAnimationFrame(() => {
-        setIsAnimating(true);
-      });
+    markAnimationStarted(animation.id);
 
-      // Schedule reveal flip at mid-duration when applicable
-      if (needsFlip && animation.duration > 0) {
-        const half = Math.max(1, Math.floor(animation.duration * 0.35)); //For cubic-bezier(0.4, 0.0, 0.2, 1), the midpoint is ~35%
-        flipTimer = setTimeout(() => setIsRevealed(animation.targetRevealed), half);
-      }
-    }, animation.initialDelay);
+    const el = rootRef.current;
+    if (!el) return;
+
+    const style = getComputedStyle(el);
+    const cardW = parseFloat(style.getPropertyValue('--card-width')) || 0;
+    const cardH = parseFloat(style.getPropertyValue('--card-height')) || 0;
+    const halfW = cardW / 2;
+    const halfH = cardH / 2;
+
+    const startAngle = animation.startAngleDeg ?? 0;
+    const endAngle = animation.endAngleDeg ?? 0;
+    const sx = animation.startPosition.x - halfW;
+    const sy = animation.startPosition.y - halfH;
+    const ex = animation.endPosition.x - halfW;
+    const ey = animation.endPosition.y - halfH;
+
+    // Pin the card at startPosition before WAAPI fires so it's never at 0,0
+    el.style.transform = `translate(${sx}px, ${sy}px) rotateZ(${startAngle}deg)`;
+
+    const { duration } = animation;
+
+    // Guard for environments without WAAPI (e.g. jsdom in unit tests)
+    if (typeof el.animate !== 'function') {
+      const fallback = setTimeout(() => removeAnimation(animation.id), duration);
+      return () => clearTimeout(fallback);
+    }
+
+    // Main travel animation — no two-frame dance; WAAPI handles timing precisely
+    const travelAnim = el.animate(
+      [
+        { transform: `translate(${sx}px, ${sy}px) rotateZ(${startAngle}deg)` },
+        { transform: `translate(${ex}px, ${ey}px) rotateZ(${endAngle}deg)` },
+      ],
+      { duration, easing: 'cubic-bezier(0.4, 0.0, 0.2, 1)', fill: 'forwards' }
+    );
+
+    // Remove from context once travel completes — no setTimeout guess needed
+    travelAnim.finished.then(() => removeAnimation(animation.id)).catch(() => {});
+
+    // Flip animation: two-phase rotateY so the face-swap happens at 90°
+    // (edge-on = invisible), avoiding any dependency on backface-visibility or
+    // preserve-3d, both of which are broken by the filter: rule on .animation-*
+    let firstHalfAnim: Animation | undefined;
+    let flipCancelled = false;
+    if (needsFlip && flipRef.current && duration > 0) {
+      const flipDuration = duration * 0.4;
+      const flipDelay  = duration * 0.3;
+
+      firstHalfAnim = flipRef.current.animate(
+        [{ transform: 'rotateY(0deg)' }, { transform: 'rotateY(90deg)' }],
+        { duration: flipDuration / 2, delay: flipDelay, easing: 'ease-in', fill: 'forwards' }
+      );
+
+      firstHalfAnim.finished.then(() => {
+        // Guard: cleanup may have run between firstHalf finishing and this callback
+        if (flipCancelled) return;
+        // Card is edge-on (invisible) — swap the face; the re-render is imperceptible
+        setIsRevealed(animation.targetRevealed);
+        // Second half: start from the opposite edge so the card "unfolds" forward
+        secondHalfRef.current = flipRef.current!.animate(
+          [{ transform: 'rotateY(-90deg)' }, { transform: 'rotateY(0deg)' }],
+          { duration: flipDuration / 2, easing: 'ease-out', fill: 'forwards' }
+        );
+        secondHalfRef.current.finished.catch(() => {});
+      }).catch(() => {});
+    }
 
     return () => {
-      if (startTimer) cancelAnimationFrame(startTimer);
-      clearTimeout(startedTimeout);
-      if (flipTimer) clearTimeout(flipTimer);
+      travelAnim.cancel();
+      flipCancelled = true;
+      firstHalfAnim?.cancel();
+      secondHalfRef.current?.cancel();
     };
-  }, [animation.id, animation.duration, animation.animationType, animation.card.value, animation.initialDelay, needsFlip, animation.targetRevealed]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isVisible]);
 
   if (!isVisible) {
     return null;
   }
 
-  const currentAngleZ = isAnimating ? (animation.endAngleDeg ?? 0) : (animation.startAngleDeg ?? 0);
-
-  // Apply rotateY for flip during animation
-  const currentAngleY = needsFlip ? (isAnimating ? 0 : 180) : 0;
-
-  const style: React.CSSProperties = {
-    position: 'absolute',
-    left: isAnimating ? animation.endPosition.x : animation.startPosition.x,
-    top: isAnimating ? animation.endPosition.y : animation.startPosition.y,
-    zIndex: 1000 - animation.sourceInfo.index, // Ensure animated cards appear above everything
-    pointerEvents: 'none', // Don't interfere with user interactions
-    transition: isAnimating ? `all ${animation.duration}ms cubic-bezier(0.4, 0.0, 0.2, 1)` : 'none',
-    transform: `translate(-50%, -50%) rotateZ(${currentAngleZ}deg) rotateY(${currentAngleY}deg)`,
-    transformStyle: 'preserve-3d',
-    willChange: 'transform left top',
-  };
-
-  const faceCommon: React.CSSProperties = {
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    transformStyle: 'preserve-3d',
-  };
-
   return (
     <div
-      className={cn(
-        'animated-card',
-        `animation-${animation.animationType}`
-      )}
-      style={style}
+      ref={rootRef}
+      className={cn('animated-card', `animation-${animation.animationType}`)}
+      style={{
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        zIndex: 1000 - animation.sourceInfo.index,
+        pointerEvents: 'none',
+      }}
     >
       {needsFlip ? (
-        <div style={{ position: 'relative', width: 'var(--card-width)', height: 'var(--card-height)' }}>
-          {/* Front face (target state) */}
-          <div style={{ ...faceCommon, visibility: isRevealed ? 'visible' : 'hidden' }}>
-            <Card
-              hint="AnimatedCardFront"
-              card={animation.card}
-              isRevealed={animation.targetRevealed}
-              canBeGrabbed={false}
-            />
-          </div>
-          {/* Back face (source state) */}
-          <div style={{ ...faceCommon, transform: 'rotateY(180deg)', visibility: !isRevealed ? 'visible' : 'hidden' }}>
-            <Card
-              hint="AnimatedCardBack"
-              card={animation.card}
-              isRevealed={animation.sourceRevealed}
-              canBeGrabbed={false}
-            />
-          </div>
+        <div ref={flipRef}>
+          <Card
+            hint="AnimatedCard"
+            card={animation.card}
+            isRevealed={isRevealed}
+            canBeGrabbed={false}
+          />
         </div>
       ) : (
         <Card
           hint="AnimatedCard"
           card={animation.card}
-          isRevealed={isRevealed}
+          isRevealed={animation.sourceRevealed}
           canBeGrabbed={false}
         />
       )}

--- a/apps/web/src/components/Card.tsx
+++ b/apps/web/src/components/Card.tsx
@@ -27,6 +27,8 @@ function getTextAndColourForCard(card: CardType | null, overriddenDisplayValue: 
   return { colourClass, cardValue };
 }
 
+const MORPH_START_DELAY_MS = 50;
+
 const CardComponent: React.FC<CardProps> = ({
                                               card,
                                               isRevealed = true,
@@ -50,15 +52,13 @@ const CardComponent: React.FC<CardProps> = ({
     isMorphCandidate ? 'yes' : 'no'
   );
 
-  const morphingStartDelay = 50;
-
   useLayoutEffect(() => {
     if (!isMorphCandidate) return;
     // Transition to 'after' to start the crossfade, then stay there — the card is
     // remounted via `key` on each new play so there is no need to clean up state.
     // Switching back to 'no' (single-card branch) causes a DOM structure swap that
     // shifts the corner-number by 1-2 px due to absolute vs. static positioning.
-    const toAfter = setTimeout(() => setMorphing('after'), morphingStartDelay);
+    const toAfter = setTimeout(() => setMorphing('after'), MORPH_START_DELAY_MS);
     return () => clearTimeout(toAfter);
   }, [isMorphCandidate]);
 

--- a/apps/web/src/components/Card.tsx
+++ b/apps/web/src/components/Card.tsx
@@ -39,26 +39,28 @@ const CardComponent: React.FC<CardProps> = ({
                                               displayValue: overriddenDisplayValue,
                                               hint,
                                             }) => {
-  const [morphing, setMorphing] = useState<'no' | 'yes' | 'after'>('no');
+  // When a Skip-Bo card is rendered with a displayValue (e.g. settled on a build
+  // pile), morph from the Skip-Bo face to the numeric value. Start in 'yes' via
+  // the useState initializer so the first painted frame shows Skip-Bo — otherwise
+  // the user sees the numeric value flash before the morph begins. Callers must
+  // give the Card a key derived from card identity so a new play remounts this
+  // component and the initializer re-runs.
+  const isMorphCandidate = Boolean(card?.isSkipBo && overriddenDisplayValue !== undefined);
+  const [morphing, setMorphing] = useState<'no' | 'yes' | 'after'>(
+    isMorphCandidate ? 'yes' : 'no'
+  );
 
-  const morphingDelay = 100;
-  const morphingAfterDelay = 700;
+  const morphingStartDelay = 50;
 
   useLayoutEffect(() => {
-    let startTimer: ReturnType<typeof setTimeout> | undefined;
-    let timer1: ReturnType<typeof setTimeout> | undefined;
-    let timer2: ReturnType<typeof setTimeout> | undefined;
-    if (card && card.isSkipBo) {
-      startTimer = setTimeout(() => setMorphing('yes'), 0);
-      timer1 = setTimeout(() => setMorphing('after'), morphingDelay);
-      timer2 = setTimeout(() => setMorphing('no'), morphingDelay + morphingAfterDelay);
-    }
-    return () =>  {
-      clearTimeout(startTimer);
-      clearTimeout(timer1);
-      clearTimeout(timer2);
-    }
-  }, [card, card?.isSkipBo]);
+    if (!isMorphCandidate) return;
+    // Transition to 'after' to start the crossfade, then stay there — the card is
+    // remounted via `key` on each new play so there is no need to clean up state.
+    // Switching back to 'no' (single-card branch) causes a DOM structure swap that
+    // shifts the corner-number by 1-2 px due to absolute vs. static positioning.
+    const toAfter = setTimeout(() => setMorphing('after'), morphingStartDelay);
+    return () => clearTimeout(toAfter);
+  }, [isMorphCandidate]);
 
   // Determine whether we should render a morphing overlay
   const shouldMorph = Boolean(
@@ -98,24 +100,23 @@ const CardComponent: React.FC<CardProps> = ({
     </> : <div className='back'></div>
   );
 
-  if (card && shouldMorph) {
-    const interactiveProps: HTMLAttributes<HTMLDivElement> = onClick ? {
-      onClick,
-      role: 'button',
-      tabIndex: 0,
-      'aria-label': hint ?? cardValue,
-      'aria-pressed': isSelected ? true : undefined,
-      onKeyDown: ((event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          onClick(event as unknown as Parameters<NonNullable<CardProps['onClick']>>[0]);
-        }
-      }) as KeyboardEventHandler<HTMLDivElement>,
-    } : {};
+  const interactiveProps: HTMLAttributes<HTMLDivElement> = onClick ? {
+    onClick,
+    role: 'button',
+    tabIndex: 0,
+    'aria-label': hint ?? cardValue,
+    'aria-pressed': isSelected ? true : undefined,
+    onKeyDown: ((event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onClick(event as unknown as Parameters<NonNullable<CardProps['onClick']>>[0]);
+      }
+    }) as KeyboardEventHandler<HTMLDivElement>,
+  } : {};
 
-    // During morphing: outer card acts as a transparent wrapper to preserve layout/hover positions.
-    const fromOpacity = morphing === 'yes' ? 1 : 0; // fade out after delay
-    const toOpacity = morphing === 'yes' ? 0 : 1;   // fade in after delay
+  if (card && shouldMorph) {
+    const fromOpacity = morphing === 'yes' ? 1 : 0;
+    const toOpacity = morphing === 'yes' ? 0 : 1;
 
     return (
       <div
@@ -151,27 +152,13 @@ const CardComponent: React.FC<CardProps> = ({
     );
   }
 
-  // Default: render single card as before
   const content = renderContent(cardValue);
-  const interactiveProps: HTMLAttributes<HTMLDivElement> = onClick ? {
-    onClick,
-    role: 'button',
-    tabIndex: 0,
-    'aria-label': hint ?? cardValue,
-    'aria-pressed': isSelected ? true : undefined,
-    onKeyDown: ((event) => {
-      if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        onClick(event as unknown as Parameters<NonNullable<CardProps['onClick']>>[0]);
-      }
-    }) as KeyboardEventHandler<HTMLDivElement>,
-  } : {};
 
   return (card ?
       <div
         className={cn(
           'card',
-          (card && isRevealed) && (card.isSkipBo ? 'skip-bo' : 'normal-card'), 
+          (card && isRevealed) && (cardValue === 'Skip-Bo' ? 'skip-bo' : 'normal-card'),
           colourClass,
           morphing === 'after' && `transition duration-800`,
           isSelected && 'selected',

--- a/apps/web/src/components/CenterArea.tsx
+++ b/apps/web/src/components/CenterArea.tsx
@@ -73,10 +73,13 @@ export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps
                   animation.targetInfo?.source === 'build' &&
                   animation.targetInfo.index === index,
               );
+              // True while at least one card is still waiting to depart (in its initialDelay).
+              // Becomes false once the last card has left the pile position.
               const buildPileIsCompleting = activeAnimations.some(
                 (animation) =>
                   animation.sourceInfo.source === 'build' &&
-                  animation.sourceInfo.index === index,
+                  animation.sourceInfo.index === index &&
+                  !animation.hasStarted,
               );
               const shouldMaskIncomingPlay = Boolean(incomingPlayAnimation);
               const visiblePileLength = shouldMaskIncomingPlay
@@ -120,16 +123,24 @@ export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps
                 >
                   {visibleTopCard && !buildPileIsCompleting ? (
                     <Card
+                      key={`build-top-${index}-${visiblePileLength}`}
                       hint={`Construction pile ${index + 1}`}
-                      card={{
-                        ...visibleTopCard,
-                        isSkipBo: false,
-                      }}
+                      card={visibleTopCard}
                       isRevealed={true}
                       canBeGrabbed={false}
                       displayValue={visiblePileLength.toString()}
                     />
-                  ) : shouldMaskIncomingPlay && pile.length === 0 && !buildPileIsCompleting ? (
+                  ) : buildPileIsCompleting ? (
+                    // Pile cleared in state before animation runs — keep showing the
+                    // completed "12" card as a static backdrop while cards fly off.
+                    <Card
+                      hint={`Construction pile ${index + 1}`}
+                      card={{ value: gameState.config.CARD_VALUES_MAX, isSkipBo: false }}
+                      isRevealed={true}
+                      canBeGrabbed={false}
+                      displayValue={gameState.config.CARD_VALUES_MAX.toString()}
+                    />
+                  ) : shouldMaskIncomingPlay && pile.length === 0 ? (
                     <Card
                       hint={`Construction pile ${index + 1}`}
                       card={{

--- a/apps/web/src/components/__tests__/AnimatedCard.test.tsx
+++ b/apps/web/src/components/__tests__/AnimatedCard.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AnimatedCard } from '@/components/AnimatedCard';
+import { CardAnimationProvider } from '@/contexts/CardAnimationContext';
 import type { CardAnimationData } from '@/contexts/CardAnimationContext';
 
 const createAnimation = (initialDelay: number): CardAnimationData => ({
@@ -30,7 +31,11 @@ describe('AnimatedCard', () => {
   it('stays hidden until its initial delay elapses', () => {
     vi.useFakeTimers();
 
-    const { container } = render(<AnimatedCard animation={createAnimation(200)} />);
+    const { container } = render(
+      <CardAnimationProvider>
+        <AnimatedCard animation={createAnimation(200)} />
+      </CardAnimationProvider>
+    );
 
     expect(container.querySelector('.animated-card')).toBeNull();
 

--- a/apps/web/src/components/__tests__/CenterArea.test.tsx
+++ b/apps/web/src/components/__tests__/CenterArea.test.tsx
@@ -48,6 +48,7 @@ const createAnimationContext = (
   activeAnimations,
   startAnimation: vi.fn(),
   removeAnimation: vi.fn(),
+  markAnimationStarted: vi.fn(),
   isCardBeingAnimated: vi.fn(() => false),
   waitForAnimations: vi.fn(async () => undefined),
 });

--- a/apps/web/src/components/__tests__/CenterArea.test.tsx
+++ b/apps/web/src/components/__tests__/CenterArea.test.tsx
@@ -167,4 +167,27 @@ describe('CenterArea', () => {
     expect(buildPile?.querySelector('.card[data-value="4"]')).not.toBeNull();
     expect(buildPile?.querySelector('.card[data-value="5"]')).toBeNull();
   });
+
+  test('shows "12" backdrop while completion animations have not yet started', () => {
+    const gameState = createGameState([]);
+    // Build pile 0 is already cleared from state; animations are still in flight
+    const animations = createCompletionAnimations(3); // hasStarted is undefined (falsy)
+
+    const { container } = renderCenterArea(gameState, animations);
+    const buildPile = container.querySelector<HTMLElement>('[data-build-pile="0"]');
+
+    expect(buildPile?.querySelector('.card[data-value="12"]')).not.toBeNull();
+    expect(buildPile?.querySelector('.empty-card')).toBeNull();
+  });
+
+  test('hides "12" backdrop once all completion animations have started', () => {
+    const gameState = createGameState([]);
+    const animations = createCompletionAnimations(3).map((a) => ({ ...a, hasStarted: true }));
+
+    const { container } = renderCenterArea(gameState, animations);
+    const buildPile = container.querySelector<HTMLElement>('[data-build-pile="0"]');
+
+    expect(buildPile?.querySelector('.card[data-value="12"]')).toBeNull();
+    expect(buildPile?.querySelector('.empty-card')).not.toBeNull();
+  });
 });

--- a/apps/web/src/components/__tests__/OnlineAnimationMasking.test.tsx
+++ b/apps/web/src/components/__tests__/OnlineAnimationMasking.test.tsx
@@ -47,6 +47,7 @@ const createAnimationContext = (
   activeAnimations,
   startAnimation: vi.fn(),
   removeAnimation: vi.fn(),
+  markAnimationStarted: vi.fn(),
   isCardBeingAnimated: vi.fn(() => false),
   waitForAnimations: vi.fn(async () => undefined),
 });
@@ -123,6 +124,7 @@ const createStockAnimationContext = (
   activeAnimations: [],
   startAnimation: vi.fn(),
   removeAnimation: vi.fn(),
+  markAnimationStarted: vi.fn(),
   isCardBeingAnimated: vi.fn((candidatePlayerIndex, source, index) =>
     candidatePlayerIndex === playerIndex &&
     source === 'stock' &&

--- a/apps/web/src/contexts/CardAnimationContext.tsx
+++ b/apps/web/src/contexts/CardAnimationContext.tsx
@@ -19,6 +19,8 @@ export interface CardAnimationData {
   endAngleDeg?: number;
   // True when the authoritative UI state already contains the animated card at the target.
   targetSettledInState?: boolean;
+  // True once AnimatedCard has started the WAAPI travel (initialDelay elapsed).
+  hasStarted?: boolean;
   // Source information to identify which card should be hidden
   sourceInfo: {
     playerIndex: number;
@@ -38,6 +40,7 @@ export interface AnimationContextType {
   activeAnimations: CardAnimationData[];
   startAnimation: (animationData: Omit<CardAnimationData, 'id'>) => string;
   removeAnimation: (id:string) => void;
+  markAnimationStarted: (id: string) => void;
   isCardBeingAnimated: (
     playerIndex: number,
     source: 'hand' | 'stock' | 'discard' | 'deck' | 'build',
@@ -88,13 +91,8 @@ export const CardAnimationProvider: FC<CardAnimationProviderProps> = ({ children
       setActiveAnimations(prev => [...prev, newAnimation]);
     });
 
-    // Auto-remove animation after duration
-    setTimeout(() => {
-      removeAnimation(id);
-    }, animationData.duration + animationData.initialDelay);
-
     return id;
-  }, [removeAnimation]);
+  }, []);
 
   const waitForAnimations = useCallback(() => {
     return new Promise<void>((resolve) => {
@@ -103,6 +101,14 @@ export const CardAnimationProvider: FC<CardAnimationProviderProps> = ({ children
       } else {
         animationCompletionResolvers.current.push(resolve);
       }
+    });
+  }, []);
+
+  const markAnimationStarted = useCallback((id: string) => {
+    setActiveAnimations(prev => {
+      const target = prev.find(a => a.id === id);
+      if (!target || target.hasStarted) return prev; // already marked — return same ref, no re-render
+      return prev.map(anim => anim.id === id ? { ...anim, hasStarted: true } : anim);
     });
   }, []);
 
@@ -125,6 +131,7 @@ export const CardAnimationProvider: FC<CardAnimationProviderProps> = ({ children
     activeAnimations,
     startAnimation,
     removeAnimation,
+    markAnimationStarted,
     isCardBeingAnimated,
     waitForAnimations,
   };

--- a/apps/web/src/contexts/__tests__/CardAnimationContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/CardAnimationContext.test.tsx
@@ -35,12 +35,12 @@ describe('CardAnimationProvider', () => {
     );
 
     await waitFor(() => expect(context).toBeDefined());
-    vi.useFakeTimers();
 
     let resolved = false;
+    let animId: string | undefined;
 
     act(() => {
-      context!.startAnimation({
+      animId = context!.startAnimation({
         card: { value: 12, isSkipBo: false },
         startPosition: { x: 0, y: 0 },
         endPosition: { x: 40, y: 40 },
@@ -64,8 +64,9 @@ describe('CardAnimationProvider', () => {
     await Promise.resolve();
     expect(resolved).toBe(false);
 
-    await act(async () => {
-      vi.runAllTimers();
+    // Simulate AnimatedCard calling removeAnimation when its WAAPI animation finishes
+    act(() => {
+      context!.removeAnimation(animId!);
     });
 
     await waitPromise;

--- a/apps/web/src/hooks/useSkipBoGame.ts
+++ b/apps/web/src/hooks/useSkipBoGame.ts
@@ -235,90 +235,78 @@ export function useSkipBoGame() {
     return { success: true, message: 'Carte jouée' };
   }, [dispatch, isInteractionBlocked, startAnimation, waitForAnimations]);
 
-  const discardCard = useCallback((discardPile: number): Promise<MoveResult> => {
-    return new Promise((resolve) => {
-      const currentState = stateRef.current;
+  const discardCard = useCallback(async (discardPile: number): Promise<MoveResult> => {
+    const currentState = stateRef.current;
 
-      if (isInteractionBlocked()) {
-        resolve({ success: false, message: 'Action en cours' });
-        return;
-      }
-      
-      // Validate before dispatching
-      if (!currentState.selectedCard) {
-        resolve({ success: false, message: 'Aucune carte sélectionnée' });
-        return;
-      }
+    if (isInteractionBlocked()) {
+      return { success: false, message: 'Action en cours' };
+    }
 
-      if (currentState.selectedCard.source !== 'hand') {
-        resolve({ success: false, message: 'Vous devez défausser une carte de votre main' });
-        return;
-      }
+    if (!currentState.selectedCard) {
+      return { success: false, message: 'Aucune carte sélectionnée' };
+    }
 
-      if (currentState.selectedCard.card.isSkipBo) {
-        resolve({ success: false, message: 'Vous ne pouvez pas défausser une carte Skip-Bo' });
-        return;
-      }
+    if (currentState.selectedCard.source !== 'hand') {
+      return { success: false, message: 'Vous devez défausser une carte de votre main' };
+    }
 
-      interactionLockRef.current = true;
+    if (currentState.selectedCard.card.isSkipBo) {
+      return { success: false, message: 'Vous ne pouvez pas défausser une carte Skip-Bo' };
+    }
 
-      let animationDuration = 0;
+    interactionLockRef.current = true;
 
-      // Trigger animation before state change
-      try {
-        const playerAreaElement = document.querySelector<HTMLElement>(`.player-area[data-player-index="${currentState.currentPlayerIndex}"]`);
-        
-        if (playerAreaElement) {
-          // Calculate start position (hand card)
-          const handContainer = playerAreaElement.querySelector('.hand-area') as HTMLElement;
-          if (handContainer) {
-            const startPosition = getHandCardPosition(handContainer, currentState.selectedCard.index);
-            
-            // Calculate end position (discard pile)
-            const discardContainer = playerAreaElement.querySelector('.discard-piles') as HTMLElement;
-            if (discardContainer) {
-              const endPosition = getNextDiscardCardPosition(discardContainer, discardPile);
-              
-              const duration = calculateAnimationDuration(startPosition, endPosition);
-              animationDuration = duration;
-              startAnimation({
-                card: currentState.selectedCard.card,
-                startPosition,
-                endPosition,
-                animationType: 'discard',
-                sourceRevealed: true,
-                targetRevealed: true,
-                initialDelay: 0,
-                duration,
-                startAngleDeg: getHandCardAngle(handContainer, currentState.selectedCard.index),
-                sourceInfo: {
-                  playerIndex: currentState.currentPlayerIndex,
-                  source: currentState.selectedCard.source,
-                  index: currentState.selectedCard.index,
-                  discardPileIndex: currentState.selectedCard.discardPileIndex,
-                },
-                targetInfo: {
-                  playerIndex: currentState.currentPlayerIndex,
-                  source: 'discard',
-                  index: discardPile,
-                  discardPileIndex: discardPile,
-                },
-              });
-            }
+    // Trigger animation before state change
+    try {
+      const playerAreaElement = document.querySelector<HTMLElement>(`.player-area[data-player-index="${currentState.currentPlayerIndex}"]`);
+
+      if (playerAreaElement) {
+        const handContainer = playerAreaElement.querySelector('.hand-area') as HTMLElement;
+        if (handContainer) {
+          const startPosition = getHandCardPosition(handContainer, currentState.selectedCard.index);
+          const discardContainer = playerAreaElement.querySelector('.discard-piles') as HTMLElement;
+          if (discardContainer) {
+            const endPosition = getNextDiscardCardPosition(discardContainer, discardPile);
+            const duration = calculateAnimationDuration(startPosition, endPosition);
+            startAnimation({
+              card: currentState.selectedCard.card,
+              startPosition,
+              endPosition,
+              animationType: 'discard',
+              sourceRevealed: true,
+              targetRevealed: true,
+              initialDelay: 0,
+              duration,
+              startAngleDeg: getHandCardAngle(handContainer, currentState.selectedCard.index),
+              sourceInfo: {
+                playerIndex: currentState.currentPlayerIndex,
+                source: currentState.selectedCard.source,
+                index: currentState.selectedCard.index,
+                discardPileIndex: currentState.selectedCard.discardPileIndex,
+              },
+              targetInfo: {
+                playerIndex: currentState.currentPlayerIndex,
+                source: 'discard',
+                index: discardPile,
+                discardPileIndex: discardPile,
+              },
+            });
+
+            // Await in the same microtask chain as removeAnimation so the dispatch
+            // happens before the browser can paint the gap between card removal and
+            // state update (fixes the arrival flicker).
+            await waitForAnimations();
           }
         }
-      } catch (error) {
-        console.warn('Animation failed, continuing with game logic:', error);
       }
+    } catch (error) {
+      console.warn('Animation failed, continuing with game logic:', error);
+    }
 
-      // Wait for animation to complete before dispatching state change
-      setTimeout(() => {
-        dispatch({ type: 'DISCARD_CARD', discardPile });
-        interactionLockRef.current = false;
-        resolve({ success: true, message: 'Carte défaussée' });
-      }, animationDuration);
-    });
-  }, [dispatch, isInteractionBlocked, startAnimation]);
+    dispatch({ type: 'DISCARD_CARD', discardPile });
+    interactionLockRef.current = false;
+    return { success: true, message: 'Carte défaussée' };
+  }, [dispatch, isInteractionBlocked, startAnimation, waitForAnimations]);
 
   const clearSelection = useCallback(() => {
     if (isInteractionBlocked()) {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -647,7 +647,7 @@
 
 @utility card {
   @apply text-center leading-none flex items-center justify-center font-bold cursor-pointer card-height
-  lg:text-2xl text-xl text-shadow-sm shadow-(--card-shadow)
+  text-3xl text-shadow-sm shadow-(--card-shadow)
   text-(--card-color) bg-(--card-front-color) rounded-(--card-radius) w-(--card-width) border border-(--card-border-color)
   select-none will-change-auto before:will-change-auto after:will-change-auto;
   transform-origin: bottom center;
@@ -664,7 +664,7 @@
   }
 
   .card-inner, .card-inner-2 {
-    @apply w-full h-full rounded-[inherit] overflow-hidden flex items-center justify-center absolute will-change-transform;
+    @apply z-1 w-full h-full rounded-[inherit] overflow-hidden flex items-center justify-center absolute will-change-transform;
 
     & > * {
       @apply relative z-1 will-change-transform;
@@ -677,16 +677,15 @@
   }
 
   &.normal-card {
-    @apply isolate text-3xl;
+    @apply isolate;
+  }
+  
+  &.empty-card {
+    @apply lg:text-2xl text-xl;
+  }
 
-    .card-inner,
-    .card-inner-2 {
-      @apply z-1;
-    }
-
-    > .card-number {
-      @apply relative z-2;
-    }
+  .card-number {
+    @apply relative z-2;
   }
 }
 

--- a/apps/web/src/utils/cardPositions.ts
+++ b/apps/web/src/utils/cardPositions.ts
@@ -33,14 +33,26 @@ export const getHandCardPosition = (
     return getElementCenter(cardElement);
   }
 
-  const rect = handContainer.getBoundingClientRect();
-  const offset = [4, -3, -5, -3, 4][cardIndex];
+  // Slot is empty (e.g. draw animation targeting an unfilled slot).
+  // Card.tsx always applies overlapIndex offsets (handOverlaps is always true for a
+  // 5-card hand) and the .hand-area holders are narrow, so we compute the final
+  // card position from the hand container's rect + the same offsets Card.tsx uses.
+  const handRect = handContainer.getBoundingClientRect();
+  const handStyle = getComputedStyle(handContainer);
+  const cardW = parseFloat(handStyle.getPropertyValue('--card-width')) || 0;
+  const cardH = parseFloat(handStyle.getPropertyValue('--card-height')) || 0;
+  if (cardW > 0 && cardH > 0) {
+    // Mirrors Card.tsx: left = overlapIndex * (cardWidth - 10), top = yOffsets[overlapIndex]
+    const yOffsets = [4, -3, -5, -3, 4];
+    const yOff = yOffsets[cardIndex] ?? 0;
+    return {
+      x: handRect.left + cardIndex * (cardW - 10) + cardW / 2,
+      y: handRect.top + yOff + cardH / 2,
+    };
+  }
 
-  //Calc from css: `calc(${overlapIndex} * (var(--card-width) - 10px))`,
-  const cardWidth = parseInt(getComputedStyle(handContainer).getPropertyValue('--card-width'), 10);
-  const cardHeight = parseInt(getComputedStyle(handContainer).getPropertyValue('--card-height'), 10);
-  const overlapOffset = 10;
-  return { x: rect.x + (cardIndex * (cardWidth - overlapOffset)) + cardWidth / 2, y: rect.y + offset + cardHeight / 2};
+  console.warn(`[cardPositions] hand dimensions unavailable for index ${cardIndex}, falling back to container center`);
+  return getElementCenter(handContainer);
 };
 
 /**
@@ -80,12 +92,8 @@ export const getDeckPosition = (centerContainer: HTMLElement): CardPosition => {
   if (deckElement) {
     return getElementCenter(deckElement);
   }
-  // Fallback to left side of center container
-  const baseRect = centerContainer.getBoundingClientRect();
-  return {
-    x: baseRect.left + 40,
-    y: baseRect.top + baseRect.height / 2,
-  };
+  console.warn('[cardPositions] deck element not found, falling back to container center');
+  return getElementCenter(centerContainer);
 };
 
 /**


### PR DESCRIPTION
## Summary

- **WAAPI animation engine**: Replaces the fragile two-frame CSS transition approach in `AnimatedCard` with Web Animations API (`element.animate()`). Cards now use `transform: translate()` on the compositor thread; `travelAnim.finished` drives cleanup precisely instead of `setTimeout` guesses.
- **Two-phase flip**: Draw animations that flip a card from face-down to face-up now use a rotateY 0°→90° / -90°→0° two-phase approach, working around the `filter:` CSS rule on `.animation-*` classes that flattens `preserve-3d`/`backface-visibility`.
- **Skip-Bo morph on build piles**: When a Skip-Bo card settles on a construction pile it now smoothly crossfades from the Skip-Bo face to its numeric value. The morph state is initialised synchronously so the first painted frame already shows the Skip-Bo face (no numeric flash). The component stays in `'after'` phase to avoid a DOM structure swap that shifted corner numbers by 1–2 px.
- **Build-pile completion backdrop**: While the 12 completion cards fly to the retreat pile, a static "12" card is shown as a backdrop. It disappears the moment the last card physically leaves the pile (via the new `markAnimationStarted` context signal), not when it finishes travelling.
- **Discard animation flicker fix**: `discardCard` refactored from `new Promise` + `setTimeout` to `async/await` + `waitForAnimations`, so the state dispatch happens in the same microtask chain as animation removal.

## Test plan

- [ ] Play a numeric card from hand → build pile: card flies smoothly, no teleport
- [ ] Play a Skip-Bo card → build pile: card flies as Skip-Bo, then morphs to the pile value after landing
- [ ] Discard a card: no flicker on arrival at the discard pile
- [ ] Draw cards (deck → hand): cards land at the correct slot positions
- [ ] Complete a build pile: "12" remains visible while cards fly to retreat, disappears when the last card lifts off
- [ ] Draw animation flips card face-up mid-flight smoothly (two-phase rotateY)
- [ ] `pnpm test` — 148 tests pass
- [ ] `pnpm typecheck` + `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)