### PR TITLE
fix(web): draw animation lands exactly in hand slot

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev:web"],
+      "port": 5173
+    },
+    {
+      "name": "realtime-api",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev:api"],
+      "port": 8787
+    }
+  ]
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,6 +12,7 @@
       "mcp__plugin_playwright_playwright__browser_take_screenshot",
       "mcp__plugin_playwright_playwright__browser_snapshot",
       "mcp__plugin_playwright_playwright__browser_click",
+      "mcp__plugin_playwright_playwright__browser_evaluate",
       "Bash(gh pr *)",
       "Bash(chmod +x */.claude/hooks/*)"
     ]

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /playwright-report/
 /test-results/
 /apps/web/playwright-report/
+.playwright-mcp/
 /apps/web/test-results/
 /infra/terraform/envs/prod/.terraform/
 /infra/terraform/envs/prod/.terraform.lock.hcl

--- a/apps/web/src/components/AnimatedCard.tsx
+++ b/apps/web/src/components/AnimatedCard.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Card } from '@/components/Card';
 import type { CardAnimationData } from '@/contexts/CardAnimationContext';
 import { useCardAnimation } from '@/contexts/useCardAnimation';
@@ -12,6 +13,19 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({ animation }) => {
   const { removeAnimation, markAnimationStarted } = useCardAnimation();
   const rootRef = useRef<HTMLDivElement>(null);
   const flipRef = useRef<HTMLDivElement>(null);
+
+  // For draw animations, portal into the destination hand-area so the in-flight
+  // card shares its stacking context. Without this, .player-area's
+  // `isolation: isolate` traps the global animation layer (z=1000) below the
+  // hand cards' parent context, but the animated card still floats above
+  // siblings in the same stacking trap — producing the visible z-snap when the
+  // card lands and the real card mounts at its lower slot z-index.
+  const portalTarget = useMemo<HTMLElement | null>(() => {
+    if (animation.animationType !== 'draw') return null;
+    return document.querySelector<HTMLElement>(
+      `.player-area[data-player-index="${animation.sourceInfo.playerIndex}"] .hand-area.overlap-hand`
+    );
+  }, [animation.animationType, animation.sourceInfo.playerIndex]);
   // Card is invisible during the initial delay — same UX as before
   const [isVisible, setIsVisible] = useState(animation.initialDelay === 0);
   // For flip animations: tracks which face is currently showing
@@ -47,10 +61,16 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({ animation }) => {
 
     const startAngle = animation.startAngleDeg ?? 0;
     const endAngle = animation.endAngleDeg ?? 0;
-    const sx = animation.startPosition.x - halfW;
-    const sy = animation.startPosition.y - halfH;
-    const ex = animation.endPosition.x - halfW;
-    const ey = animation.endPosition.y - halfH;
+    // When portaled inside the hand-area (position: relative), the card's
+    // absolute children are positioned relative to it — so subtract its
+    // viewport offset so the same viewport coordinates resolve correctly.
+    const offsetRect = portalTarget?.getBoundingClientRect();
+    const offX = offsetRect?.left ?? 0;
+    const offY = offsetRect?.top ?? 0;
+    const sx = animation.startPosition.x - halfW - offX;
+    const sy = animation.startPosition.y - halfH - offY;
+    const ex = animation.endPosition.x - halfW - offX;
+    const ey = animation.endPosition.y - halfH - offY;
 
     // Pin the card at startPosition before WAAPI fires so it's never at 0,0
     el.style.transform = `translate(${sx}px, ${sy}px) rotateZ(${startAngle}deg)`;
@@ -119,7 +139,14 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({ animation }) => {
     return null;
   }
 
-  return (
+  // When portaled into the hand-area, use the destination slot index as
+  // z-index so the in-flight card stacks naturally with sibling hand cards
+  // (slot 4 above slot 3, etc.) — eliminating the z-snap on landing.
+  const zIndex = portalTarget
+    ? animation.sourceInfo.index
+    : 1000 - animation.sourceInfo.index;
+
+  const node = (
     <div
       ref={rootRef}
       className={cn('animated-card', `animation-${animation.animationType}`)}
@@ -127,7 +154,14 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({ animation }) => {
         position: 'absolute',
         left: 0,
         top: 0,
-        zIndex: 1000 - animation.sourceInfo.index,
+        // Give the root explicit card dimensions so its transform-origin
+        // (default 50% 50%) resolves to the card's geometric center. Without
+        // this, an empty 0×0 root rotates around its top-left corner, which
+        // offsets the rendered card by ~(h/2·sin θ, h/2·(1−cos θ)) — invisible
+        // at 0° but visible at the ±8° extremity slots.
+        width: 'var(--card-width)',
+        height: 'var(--card-height)',
+        zIndex,
         pointerEvents: 'none',
       }}
     >
@@ -150,4 +184,6 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({ animation }) => {
       )}
     </div>
   );
+
+  return portalTarget ? createPortal(node, portalTarget) : node;
 };

