### PR TITLE
fix(ci): opt into Node.js 24 for actions and fix paths-filter base ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master, develop]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   check-paths:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,9 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: write
   pages: write
@@ -50,6 +53,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          base: ${{ github.event.workflow_run.head_branch || github.ref }}
           filters: |
             backend:
               - 'apps/realtime-api/**'


### PR DESCRIPTION
## Summary

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` env var to both `ci.yml` and `deploy.yml` to opt into Node.js 24 for all third-party actions before GitHub forces the migration in June 2026
- Set explicit `base` ref on `dorny/paths-filter` in `deploy.yml` to fix the \"missing before field\" warning that occurs in `workflow_run` event contexts

## Test plan

- [ ] Verify the next CI/CD run shows no Node.js 20 deprecation warnings
- [ ] Verify paths-filter no longer warns about missing `before` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)