### PR TITLE
fix(web): eliminate face-down flash on opponent stock plays

### DIFF
--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -469,6 +469,20 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
 
                 if (opponentTransition) {
                   holdPreviousTurnPresentation();
+                  // Commit the new view *before* triggering the animation. The
+                  // DOM has not yet been updated (React only schedules the
+                  // re-render), so triggerAIAnimation can still read the
+                  // previous layout via document.querySelector. The flushSync
+                  // inside startAnimation then flushes both the new view and
+                  // the new animation in a single render — preventing a
+                  // one-frame intermediate render where the animation is
+                  // registered against the *old* state. That intermediate
+                  // render would mask the old stock top and fall back to the
+                  // second-from-top card, which on the opponent's stock is a
+                  // redacted HIDDEN_CARD and renders as a face-down back —
+                  // visible as a brief card-back flash before the new top
+                  // appears.
+                  commitView(message.view);
                   void triggerAIAnimation(previousState, opponentTransition.action, {
                     cardOverride: opponentTransition.animationCard,
                     sourceRevealedOverride: opponentTransition.sourceRevealed,
@@ -503,10 +517,12 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
                   }
                   scheduleDrawAnimations(drawTransitions);
                   applyTurnPresentationDelay(drawAnimationDuration);
+                  commitView(message.view);
                 }
+              } else {
+                commitView(message.view);
               }
 
-              commitView(message.view);
               break;
             }
             case 'presence':


### PR DESCRIPTION
## Summary

- Fix a one-frame flicker in online multiplayer where the opponent's new stock top briefly rendered as a face-down card back after they played from their stock pile.
- Root cause: a render-ordering race in the snapshot handler of `useOnlineSkipBoGame` — `triggerAIAnimation` ran before `commitView`, and the `flushSync` inside `startAnimation` forced an intermediate render with the **old** game state plus the new animation. In that render, `StockPile` masked the old top and fell back to the second-from-top card, which on an opponent's redacted stock is `HIDDEN_CARD` (`value: 0`), rendered as `.back`.
- Fix: in the opponent-transition path, call `commitView(message.view)` **before** `triggerAIAnimation`. The DOM is not yet updated (React only schedules the re-render), so position lookups via `document.querySelector` still see the previous layout. The `flushSync` then batches the new view + new animation into a single render, eliminating the buggy intermediate frame. The draw-only branch keeps its original ordering — committing first there could expose drawn-card values briefly before each successive `flushSync` registers their masking animation.

## Why not a smaller masking-side fix?

Tweaking `PlayerArea.StockPile` to also check `isHiddenMultiplayerCard` on the top card would suppress the back, but only by hiding it — the underlying staleness (animation registered against the old state during the intermediate render) would remain and could surface elsewhere. Reordering at the call site removes the intermediate render entirely.

## Test plan

- [x] `pnpm exec vitest run src/components src/hooks` — 85 / 85 pass, including all 6 `OnlineAnimationMasking` tests.
- [ ] Manual: run `pnpm dev` + `pnpm dev:api`, join a room as two players, watch an opponent play from their stock pile, confirm the new top appears revealed instantly with no card-back flash.
- [ ] Manual: confirm opponent discards and opponent build-pile plays still animate correctly (these share the same code path).
- [ ] Manual: confirm local-player stock/discard/play animations are unchanged (the local optimistic path is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)