### PR TITLE
feat(protocol): use player display names in online game messages

### DIFF
--- a/packages/multiplayer-protocol/src/views/index.ts
+++ b/packages/multiplayer-protocol/src/views/index.ts
@@ -121,6 +121,7 @@ const getViewMessage = (
   viewerSeatIndex: number,
   status: RoomStatus,
   connectedSeats: number[],
+  players: PlayerView[],
 ): string => {
   const playerCount = gameState.players.length;
   const rotatedWinnerIndex = rotateIndex(gameState.winnerIndex, viewerSeatIndex, playerCount);
@@ -133,14 +134,17 @@ const getViewMessage = (
   }
 
   if (gameState.gameIsOver) {
-    return rotatedWinnerIndex === 0 ? 'Vous avez gagné !' : 'Un adversaire a gagné.';
+    if (rotatedWinnerIndex === 0) return 'Vous avez gagné !';
+    const winnerName = rotatedWinnerIndex !== null ? players[rotatedWinnerIndex]?.displayName : undefined;
+    return winnerName ? `${winnerName} a gagné.` : 'Un adversaire a gagné.';
   }
 
   if (rotatedCurrentPlayerIndex === 0) {
-    return gameState.selectedCard ? 'Sélectionnez une destination' : "C'est votre tour";
+    return gameState.selectedCard ? 'Sélectionnez une destination' : "C’est votre tour";
   }
 
-  return "Tour d'un adversaire";
+  const currentPlayerName = players[rotatedCurrentPlayerIndex]?.displayName;
+  return currentPlayerName ? `Tour de ${currentPlayerName}` : "Tour d’un adversaire";
 };
 
 const toSelectedCardView = (
@@ -210,7 +214,7 @@ export const serializeClientGameView = ({
     currentPlayerIndex: rotateIndex(gameState.currentPlayerIndex, viewerSeatIndex, playerCount) ?? 0,
     deck: redactDeck(gameState.deck),
     gameIsOver: gameState.gameIsOver,
-    message: getViewMessage(gameState, viewerSeatIndex, status, connectedSeats),
+    message: getViewMessage(gameState, viewerSeatIndex, status, connectedSeats, players),
     players,
     room: {
       connectedSeats,


### PR DESCRIPTION
## Summary

- Replace hardcoded \"adversaire\" labels with the actual player's display name in online mode game messages
- \"Tour d'un adversaire\" → \"Tour de [nom du joueur]\" (e.g. \"Tour de Alice\")
- \"Un adversaire a gagné.\" → \"[nom du joueur] a gagné.\" (e.g. \"Bob a gagné.\")
- Falls back to the generic French string if the player name is unavailable

## Test plan

- [ ] Join an online game with two named players
- [ ] Verify the turn message shows the opponent's name instead of \"adversaire\"
- [ ] Win or lose and verify the winner message shows the winner's name
- [ ] Verify unit tests pass: `pnpm --filter @skipbo/multiplayer-protocol test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)