### PR TITLE
docs: add theme categorization and per-theme notes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,10 @@
 
 - [monitoring/SENTRY_AWS_INTEGRATION.md](monitoring/SENTRY_AWS_INTEGRATION.md): Sentry-specific AWS integration notes.
 
+### Themes
+
+- [themes/README.md](themes/README.md): categorization of visual themes and links to per-theme notes covering current features and improvement ideas.
+
 ### Historical Investigations
 
 - [investigations/README.md](investigations/README.md): dated investigation notes and bug writeups.

--- a/docs/themes/README.md
+++ b/docs/themes/README.md
@@ -1,0 +1,64 @@
+# Themes
+
+## Document Contract
+
+- Purpose: index the project's visual themes, explain how they are categorized, and link to per-theme notes describing current behavior and proposed refinements.
+- Audience: contributors and agents making visual changes, adding new themes, or tuning existing ones.
+- Source of truth: the CSS files under [../../apps/web/src/themes/](../../apps/web/src/themes/) and the registry in [../../packages/game-core/src/types/index.ts](../../packages/game-core/src/types/index.ts). The per-theme files in this folder cite those files for current behavior; their improvement sections are intentionally non-normative.
+- When to update: when a theme is added, removed, or renamed; when category boundaries shift; when an improvement idea is adopted or discarded.
+
+## Registry
+
+Themes are declared as an immutable list in [../../packages/game-core/src/types/index.ts](../../packages/game-core/src/types/index.ts) and rendered through the `ThemeProvider` in [../../apps/web/src/Root.tsx](../../apps/web/src/Root.tsx). Each theme is a CSS class (`.theme-<name>`) applied to `<html>` by `next-themes`. The contract enforced by [../../apps/web/tests/ui/theme-contract.spec.ts](../../apps/web/tests/ui/theme-contract.spec.ts) requires every theme to define `--background`, `--foreground`, `--selected-border-color`, and `--card-g1`, and to render a valid snapshot.
+
+## Categorization
+
+Themes group into five categories along a mood / visual-language axis. The goal is that each category covers one recognisable "kind of table" a player might want to sit at, and the set balances across them so picking a theme feels like choosing a vibe rather than flipping a color.
+
+| Category | What it looks like | Themes |
+|---|---|---|
+| **Clean & Minimal** | Flat surfaces, restrained palettes, no texture. The card is the star. | [light](light.md), [dark](dark.md), [metro](metro.md) |
+| **Soft & Playful** | High-key palettes, rounded shapes, decorative backgrounds. Reads as friendly and casual. | [pastel](pastel.md), [bonbon](bonbon.md), [rainbow](rainbow.md) |
+| **Retro & Vintage** | Era-specific palettes and shapes, reference-driven, avoids modern effects. | [retro](retro.md), [retro-space](retro-space.md) |
+| **Futuristic & Digital** | Glow, blur, animated gradients, high contrast, lean into screen-native effects. | [neon](neon.md), [glass](glass.md) |
+| **Tactile & Crafted** | Imitates physical materials — yarn, blocks, brass. Heavy use of textures. | [wool](wool.md), [minecraft](minecraft.md), [steampunk](steampunk.md) |
+
+Retro & Vintage and Futuristic & Digital currently hold only two themes each, while the other three hold three. This is the clearest place to add new themes if the registry grows.
+
+## Shared Tokens
+
+Every theme customises a CSS custom-property contract declared at `:root` in [../../apps/web/src/index.css](../../apps/web/src/index.css). Token families:
+
+- **Palette:** `--primary`, `--secondary`, `--success`, `--accent`, `--destructive`, `--muted` and their `*-foreground` pairs, plus `--popover`, `--border`, `--ring`.
+- **Surface:** `--background`, `--foreground`, `--text-color`, `--title-color`.
+- **Card:** `--card-front-color`, `--card-border-color`, `--card-back-color`, `--card-back-bg`, `--card-shadow`, `--card-radius`, `--card-g1|g2|g3` (number-range colors).
+- **Skip-Bo card:** `--skipbo-text`, `--skipbo-bg`.
+- **Interaction:** `--selected-border-color`, `--selected-shadow`, `--drop-indicator-color`, `--can-drop-shadow`, `--active-turn-color`.
+- **Victory:** `--victory-border`, `--victory-accent`, `--victory-accent-soft`, `--victory-piece-1..4`, `--victory-burst-size`, `--victory-burst-distance-scale`, `--victory-pattern-image|size|opacity|drift-to|animation`, `--victory-shine-opacity|duration`, `--victory-emblem-image|opacity`.
+
+A theme that only overrides the palette produces a minimal look. A theme that also overrides `--card-back-bg`, surface backgrounds, and victory tokens produces a full identity. Heavy themes additionally render decorative `::before`/`::after` layers on `.card`, `.back`, `.skip-bo`, player areas, and `body`.
+
+## Aesthetic Philosophy
+
+- **Readability beats ornament.** Numbers on cards must stay legible at a glance; decoration happens on backs, empty slots, and backgrounds, not over the numbers.
+- **The table has a mood.** Background, player area, and card-back treatment are where a theme earns its name. A recoloured palette alone is not an identity.
+- **Motion is polish, not payload.** Animations are welcome (`neon`, `rainbow`, `retro-space`, `glass` all use them) but must respect `prefers-reduced-motion` and must not compete with gameplay feedback (selection glow, drop shadows, turn highlight).
+- **Each theme should be recognisable in one glance.** A screenshot of the table alone, without the theme switcher, should tell a reader which theme is active. When a theme fails that test, the fix belongs in the category it claims — e.g. a Retro theme should read as retro, not merely "warmer dark mode".
+
+## Per-Theme Notes
+
+- [light](light.md)
+- [dark](dark.md)
+- [pastel](pastel.md)
+- [bonbon](bonbon.md)
+- [rainbow](rainbow.md)
+- [metro](metro.md)
+- [neon](neon.md)
+- [retro](retro.md)
+- [retro-space](retro-space.md)
+- [glass](glass.md)
+- [wool](wool.md)
+- [minecraft](minecraft.md)
+- [steampunk](steampunk.md)
+
+Each per-theme file describes current behavior (normative, anchored in the CSS file) and lists improvement ideas (non-normative, candidates for future work).