--- a/apps/web/src/components/Card.tsx
+++ b/apps/web/src/components/Card.tsx
@@ -1,5 +1,6 @@
 import type {Card as CardType} from '@/types';
 import {cn} from '@/lib/utils';
+import {HAND_Y_OFFSETS} from '@/utils/cardPositions';
 import type {CSSProperties, HTMLAttributes, KeyboardEventHandler, MouseEventHandler} from "react";
 import React, {memo, useLayoutEffect, useState} from "react";
 
@@ -81,7 +82,7 @@ const CardComponent: React.FC<CardProps> = ({
       zIndex: stackIndex,
     }
   } else if (overlapIndex !== undefined) {
-    const offset = [4, -3, -5, -3, 4][overlapIndex]
+    const offset = HAND_Y_OFFSETS[overlapIndex]
 
     style = {
       left: `calc(${overlapIndex} * (var(--card-width) - 10px))`,

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -6,6 +6,7 @@ import type {MouseEventHandler} from "react";
 import {Fragment} from "react";
 import {useCardAnimation} from "@/contexts/useCardAnimation.ts";
 import {VictoryEffects} from '@/components/VictoryEffects';
+import {HAND_Y_OFFSETS} from '@/utils/cardPositions';
 
 export interface PlayerAreaProps {
   player: Player;
@@ -366,7 +367,7 @@ export function HandSection({
               className="card opacity-0 pointer-events-none"
               style={handOverlaps ? {
                 left: `calc(${index} * (var(--card-width) - 10px))`,
-                top: `${[4, -3, -5, -3, 4][index]}px`,
+                top: `${HAND_Y_OFFSETS[index]}px`,
                 zIndex: index,
               } : undefined}
             />

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -362,7 +362,14 @@ export function HandSection({
           {/* Hide cards that are being animated INTO the hand (draw animations) until animation completes */}
           {/* Only show cards that are in the hand normally and not being animated */}
           {isCardBeingAnimated(playerIndex, 'hand', index) || isCardBeingAnimated(playerIndex, 'deck', index) ? (
-            <div className="card opacity-0 pointer-events-none"/>
+            <div
+              className="card opacity-0 pointer-events-none"
+              style={handOverlaps ? {
+                left: `calc(${index} * (var(--card-width) - 10px))`,
+                top: `${[4, -3, -5, -3, 4][index]}px`,
+                zIndex: index,
+              } : undefined}
+            />
           ) : (
             <Card
               hint={`Hand card ${index + 1}`}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -345,6 +345,11 @@
 
     &.overlap-hand {
       position: relative;
+      /* Stacking context above the stock pile (z=10) so a draw animation
+         portaled into the hand-area renders above the talon as it flies in.
+         Stays well below .card-animation-layer (z=1000) so play/discard
+         animations still float above the hand. */
+      z-index: 11;
       /* Remove flexbox properties that conflict with absolute positioning */
       .card {
         position: absolute;

--- a/apps/web/src/services/drawAnimationService.ts
+++ b/apps/web/src/services/drawAnimationService.ts
@@ -3,7 +3,7 @@ import {
   calculateAnimationDuration,
   getDeckPosition,
   getHandCardAngle,
-  getHandCardPosition
+  getHandSlotLayoutPosition
 } from '@/utils/cardPositions';
 import type {CardAnimationData} from "@/contexts/CardAnimationContext.tsx";
 
@@ -46,7 +46,7 @@ const getDrawAnimationMetrics = (
       return null;
     }
 
-    const endPosition = getHandCardPosition(handContainer, handIndex);
+    const endPosition = getHandSlotLayoutPosition(handContainer, handIndex);
     const endAngleDeg = getHandCardAngle(handContainer, handIndex);
     const duration = calculateAnimationDuration(startPosition, endPosition);
 

--- a/apps/web/src/utils/cardPositions.ts
+++ b/apps/web/src/utils/cardPositions.ts
@@ -33,10 +33,26 @@ export const getHandCardPosition = (
     return getElementCenter(cardElement);
   }
 
-  // Slot is empty (e.g. draw animation targeting an unfilled slot).
-  // Card.tsx always applies overlapIndex offsets (handOverlaps is always true for a
-  // 5-card hand) and the .hand-area holders are narrow, so we compute the final
-  // card position from the hand container's rect + the same offsets Card.tsx uses.
+  return getHandSlotLayoutPosition(handContainer, cardIndex);
+};
+
+/**
+ * Get the neutral layout position of a hand slot — independent of any transient
+ * per-card state (selected, hovered, in-flight transition). Use this for draw
+ * animation endpoints so the animated card lands exactly where the real card
+ * will settle, even if the slot currently renders a selected/translated card.
+ *
+ * Accounts for the `transform-origin: bottom center` rotation applied to hand
+ * cards: a card rotated by θ around its bottom-center has its visual (AABB)
+ * center shifted by ((h/2)·sin θ, (h/2)·(1 − cos θ)) relative to its unrotated
+ * center. Without this compensation, the animation lands at the slot's formula
+ * position but the real card settles at formula + rotation offset — a visible
+ * glitch on the ±8° extremity cards.
+ */
+export const getHandSlotLayoutPosition = (
+  handContainer: HTMLElement,
+  cardIndex: number,
+): CardPosition => {
   const handRect = handContainer.getBoundingClientRect();
   const handStyle = getComputedStyle(handContainer);
   const cardW = parseFloat(handStyle.getPropertyValue('--card-width')) || 0;
@@ -45,9 +61,13 @@ export const getHandCardPosition = (
     // Mirrors Card.tsx: left = overlapIndex * (cardWidth - 10), top = yOffsets[overlapIndex]
     const yOffsets = [4, -3, -5, -3, 4];
     const yOff = yOffsets[cardIndex] ?? 0;
+    const angleDeg = getHandCardAngle(handContainer, cardIndex);
+    const theta = (angleDeg * Math.PI) / 180;
+    const rotDx = (cardH / 2) * Math.sin(theta);
+    const rotDy = (cardH / 2) * (1 - Math.cos(theta));
     return {
-      x: handRect.left + cardIndex * (cardW - 10) + cardW / 2,
-      y: handRect.top + yOff + cardH / 2,
+      x: handRect.left + cardIndex * (cardW - 10) + cardW / 2 + rotDx,
+      y: handRect.top + yOff + cardH / 2 + rotDy,
     };
   }
 

--- a/apps/web/src/utils/cardPositions.ts
+++ b/apps/web/src/utils/cardPositions.ts
@@ -9,6 +9,13 @@ export interface CardPosition {
 }
 
 /**
+ * Vertical pixel offsets per overlap-hand slot — the fan curve. Shared between
+ * Card.tsx (layout), PlayerArea.tsx (animation placeholder), and the animation
+ * endpoint math below so all three stay in sync.
+ */
+export const HAND_Y_OFFSETS = [4, -3, -5, -3, 4] as const;
+
+/**
  * Get the center position of a DOM element
  */
 export const getElementCenter = (element: HTMLElement): CardPosition => {
@@ -58,9 +65,7 @@ export const getHandSlotLayoutPosition = (
   const cardW = parseFloat(handStyle.getPropertyValue('--card-width')) || 0;
   const cardH = parseFloat(handStyle.getPropertyValue('--card-height')) || 0;
   if (cardW > 0 && cardH > 0) {
-    // Mirrors Card.tsx: left = overlapIndex * (cardWidth - 10), top = yOffsets[overlapIndex]
-    const yOffsets = [4, -3, -5, -3, 4];
-    const yOff = yOffsets[cardIndex] ?? 0;
+    const yOff = HAND_Y_OFFSETS[cardIndex] ?? 0;
     const angleDeg = getHandCardAngle(handContainer, cardIndex);
     const theta = (angleDeg * Math.PI) / 180;
     const rotDx = (cardH / 2) * Math.sin(theta);


### PR DESCRIPTION
## Summary
- Cards drawn from the deck now land precisely at the final hand-slot position — no more visible snap at the end of the flight, especially on the ±8° extremity slots.
- In-flight cards stack correctly among sibling hand cards (via a portal into the destination `.hand-area`) instead of floating above all cards and snapping back at landing.
- Hand area now sits above the stock pile during flight so draw animations are never occluded by the talon.

## Root causes fixed
1. **Placeholder layout mismatch** — `PlayerArea` placeholder now mirrors the real card's absolute layout (`left`, `top`, `z-index`) so the slot geometry stays consistent during animation.
2. **Selection-translated endpoint** — replaced `getHandCardPosition` (which read the currently-translated `.selected` card) with a new `getHandSlotLayoutPosition` that computes the neutral slot center from layout variables.
3. **Bottom-center rotation offset** — hand cards use `transform-origin: bottom center`, so their AABB center shifts by `((h/2)·sin θ, (h/2)·(1−cos θ))`. The animation endpoint now applies the same compensation.
4. **AnimatedCard transform-origin** — the root div was 0×0, so `transform-origin: 50% 50%` resolved to the top-left corner and rotation offset the rendered card at extremity angles. Root now has explicit `--card-width`/`--card-height`.

## Z-ordering
- `AnimatedCard` portals draw animations into the destination `.hand-area.overlap-hand` so the in-flight card shares a stacking context with sibling hand cards and uses the destination slot index as its `z-index`.
- `.hand-area.overlap-hand` now gets `z-index: 11` to stack above the stock pile's `z-index: 10` during flight.

## Test plan
- [ ] Draw a 5-card hand in local mode — cards land exactly at their final positions with no snap, including the extremity slots (index 0 and 4).
- [ ] While drawing, watch z-ordering: each in-flight card stacks naturally under the cards already drawn to its right, never floating above them.
- [ ] Draw animations fly over the stock pile (not under it).
- [ ] `pnpm --filter @skipbo/web test` still passes.
- [ ] `pnpm --filter @skipbo/web test:e2e` — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)