### PR TITLE
Refine player area styles in Minecraft theme

### DIFF
--- a/apps/web/src/themes/minecraft.css
+++ b/apps/web/src/themes/minecraft.css
@@ -66,14 +66,17 @@
     background-repeat: repeat;
   }
 
-  .player-area.active-turn {
+  .player-area {
     --minecraft-active-border-tile-size: 5px;
     --minecraft-active-border-width: 5px;
+  }
+
+  .player-area.active-turn {
     --tw-ring-color: transparent;
     --tw-ring-shadow: 0 0 #0000;
   }
 
-  .player-area.active-turn:not(.winner)::after {
+  .player-area::after {
     content: '';
     position: absolute;
     inset: 0;
@@ -95,6 +98,12 @@
     box-shadow:
       inset 0 0 0 2px rgba(0, 0, 0, 0.55),
       5px 5px 0 rgba(0, 0, 0, 0.28);
+    opacity: 0;
+    transition: opacity 0.6s;
+  }
+
+  .player-area.active-turn:not(.winner)::after {
+    opacity: 1;
   }
 
   /* Empty spots — wood plank texture */


### PR DESCRIPTION
Refines the `.player-area` styles for consistency and improved visual clarity in the Minecraft theme. Changes include:

- Adjusting base styles for `.player-area` for better consistency.
- Adding smoother transition effects and opacity control to `.player-area::after`.
- Enhancing `.player-area.active-turn` logic for clearer visual feedback.