--- a/docs/themes/bonbon.md
+++ b/docs/themes/bonbon.md
@@ -1,0 +1,36 @@
+# Bonbon
+
+## Document Contract
+
+- Purpose: describe the `theme-bonbon` look and record improvement ideas.
+- Audience: contributors maintaining the candy-inspired theme.
+- Source of truth: [../../apps/web/src/themes/candy.css](../../apps/web/src/themes/candy.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Soft & Playful
+- **Label / icon:** "Bonbon" / `Candy`
+- **Role:** The most decorated theme in the registry — pink, whimsical, unapologetically sweet.
+
+## Palette & Typography
+
+- Primary hot pink `#ff76a5`, very pale pink background `hsl(332 100% 96%)`, cyan / gold / purple secondaries.
+- Card front near-white `#fffafc`, bright-pink borders `#ff8eb5`, 16px radius.
+- Typography: Trebuchet MS → Arial Rounded → `ui-rounded` with added letter-spacing, the roundest stack in the project.
+
+## Current Features
+
+- Body background combines radial gradients (pink / cyan / gold orbs) with a repeating 135° diagonal stripe pattern for a layered "candy shop" feel.
+- Skip-Bo card is rendered as a stylised lollipop: conic rainbow gradient head, striped stick, nested shadows.
+- Card backs use six-color striped panels (135° gradient pairs).
+- Player and center areas add `backdrop-filter: blur(10px)` plus a gradient overlay and a thick outline for a frosted-glass inset effect.
+- Buttons lift on hover with a soft shadow.
+- Victory pieces: pink / gold / cyan / purple on the default pattern.
+
+## Improvement Ideas
+
+- **Sparkle motes on victory.** Small fading stars or sparkles emitting from the winner's area would match the confectionery identity and give the theme a dedicated victory beat.
+- **Wrapper-twist animation on Skip-Bo card.** A very slow continuous rotation of the lollipop's conic rainbow (e.g. `animation: 18s linear infinite`) would echo real candy wrappers without being distracting.
+- **Card-back candy variants.** Rotate between three card-back stripe patterns by index so the table looks like a mixed bag of sweets rather than 30 copies of the same wrapper.
+- **Soft pop on hover.** Pair the existing button lift with a 1.02x scale on hoverable cards so the theme feels universally bouncy, not only in button chrome.

--- a/docs/themes/dark.md
+++ b/docs/themes/dark.md
@@ -1,0 +1,34 @@
+# Dark
+
+## Document Contract
+
+- Purpose: describe the `theme-dark` look and record improvement ideas.
+- Audience: contributors maintaining the primary dark theme.
+- Source of truth: [../../apps/web/src/themes/dark.css](../../apps/web/src/themes/dark.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Clean & Minimal
+- **Label / icon:** "Sombre" / `Moon`
+- **Role:** Standard dark mode — a comfortable low-light counterpart to [light](light.md).
+
+## Palette & Typography
+
+- Primary indigo `#6366f1`, secondary dark gray `#1f2937`, success emerald `#34d399`.
+- Surface: near-black background `#0a0a0a`, charcoal card fronts `#374151`, gray borders `#6b7280`.
+- Typography: inherited; no overrides.
+
+## Current Features
+
+- Card back is a 45° gradient from `#1d4ed8` blue to `#22c55e` green; card fronts flat charcoal.
+- Card radius 8px, medium shadow, standard selection ring.
+- Victory burst uses amber / pink / emerald / blue pieces; default pattern and shine.
+- No background textures, no animations.
+
+## Improvement Ideas
+
+- **Starfield or constellation overlay.** A very low-opacity scattered-dots background would give the theme a subtle identity beyond "dark" without stepping on [retro-space](retro-space.md) (which is maximal sci-fi).
+- **Card-back depth.** Add a soft inner shadow so cards read as slightly recessed against the near-black table; currently the 8px radius on flat gradient feels generic.
+- **Glow on active turn.** The active-turn outline is subtle on an already-dark background — a soft indigo glow (`box-shadow: 0 0 12px var(--primary)`) would make the current player's area easier to find.
+- **Range-aware card-back gradient.** Swap the fixed blue→green gradient for a subtle dual-tone derived from `--card-g1` and `--card-g3`, so the theme's identity is tied to its palette rather than hard-coded colors.

--- a/docs/themes/glass.md
+++ b/docs/themes/glass.md
@@ -1,0 +1,42 @@
+# Glass
+
+## Document Contract
+
+- Purpose: describe the `theme-glass` look and record improvement ideas.
+- Audience: contributors maintaining the liquid-glass theme.
+- Source of truth: [../../apps/web/src/themes/glass.css](../../apps/web/src/themes/glass.css) and the shared utility [../../apps/web/src/themes/utils/liquid-glass.css](../../apps/web/src/themes/utils/liquid-glass.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Futuristic & Digital
+- **Label / icon:** "Verre" / `Squircle`
+- **Role:** Modern frosted-glass UI. Leans heavily on `backdrop-filter` and translucency for a contemporary OS feel.
+
+## Palette & Typography
+
+- Primary blue `#6786d3`, body background `#2d6698`, card back deep indigo `#1f3a8a`, borders blue-gray `#5b6470`.
+- Accent gold (x3) + cyan pieces for victory.
+- Card front is transparent; fronts rely entirely on backdrop-filter to read as glass.
+- Card radius is dynamic (`calc(var(--card-height) / 8)`) — the only theme that scales corner radius with card size.
+- Typography: inherited.
+
+## Current Features
+
+- Body background is a blue gradient overlaid with a moving SVG line pattern (60s `glass-texture-pan`).
+- Card backs render a "cracked glass" effect: conic gradients emanate as rays from origin `82% 82%`, with concentric halos.
+- Skip-Bo card is a 6-panel glass mosaic (azure / coral / mint / amber / lavender / pink) with `color-mix` transparency and its own backdrop-filter.
+- Player and center areas use the `liquid-glass` utility: backdrop-filter blur, color-mix border gradient, animated background-position for a subtle shimmer.
+- Active player's area flips its inner glass color to near-white for visibility.
+- Victory intentionally disables default burst/shine (`display: none`) and relies on gradient overlay alone.
+
+## Current Strengths
+
+The theme commits to a single idea (transparency + motion) and executes it consistently — every surface honors the same material language. Improvement ideas focus on variety within that language.
+
+## Improvement Ideas
+
+- **Refraction highlight on card hover.** A moving gradient sheen across the card front on hover (like light catching real glass) would make the theme feel alive during normal play, not only during idle animation.
+- **Re-enable victory beat in-material.** Replacing the disabled burst/shine with a "glass shatters into particles" effect (burst pieces styled as small translucent shards with a short rotate) would give the theme a dedicated win beat without breaking the material language.
+- **Depth tint on stacked piles.** Slightly increase the blur radius of cards deeper in a pile (via `--stack-index` variable) so piles read as physically layered rather than visually coplanar — plays directly to the strength of the material.
+- **Reduced-motion baseline check.** The theme currently animates background-position and the line-pattern pan even when motion is available; verify the `prefers-reduced-motion` media query in the liquid-glass utility disables both, since sustained motion on a heavily-blurred surface is a likely comfort issue.

--- a/docs/themes/light.md
+++ b/docs/themes/light.md
@@ -1,0 +1,34 @@
+# Light
+
+## Document Contract
+
+- Purpose: describe the `theme-light` look and record improvement ideas.
+- Audience: contributors tuning the default light theme or using it as a baseline for new themes.
+- Source of truth: [../../apps/web/src/themes/light.css](../../apps/web/src/themes/light.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Clean & Minimal
+- **Label / icon:** "Clair" / `Sun`
+- **Role:** Accessible default; the reference point other themes diverge from.
+
+## Palette & Typography
+
+- Primary indigo `#4f46e5`, secondary near-white `#f9fafb`, success green `#22c55e`.
+- Surface: light gray background `#e5e7eb`, white card fronts, medium-gray borders `#9ca3af`.
+- Typography: inherited Inter stack from the base; no theme-specific overrides.
+
+## Current Features
+
+- Card back is a 45° linear gradient from green `#22c55e` to blue `#3b82f6`; no decorative overlay on the face.
+- Card radius 8px, light drop shadow, standard selection ring.
+- Victory burst uses red / orange / green / blue squares over the default pattern; no custom emblem or shine override.
+- Table and player areas use the flat `--background` with no textures or gradients.
+
+## Improvement Ideas
+
+- **Subtle paper texture.** Add a very low-opacity noise or paper-grain filter to the body background so the theme reads as "paper" rather than "untreated gray". Keeps the minimal feel but gives it a name.
+- **Gentle card-back accent.** Replace the green-to-blue gradient with a token-aware gradient that follows `--card-g1..g3` so the back visually hints at the range palette used on the faces.
+- **Active-turn warmth.** The active-turn highlight inherits the default blue; a warm secondary (amber) would separate it from the indigo primary at a glance.
+- **Typography confidence.** Pair the theme with a single display font for headings (e.g. Inter Tight) so the "default" theme still has a voice; currently it reads as unstyled rather than intentional.

--- a/docs/themes/metro.md
+++ b/docs/themes/metro.md
@@ -1,0 +1,36 @@
+# Metro
+
+## Document Contract
+
+- Purpose: describe the `theme-metro` look and record improvement ideas.
+- Audience: contributors maintaining the Windows-Phone-inspired theme.
+- Source of truth: [../../apps/web/src/themes/metro.css](../../apps/web/src/themes/metro.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Clean & Minimal
+- **Label / icon:** "Metro" / `Building2`
+- **Role:** Flat, tile-based, high-contrast digital aesthetic. The only theme currently leaning on sharp 2px corners.
+
+## Palette & Typography
+
+- Primary green `#60a917`, charcoal background `#1d1d1d`, saturated accents: yellow `#ffd426`, cyan `#00befc`, red `#ff3b30`, green `#60a917`.
+- Card front charcoal `#3c3c3c`, card back bright yellow `#ffd426`, gray borders `#5e5e5e`.
+- Card radius 2px, no card shadow — the theme intentionally avoids depth.
+- Typography: inherited.
+
+## Current Features
+
+- Card back renders a 4-colour conic gradient (teal / red / cyan / blue quadrants) via `.back::before`.
+- Skip-Bo card has a yellow top band and a striped multi-color bottom band.
+- Victory pattern is a 24px crosshatch grid (two repeating linear gradients at 90°) with 0.12 opacity, animated at 16s.
+- Victory burst pieces are 11×11px squares (0 border-radius) in yellow / red / cyan / green.
+- Winner player area drops its shadow (`box-shadow: none`) to stay flat.
+
+## Improvement Ideas
+
+- **Live-tile flip on card backs.** The theme is named Metro, but today it reads as "flat dark with a conic gradient". A slow 180° Y-axis flip every ~15-30s — staggered across card-holder siblings — revealing a secondary conic pattern on the back face would earn the name. Requires `perspective` on `.card`, `transform-style: preserve-3d` on `.back`, a second `::after` face rotated 180°, and `backface-visibility: hidden` on both faces. Must be gated by `prefers-reduced-motion`.
+- **Accent-color card bands.** Windows Phone tiles used one accent per tile. Let the number-range groups (`--card-g1..g3`) each claim a solid accent on the card face — a strip or corner block — instead of using them only as text color.
+- **Chevron drop indicator.** The drop indicator is currently generic; a chunky right-pointing chevron would echo the "next" arrows used throughout the Metro language.
+- **Victory crosshatch intensification.** On victory, ramp the crosshatch opacity from 0.12 to ~0.4 over the win animation so the grid reads as "the Start screen lights up" rather than an unchanging background.

--- a/docs/themes/minecraft.md
+++ b/docs/themes/minecraft.md
@@ -1,0 +1,38 @@
+# Minecraft
+
+## Document Contract
+
+- Purpose: describe the `theme-minecraft` look and record improvement ideas.
+- Audience: contributors maintaining the blocky / voxel theme.
+- Source of truth: [../../apps/web/src/themes/minecraft.css](../../apps/web/src/themes/minecraft.css) and the texture assets in [../../apps/web/src/themes/textures/](../../apps/web/src/themes/textures/) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Tactile & Crafted
+- **Label / icon:** "Minecraft" / `Blocks`
+- **Role:** Voxel / pixel-art identity. The only theme that enforces `image-rendering: pixelated` and `border-radius: 0` globally.
+
+## Palette & Typography
+
+- Earthy pixel palette: dark brown `#3d2e1e`, gray `#8c8c8c`, white `#e6e6e6`, neon green `#9adf5a`, cyan `#37ceff`.
+- Card front `#e5e5e5`, card back `#8c8c8c` (overridden by stone texture).
+- Typography: **Monaco, monospace**, `letter-spacing: 0.01em` with 8-direction outline text-shadow for the retro pixel-font feel.
+
+## Current Features
+
+- Every element has `border-radius: 0` (enforced on all children via `!important`) — no rounding anywhere.
+- Body background uses a `dirt.webp` tile; playable areas use `grass.webp`; empty card slots use `wood.webp`; card backs use `stone.webp`.
+- Active player area uses a `netherite` border texture.
+- Skip-Bo card layers `obsidian.webp` with `diamond.webp` overlay.
+- Card backs include a sword overlay.
+- Victory burst pieces are 14×14px cycling between `grass`, `stone`, `diamond`, `wood` textures with no rounding.
+- All textures are 80×80px webp, rendered pixelated.
+
+## Improvement Ideas
+
+- **Ambient particle drift.** Float small 4×4px squares (XP-orb green, redstone red, portal purple) slowly across the body background during idle. Cheap via CSS keyframes, strongly reinforces the theme identity.
+- **Break-block animation on card play.** When a card is played, a quick 3-frame "cracking" overlay (small SVG or CSS art) then disappear could mimic block-breaking. Should respect the shared animation gate to avoid stacking.
+- **Biome-based player tinting.** Human player area uses grass biome; AI player area could use a different biome (e.g. desert, nether, snow) so the two sides feel like distinct worlds rather than the same field.
+- **Iconic drop indicator.** The drop indicator could render as a tiny pickaxe or a block outline, matching the theme's gaming vocabulary.
+- **Victory fireworks block.** Minecraft's on-win motif is firework stars — a burst variant that spawns 3-4 firework trails (short vertical line, puff at top) would give the theme a dedicated win beat rather than the current block-confetti.

--- a/docs/themes/neon.md
+++ b/docs/themes/neon.md
@@ -1,0 +1,34 @@
+# Neon
+
+## Document Contract
+
+- Purpose: describe the `theme-neon` look and record improvement ideas.
+- Audience: contributors maintaining the cyberpunk / synthwave theme.
+- Source of truth: [../../apps/web/src/themes/neon.css](../../apps/web/src/themes/neon.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Futuristic & Digital
+- **Label / icon:** "Néon" / `Zap`
+- **Role:** High-saturation glow on black; the theme with the most animation layered on top of a relatively minimal structure.
+
+## Palette & Typography
+
+- Primary hot pink `#ff0099`, success neon green `#00ff88`, cyan `#00d4ff` accents on a black `#0a0a0a` body.
+- Card front `#1a1a1a`, neon-green border `#00ff88`, 12px radius, neon-green glow shadow (`0 0 10px rgba(0,255,136,0.3)`).
+- Typography: inherited (the glow does the work).
+
+## Current Features
+
+- Card back animates a 135° pink/green/blue/pink gradient (`neonShift`, 6s) with an overlayed blurred glow (`neonDrift`, 9s) via `::before`, and faint scanlines via `::after`.
+- Skip-Bo card gets an oversized neon glow, scanline overlay, and the same animated gradient.
+- Multi-layer text-shadow produces the glow effect on text.
+- Victory pieces are saturated green / pink / cyan / yellow; the default burst gains the neon treatment through theme tokens.
+
+## Improvement Ideas
+
+- **Synced flicker on the winner.** A very short, low-opacity flicker (e.g. 2-3 sub-second dips in brightness) on the winner's player area right before the burst would sell the "neon sign tripping on" moment.
+- **Grid-floor background.** Add a low-opacity perspective grid on the body background (two linear gradients + skewed transform) to place the theme in a classic synthwave scene rather than an undifferentiated black room.
+- **Tron-like trail on card selection.** When a card is selected, the glow could trail for ~200ms along the neighbouring border before settling, selling the "electric current" metaphor.
+- **Chromatic aberration on Skip-Bo text.** Split "Skip-Bo" text into R / G / B layers offset by 1-2px for a VHS-like effect — cheap to add via `text-shadow`, big identity payoff.

--- a/docs/themes/pastel.md
+++ b/docs/themes/pastel.md
@@ -1,0 +1,33 @@
+# Pastel
+
+## Document Contract
+
+- Purpose: describe the `theme-pastel` look and record improvement ideas.
+- Audience: contributors maintaining the soft-palette theme.
+- Source of truth: [../../apps/web/src/themes/pastel.css](../../apps/web/src/themes/pastel.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Soft & Playful
+- **Label / icon:** "Pastel" / `Flower2`
+- **Role:** Low-contrast, gentle-on-the-eyes alternative; the calmest of the playful group.
+
+## Palette & Typography
+
+- Primary soft cyan `hsl(170 70% 70%)`, secondary soft yellow `#f4edaf`, success soft green `#a5dda5`.
+- Surface: pale yellow background `#fbef8b`, white card fronts, very soft purple-blue borders `#d8e2ef`.
+- Typography: inherited.
+
+## Current Features
+
+- Card back is a 135° gradient from soft cyan `#a0d2eb` to ice `#bee5eb`; 10px radius; ultra-soft shadow (0.05 opacity).
+- Victory pattern renders subtle radial gradients (soft white circles) for a gentle bloom on win.
+- No body-level background texture; the table relies on the pale yellow alone.
+
+## Improvement Ideas
+
+- **Drifting pastel clouds.** Pair the subtle victory radial gradient with a very slow, very low-opacity cloud drift on the table background, echoing [rainbow](rainbow.md) but at a much lower contrast. Reinforces "gentle daydream" aesthetic.
+- **Sway on the active turn border.** A slow, low-amplitude sway animation (2-3s ease-in-out) on the active player's outline would fit the soft character without being distracting.
+- **Petal burst on victory.** Replace the square burst pieces with small rounded petal shapes (oval with border-radius 50% on one axis) for a theme that matches the `Flower2` icon.
+- **Dedicated display font.** A rounded humanist face (e.g. Quicksand) for titles would earn the "pastel" name; the current default font reads as a palette swap rather than a full identity.

--- a/docs/themes/rainbow.md
+++ b/docs/themes/rainbow.md
@@ -1,0 +1,34 @@
+# Rainbow
+
+## Document Contract
+
+- Purpose: describe the `theme-rainbow` look and record improvement ideas.
+- Audience: contributors maintaining the rainbow theme.
+- Source of truth: [../../apps/web/src/themes/rainbow.css](../../apps/web/src/themes/rainbow.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Soft & Playful
+- **Label / icon:** "Arc-en-ciel" / `Rainbow`
+- **Role:** Bright, cheerful, sky-and-clouds table. High saturation, low visual complexity.
+
+## Palette & Typography
+
+- Primary red `hsl(0 100% 70%)`, sky-blue background `#87ceeb`, success green `#4caf50`, purple border `#9381ff`.
+- Card front white, card back a vertical red → orange → yellow → green → blue → indigo → violet gradient; 12px radius.
+- Typography: inherited.
+
+## Current Features
+
+- Body background animates cloud shapes (ellipse radial gradients) drifting left-to-right over a 90s loop.
+- Skip-Bo card uses a radial spectrum ring overlay with computed band widths.
+- Discard piles have a hover glow with a purple hue.
+- Victory pattern uses a custom stars SVG; burst pieces are yellow / orange / blue / purple.
+
+## Improvement Ideas
+
+- **Real rainbow arc on victory.** Overlay a conic-gradient arc (clipped through an SVG path) across the winner's area so the theme's name pays off at the moment it matters most.
+- **Sky-time drift.** Slowly shift the body background hue across a long cycle (2-3 min) between dawn warm, midday blue, and dusk pink. Subtle enough not to distract, enough to make a long game feel alive.
+- **Synced cloud + pattern.** The victory stars pattern currently reads as unrelated to the cloud drift. Synchronising them (same drift direction, staggered by a few seconds) would make the win feel like "the clouds parted to reveal stars".
+- **Band-aligned range colors.** `--card-g1..g3` currently don't obviously match the rainbow back. Picking them from the gradient's red / green / violet bands would make the theme internally coherent.

--- a/docs/themes/retro-space.md
+++ b/docs/themes/retro-space.md
@@ -1,0 +1,39 @@
+# Retro Space
+
+## Document Contract
+
+- Purpose: describe the `theme-retro-space` look and record improvement ideas.
+- Audience: contributors maintaining the mid-century sci-fi theme.
+- Source of truth: [../../apps/web/src/themes/retro-space.css](../../apps/web/src/themes/retro-space.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Retro & Vintage
+- **Label / icon:** "Espace" / `Rocket`
+- **Role:** 1950s–1960s space-race aesthetic — cream, copper, deep navy, dense grids and astronomical iconography.
+
+## Palette & Typography
+
+- Deep navy body `#07111d`, secondary navy `#122134`, cream card front `#e7ddcf`, copper `#d87939`, cyan `#7fd4d7`, gray-blue borders `#8d98a1`.
+- Card radius 14px; layered card shadows (`0 10px 22px + 0 1px 0`).
+- Typography: **Avenir Next Condensed / Segoe UI**, uppercase, `letter-spacing: 0.08em` — the only condensed / uppercase theme in the project.
+
+## Current Features
+
+- Body background combines a nebula-like radial gradient, a starfield made of tiny radial dots, a dashed grid, and a slow drift animation (`retroSpaceVictoryFlyby` on victory).
+- Card backs are dense — concentric rings, stellar crosshairs, and a copper inset border — evoking a telescope reticle.
+- Skip-Bo card centers a planet-like multi-layer radial gradient with a labeled banner at the bottom.
+- Player areas use differently-tinted grids for human vs AI areas (cyan vs copper), reinforcing identity at a glance.
+- Victory bursts use a 12-point star polygon (clip-path); victory shine is a custom 5.2s cubic-bezier flyby.
+
+## Current Strengths
+
+The most identity-rich theme currently in the registry: fonts, background, card structure, victory beat, and per-player tinting all reinforce the same idea. Improvement ideas below are polish, not rescue.
+
+## Improvement Ideas
+
+- **Slow parallax on the starfield.** Shift the starfield layer 5–10% slower than the grid layer so the depth implied by the two backgrounds becomes visible during long sessions.
+- **Orbit ring on the Skip-Bo planet.** A faint elliptical ring (border over a rotated pseudo-element) around the Skip-Bo card's central planet would reinforce the "astronomical object" reading that the card already hints at.
+- **Countdown rumble before bot turn.** A very subtle screen-shake or border pulse when the AI starts thinking would fit the Mission-Control vibe without interfering with gameplay pacing.
+- **Second victory flyby direction.** The current 5.2s flyby always goes the same way. Alternating direction by winner id (or adding a second inbound streak) would make repeated wins feel less scripted.

--- a/docs/themes/retro.md
+++ b/docs/themes/retro.md
@@ -1,0 +1,36 @@
+# Retro
+
+## Document Contract
+
+- Purpose: describe the `theme-retro` look and record improvement ideas.
+- Audience: contributors maintaining the 70s / 80s print-inspired theme.
+- Source of truth: [../../apps/web/src/themes/retro.css](../../apps/web/src/themes/retro.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Retro & Vintage
+- **Label / icon:** "Rétro" / `Radio`
+- **Role:** Warm, print-era nostalgia. Earth tones, chunky offset shadows, geometric stripes — reads as a 1970s board-game box.
+
+## Palette & Typography
+
+- Earth palette: cream `#f4f1de`, orange `#f4a261`, coral `#e76f51`, teal `hsl(174 59% 39%)`, tan/gold `#e9c46a`.
+- Primary teal, card front orange, card back tan, coral borders.
+- Card radius 15px, chunky 3px solid offset shadow (`3px 3px 0 #e76f51`) — the signature "lifted sticker" feel.
+- Typography: inherited.
+
+## Current Features
+
+- Card backs layer a complex 45° repeating stripe pattern (gradient stripes alternating with transparent bands).
+- Skip-Bo card uses conic gradients on the top and bottom 1/6 of the card face, styled differently from normal cards.
+- Victory uses a custom simplified SVG pattern and hides the default shine/burst animations (`display: none`), keeping the theme print-era rather than screen-era.
+- Selection shadow is also chunky and offset (`3px 3px`), preserving the style under interaction.
+
+## Improvement Ideas
+
+- **CRT scanlines on the table.** A 1px repeating linear-gradient overlay on the body background would push the theme from "70s print" toward "70s TV" — a welcome secondary register without new assets.
+- **Replace the disabled victory shine with a tape-tracking glitch.** A slow horizontal line sweeping the winner's area once, mimicking VHS tracking, fits the era better than hiding the shine entirely.
+- **Period headline font.** A condensed display face (e.g. Antonio, Bebas Neue) on titles would give the theme a poster-era voice the palette is already promising.
+- **Halftone Skip-Bo card.** Replace the two conic bands with a halftone dot pattern (radial-gradient repeats) for a print-comic feel that differentiates the Skip-Bo card from the normal cards more clearly.
+- **Warmer empty-slot contrast.** Empty slots currently inherit the cream background; a slightly darker cream plus a dashed coral outline would read as "a dedicated spot", not a missing card.

--- a/docs/themes/steampunk.md
+++ b/docs/themes/steampunk.md
@@ -1,0 +1,43 @@
+# Steampunk
+
+## Document Contract
+
+- Purpose: describe the `theme-steampunk` look and record improvement ideas.
+- Audience: contributors maintaining the brass-and-gears theme.
+- Source of truth: [../../apps/web/src/themes/steampunk.css](../../apps/web/src/themes/steampunk.css) and the texture at [../../apps/web/src/themes/textures/steampunk-clockwork.png](../../apps/web/src/themes/textures/steampunk-clockwork.png) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Tactile & Crafted
+- **Label / icon:** "Steampunk" / `Cog`
+- **Role:** Victorian industrial — brass, bronze, parchment, gears. The theme with the most ornate Skip-Bo card treatment.
+
+## Palette & Typography
+
+- Warm metallics: brass `hsl(37 61% 47%)`, bronze `hsl(27 32% 32%)`, aged plum `#7b5a6e`, patina teal `#4f7a6d`, parchment `#f1e3c9`.
+- Body background workshop charcoal `#1f1a14`, card front parchment `#f1e3c9`, card back aged leather / bronze `#463a2f`, burnished-brass borders `#6b5640`.
+- Card radius 12px; standard shadows.
+- Typography: inherited.
+
+## Current Features
+
+- Body combines an SVG gear overlay (very low opacity `#e0a84f` 6%), a blueprint grid (repeating linear gradients at 28px, 4%), and a dark gradient.
+- Player area shows rivets at all four corners (radial gradients positioned precisely).
+- Card backs add a rivet grid at 12px spacing, a diagonal brass tint, and a brushed texture.
+- **Skip-Bo card is the centerpiece:** a mask-composited "machine window" reveals the `steampunk-clockwork.png` background (visible cogs), framed by an ornate parchment border shaped via SVG `mask-image`.
+- Empty cards use a dashed brass outline with an ornate shadow.
+- Normal cards overlay a compass-rose SVG (50% opacity) with inset panel seams and domed rivets.
+- Victory tokens use brass / copper / patina / plum but no custom burst shape.
+
+## Current Strengths
+
+Alongside [retro-space](retro-space.md), one of the most committed theme identities. Every surface speaks the same material language.
+
+## Improvement Ideas
+
+- **Rotating clockwork on the Skip-Bo card.** Animate the `steampunk-clockwork.png` background with a slow 40-60s rotation so the visible gears actually turn. Single keyframe, huge payoff. Must gate on `prefers-reduced-motion`.
+- **Brass glint sweep on card-back hover.** A diagonal gradient sweep across card backs on hover (similar to [retro-space](retro-space.md)'s flyby but shorter) would make the metallic surface read as polished on interaction.
+- **Steam release on victory.** A short puff of 3-4 white/gray radial gradients rising and fading from the winner's area would give the theme a dedicated win beat; the current victory inherits defaults, which reads as generic confetti on an otherwise committed theme.
+- **Animated pressure gauge on active turn.** Replace the active-turn outline with a tiny gauge dial in the top-left corner whose needle sweeps as the turn elapses. Non-trivial, but meaningfully on-theme.
+- **Period-appropriate headline font.** A classical serif (e.g. Cinzel, IM Fell) on titles would finish the Victorian identity the visuals already promise.

--- a/docs/themes/wool.md
+++ b/docs/themes/wool.md
@@ -1,0 +1,39 @@
+# Wool
+
+## Document Contract
+
+- Purpose: describe the `theme-wool` look and record improvement ideas.
+- Audience: contributors maintaining the woven-texture theme.
+- Source of truth: [../../apps/web/src/themes/wool.css](../../apps/web/src/themes/wool.css) for current behavior. Improvement Ideas below are non-normative.
+- When to update: when the CSS changes, when ideas are adopted, or when the theme is retired.
+
+## Identity
+
+- **Category:** Tactile & Crafted
+- **Label / icon:** "Laine" / `Spool`
+- **Role:** Soft, crafted, quilted feel — the theme that looks like a hand-knit blanket on a table.
+
+## Palette & Typography
+
+- Cool gray palette: `#c9c9c9`, `#ddd`, `#808080` ranges with a sage-green accent `hsl(152 33% 60%)`.
+- Body background `hsl(206 13% 51%)` (medium gray-blue); card front `#ddd`, card back same as body.
+- Card radius `calc(var(--card-height) / 10)` — less rounded than most tactile themes.
+- Card shadow uses dual inset (`inset ... rgba(0,0,0,0.2)` + `inset ... rgba(255,255,255,0.5)`) to produce the embossed / stitched-in feel.
+- Typography: inherited.
+
+## Current Features
+
+- Body layers a fine grid (two scales: 6px and 3px) with an SVG `feTurbulence` noise filter for organic texture.
+- Card backs use a 120° repeating diagonal gradient with striped yarn-weave pattern.
+- Player areas apply an embossed effect: 10px outset light shadow + 10px inset dark shadow, both produced via `color-mix` on the background color.
+- Empty cards use inset shadows to read as embossed cutouts.
+- Skip-Bo card has a 3-color diagonal stripe (`--card-g1 / g2 / g3` at 135°); corner number hidden so the stripes read as a dedicated yarn block.
+- Victory pattern is a woven-rope SVG on a slow 12s drift.
+
+## Improvement Ideas
+
+- **Cross-stitch on active turn.** Replace the current active-turn outline with an animated dashed border whose background-position animates, selling "running cross-stitch" on the active player's area.
+- **Button-style rivets on piles.** Empty pile slots could show a small button / button-hole motif at center (two stacked radial gradients) so each slot reads as a physical attachment point.
+- **Yarn trail on card play.** When a card is played, a short "yarn thread" could animate between source and destination (1px SVG path fading out). Cheap to implement and perfectly on-theme.
+- **Palette variant set.** Offer two or three palette variants (warm sweater, autumn, winter) so the theme reads as a "wool wardrobe" rather than a single gray sample. Selection could cycle with the random-theme button.
+- **Low-opacity stitched seam on card borders.** Add a 1px dashed inner border on card fronts mimicking a stitched seam; currently only the back communicates the woven identity.


### PR DESCRIPTION
## Summary

- Add [docs/themes/README.md](../blob/claude/blissful-galileo-8a0db9/docs/themes/README.md) with a 5-category taxonomy of the existing 13 visual themes, the shared CSS token contract, and general aesthetic philosophy
- Add one per-theme markdown file for each registered theme (light, dark, pastel, bonbon, rainbow, metro, neon, retro, retro-space, glass, wool, minecraft, steampunk) documenting current behavior against the owning CSS file and listing non-normative improvement ideas
- Link the new section from [docs/README.md](../blob/claude/blissful-galileo-8a0db9/docs/README.md)

## Test plan

- [ ] Verify all links in docs/themes/README.md resolve to existing theme files and CSS paths
- [ ] Confirm each per-theme file cites the correct file under apps/web/src/themes/
- [ ] Skim improvement sections to confirm they read as non-normative proposals rather than commitments

🤖 Generated with [Claude Code](https://claude.com/claude-code)