### PR TITLE
fix(web): retreat animation flicker on build pile completion in online mode

### DIFF
--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -779,6 +779,18 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
       }
 
       optimisticViewCommitted = true;
+      // Register the build→retreat animation BEFORE committing the optimistic view.
+      // The reducer moves the completed cards into completedBuildPiles, and CenterArea
+      // relies on activeAnimations to mask them at the destination. If we commit first,
+      // the cards render on the retreat pile for one frame before the animation starts.
+      if (completedBuildPileCards) {
+        triggerCompletedBuildPileAnimation(
+          currentState,
+          buildPile,
+          completedBuildPileCards,
+          currentState.completedBuildPiles.length,
+        );
+      }
       commitView(applyOptimisticPlayView(viewRef.current, buildPile, willEmptyHand));
     };
 
@@ -845,14 +857,6 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
 
     commitOptimisticPlayView();
 
-    if (completedBuildPileCards) {
-      triggerCompletedBuildPileAnimation(
-        currentState,
-        buildPile,
-        completedBuildPileCards,
-        currentState.completedBuildPiles.length,
-      );
-    }
     sendAction({ type: 'PLAY_CARD', buildPile });
     return { success: true, message: 'Carte jouée' };
   }, [commitView, gameState, isInteractionBlocked, sendAction, setInteractionLocked, startAnimation, waitForAnimations]);


### PR DESCRIPTION
## Summary

In online multiplayer, when a player completed a build pile (12 cards), the Skip-Bo / 12 cards briefly appeared stacked on the retreat pile **before** the build→retreat animation started. The flicker was most visible when the retreat pile was empty.

## Root cause

`playCard` in `apps/web/src/hooks/useOnlineSkipBoGame.ts` was running:

1. `commitOptimisticPlayView()` — runs the reducer, which moves the 12 completed cards into `completedBuildPiles`
2. `triggerCompletedBuildPileAnimation()` — registers the animations that fly cards from the build pile to the retreat pile

`CenterArea` masks the retreat-pile destination by subtracting the count of pending `complete` animations from `completedBuildPiles.length`. Between steps 1 and 2, that count was `0` while the state already showed the cards on the retreat pile, so React painted them at the destination for one frame before the animation began.

Local mode (`useSkipBoGame.ts`) already gets the order right by triggering the animation before the reducer dispatch.

## Fix

Move `triggerCompletedBuildPileAnimation` *inside* `commitOptimisticPlayView`, before `commitView`. React then batches the animation-context update with the state update, so the mask is in place the moment the reducer finishes moving the cards.

## Test plan
- [x] `pnpm --filter @skipbo/web exec vitest run src/hooks/__tests__/useOnlineSkipBoGame.test.tsx` — 16/16 passing
- [x] `pnpm --filter @skipbo/web exec vitest run src/hooks/__tests__/` — 24/24 passing
- [ ] Manual: start `pnpm dev` + `pnpm dev:api`, join a multiplayer room with two clients, build pile 0 to 12 — verify the retreat pile stays empty until the cards finish flying in (especially noticeable on an empty retreat pile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)