### PR TITLE
fix(web): keep top remote seat above siblings in 3+ player board

### DIFF
--- a/apps/web/src/components/OnlineGameBoard.tsx
+++ b/apps/web/src/components/OnlineGameBoard.tsx
@@ -16,6 +16,7 @@ interface RemoteSeatProps {
   player: OnlineGameBoardProps['gameState']['players'][number];
   playerIndex: number;
   selectCard: OnlineGameBoardProps['selectCard'];
+  stackingZIndex: number;
 }
 
 function RemoteSeat({
@@ -27,6 +28,7 @@ function RemoteSeat({
   player,
   playerIndex,
   selectCard,
+  stackingZIndex,
 }: RemoteSeatProps) {
   return (
     <section
@@ -38,6 +40,7 @@ function RemoteSeat({
       data-player-index={playerIndex}
       data-player-seat={player.seatIndex}
       data-player-state={isWinner ? 'winner' : isCurrentPlayer ? 'active' : 'idle'}
+      style={{ zIndex: stackingZIndex }}
     >
       <div className="bg-layer" />
       {isWinner && <VictoryEffects />}
@@ -142,6 +145,10 @@ export function OnlineGameBoard({
                 player={player}
                 playerIndex={playerIndex}
                 selectCard={selectCard}
+                // Higher z-index for earlier-DOM seats so draw animations
+                // portaled into a top seat's hand-area aren't covered by the
+                // seat rendered below it.
+                stackingZIndex={20 + (remotePlayers.length - remotePlayerOffset)}
               />
             );
           })}


### PR DESCRIPTION
## Summary

- In a 3+ player online game, `.player-area` siblings share `z-index: 20` + `isolation: isolate`. Same z-index → later DOM sibling paints on top, so Player 2 was visually covering Player 1.
- Combined with the draw-animation portal in `AnimatedCard.tsx` (which moves the in-flight card into the destination seat's stacking context), cards flying from the deck to the top player disappeared behind the seat below as they crossed it. The same inversion also clipped the upper seat's overflowing discard stack.
- Each `RemoteSeat` now gets an explicit `z-index` that decreases with DOM order, so the visually-higher seat always paints above the one below it (e.g. 3-player: top seat z=22, second seat z=21).

## Why

User report (FR): *"Dans une partie multijoueur à 3, les cartes du deck passent sous le 2ème joueur pour se rendre au premier joueur en haut. La défausse du premier joueur est en dessous du deuxième."* — both symptoms fall out of the same z-stacking issue.

## Notes for reviewers

- 2-player path is unchanged: `OnlineGameBoard` short-circuits to `<GameBoard>` when `players.length === 2`.
- The fix is layout-only; no game-state, protocol, or animation logic touched.
- The pre-existing portal logic in `AnimatedCard.tsx` is still required (smooth z-snap on landing); it's just no longer trapped underneath a sibling seat.

## Test plan

- [ ] Visually verify in a real 3-player room (`pnpm dev` + `pnpm dev:api` + 3 clients): cards drawn from the deck to the top remote seat fly above the second remote seat.
- [ ] Discard pile of the top remote seat (with several cards stacked) renders above the seat below, not behind it.
- [ ] 4-player layout (xl: 2 cols × 2 rows) still looks correct — no horizontal regressions since the seats don't overlap on that axis.
- [ ] 2-player layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)