### PR TITLE
fix(web): break iOS PWA splash → blank reload loop on hard updates

### DIFF
--- a/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
@@ -63,6 +63,8 @@ describe('usePwaVersionGate', () => {
     applyServiceWorkerUpdateMock.mockResolvedValue(false);
     refreshServiceWorkerRegistrationMock.mockResolvedValue(undefined);
 
+    globalThis.sessionStorage?.clear();
+
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       value: 'visible',
@@ -126,6 +128,42 @@ describe('usePwaVersionGate', () => {
     await waitFor(() => {
       expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('skips the auto-reload when sessionStorage already records this minimum version', async () => {
+    globalThis.sessionStorage?.setItem('skipbo:pwa-auto-reload-version', 'v1.1.0');
+
+    fetchRuntimeConfigMock.mockResolvedValue({
+      appVersion: 'v1.2.0',
+      minimumSupportedVersion: 'v1.1.0',
+    });
+
+    const {result} = renderHook(() => usePwaVersionGate());
+
+    await waitFor(() => {
+      expect(result.current.isHardUpdateRequired).toBe(true);
+    });
+
+    // Give any pending promise/effect a chance to (incorrectly) trigger.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(applyServiceWorkerUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('records the minimum supported version in sessionStorage before the auto-reload runs', async () => {
+    fetchRuntimeConfigMock.mockResolvedValue({
+      appVersion: 'v1.2.0',
+      minimumSupportedVersion: 'v1.1.0',
+    });
+
+    renderHook(() => usePwaVersionGate());
+
+    await waitFor(() => {
+      expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(globalThis.sessionStorage?.getItem('skipbo:pwa-auto-reload-version')).toBe('v1.1.0');
   });
 
   it('rechecks runtime config when the document becomes visible again', async () => {

--- a/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
@@ -43,7 +43,7 @@ vi.mock('@/lib/pwaUpdates', () => ({
   },
 }));
 
-import {usePwaVersionGate} from '../usePwaVersionGate';
+import {AUTO_RELOAD_SESSION_STORAGE_KEY, usePwaVersionGate} from '../usePwaVersionGate';
 
 describe('usePwaVersionGate', () => {
   beforeEach(() => {
@@ -131,7 +131,7 @@ describe('usePwaVersionGate', () => {
   });
 
   it('skips the auto-reload when sessionStorage already records this minimum version', async () => {
-    globalThis.sessionStorage?.setItem('skipbo:pwa-auto-reload-version', 'v1.1.0');
+    globalThis.sessionStorage?.setItem(AUTO_RELOAD_SESSION_STORAGE_KEY, 'v1.1.0');
 
     fetchRuntimeConfigMock.mockResolvedValue({
       appVersion: 'v1.2.0',
@@ -144,7 +144,6 @@ describe('usePwaVersionGate', () => {
       expect(result.current.isHardUpdateRequired).toBe(true);
     });
 
-    // Give any pending promise/effect a chance to (incorrectly) trigger.
     await Promise.resolve();
     await Promise.resolve();
 
@@ -163,7 +162,7 @@ describe('usePwaVersionGate', () => {
       expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
     });
 
-    expect(globalThis.sessionStorage?.getItem('skipbo:pwa-auto-reload-version')).toBe('v1.1.0');
+    expect(globalThis.sessionStorage?.getItem(AUTO_RELOAD_SESSION_STORAGE_KEY)).toBe('v1.1.0');
   });
 
   it('rechecks runtime config when the document becomes visible again', async () => {

--- a/apps/web/src/hooks/usePwaVersionGate.ts
+++ b/apps/web/src/hooks/usePwaVersionGate.ts
@@ -6,6 +6,23 @@ import {fetchRuntimeConfig} from '@/lib/runtimeConfig';
 import {compareAppVersions, normalizeVersionTag} from '@/lib/versionUtils';
 
 const UPDATE_CHECK_INTERVAL_MS = 10 * 60 * 1000;
+const AUTO_RELOAD_SESSION_STORAGE_KEY = 'skipbo:pwa-auto-reload-version';
+
+const readAutoReloadVersion = (): string | null => {
+  try {
+    return globalThis.sessionStorage?.getItem(AUTO_RELOAD_SESSION_STORAGE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const writeAutoReloadVersion = (version: string) => {
+  try {
+    globalThis.sessionStorage?.setItem(AUTO_RELOAD_SESSION_STORAGE_KEY, version);
+  } catch {
+    // ignore storage failures (private mode, disabled storage)
+  }
+};
 
 interface RuntimeVersionSnapshot {
   latestAppVersion: string | null;
@@ -67,10 +84,14 @@ export const usePwaVersionGate = (): PwaVersionGateState => {
     try {
       await refreshServiceWorkerRegistration().catch(() => undefined);
 
-      const appliedServiceWorkerUpdate = await applyServiceWorkerUpdate().catch(() => false);
-      if (!appliedServiceWorkerUpdate) {
-        globalThis.location.reload();
-      }
+      // We deliberately do NOT fall back to `location.reload()` when no
+      // service-worker update was applied: reloading just re-serves the
+      // stale precached bundle, which on iOS standalone PWAs creates a
+      // splash → blank → reload loop whenever a hard update is required.
+      // The `ForcedUpdateOverlay` stays visible so the user can retry
+      // manually, and the next interval check (or visibility-change event)
+      // will pick up the new worker as soon as it installs.
+      await applyServiceWorkerUpdate().catch(() => false);
     } finally {
       isApplyingUpdateRef.current = false;
       setIsApplyingUpdate(false);
@@ -138,7 +159,18 @@ export const usePwaVersionGate = (): PwaVersionGateState => {
       return;
     }
 
+    // sessionStorage survives `location.reload()` so a single tab will only
+    // auto-trigger the update flow once per minimum-supported version. Any
+    // subsequent retries must come from the manual `ForcedUpdateOverlay`
+    // button. This is defensive against cycles where the page reloads with
+    // the same stale bundle.
+    if (readAutoReloadVersion() === runtimeVersionSnapshot.minimumSupportedVersion) {
+      autoReloadVersionRef.current = runtimeVersionSnapshot.minimumSupportedVersion;
+      return;
+    }
+
     autoReloadVersionRef.current = runtimeVersionSnapshot.minimumSupportedVersion;
+    writeAutoReloadVersion(runtimeVersionSnapshot.minimumSupportedVersion);
     void reloadToUpdate();
   }, [isHardUpdateRequired, runtimeVersionSnapshot.minimumSupportedVersion]);
 

--- a/apps/web/src/hooks/usePwaVersionGate.ts
+++ b/apps/web/src/hooks/usePwaVersionGate.ts
@@ -6,7 +6,7 @@ import {fetchRuntimeConfig} from '@/lib/runtimeConfig';
 import {compareAppVersions, normalizeVersionTag} from '@/lib/versionUtils';
 
 const UPDATE_CHECK_INTERVAL_MS = 10 * 60 * 1000;
-const AUTO_RELOAD_SESSION_STORAGE_KEY = 'skipbo:pwa-auto-reload-version';
+export const AUTO_RELOAD_SESSION_STORAGE_KEY = 'skipbo:pwa-auto-reload-version';
 
 const readAutoReloadVersion = (): string | null => {
   try {
@@ -20,7 +20,7 @@ const writeAutoReloadVersion = (version: string) => {
   try {
     globalThis.sessionStorage?.setItem(AUTO_RELOAD_SESSION_STORAGE_KEY, version);
   } catch {
-    // ignore storage failures (private mode, disabled storage)
+    // private mode / disabled storage — silently no-op
   }
 };
 
@@ -51,7 +51,6 @@ export const usePwaVersionGate = (): PwaVersionGateState => {
     minimumSupportedVersion: null,
     lastCheckAt: null,
   });
-  const autoReloadVersionRef = useRef<string | null>(null);
   const isApplyingUpdateRef = useRef(false);
   const pwaUpdateSnapshot = useSyncExternalStore(
     subscribeToPwaUpdates,
@@ -82,15 +81,9 @@ export const usePwaVersionGate = (): PwaVersionGateState => {
     setIsApplyingUpdate(true);
 
     try {
-      await refreshServiceWorkerRegistration().catch(() => undefined);
-
-      // We deliberately do NOT fall back to `location.reload()` when no
-      // service-worker update was applied: reloading just re-serves the
-      // stale precached bundle, which on iOS standalone PWAs creates a
-      // splash → blank → reload loop whenever a hard update is required.
-      // The `ForcedUpdateOverlay` stays visible so the user can retry
-      // manually, and the next interval check (or visibility-change event)
-      // will pick up the new worker as soon as it installs.
+      // No `location.reload()` fallback: reloading without a freshly installed
+      // worker re-serves the same precached bundle, which on iOS standalone
+      // PWAs loops splash → blank → reload whenever a hard update is required.
       await applyServiceWorkerUpdate().catch(() => false);
     } finally {
       isApplyingUpdateRef.current = false;
@@ -151,25 +144,16 @@ export const usePwaVersionGate = (): PwaVersionGateState => {
 
   useEffect(() => {
     if (!isHardUpdateRequired || !runtimeVersionSnapshot.minimumSupportedVersion) {
-      autoReloadVersionRef.current = null;
       return;
     }
 
-    if (autoReloadVersionRef.current === runtimeVersionSnapshot.minimumSupportedVersion) {
-      return;
-    }
-
-    // sessionStorage survives `location.reload()` so a single tab will only
-    // auto-trigger the update flow once per minimum-supported version. Any
-    // subsequent retries must come from the manual `ForcedUpdateOverlay`
-    // button. This is defensive against cycles where the page reloads with
-    // the same stale bundle.
+    // sessionStorage survives `location.reload()`, so this guard keeps a single
+    // tab from re-auto-triggering the flow for the same minimum version after
+    // a reload — required retries must come from `ForcedUpdateOverlay`.
     if (readAutoReloadVersion() === runtimeVersionSnapshot.minimumSupportedVersion) {
-      autoReloadVersionRef.current = runtimeVersionSnapshot.minimumSupportedVersion;
       return;
     }
 
-    autoReloadVersionRef.current = runtimeVersionSnapshot.minimumSupportedVersion;
     writeAutoReloadVersion(runtimeVersionSnapshot.minimumSupportedVersion);
     void reloadToUpdate();
   }, [isHardUpdateRequired, runtimeVersionSnapshot.minimumSupportedVersion]);

--- a/apps/web/src/lib/__tests__/pwaUpdates.test.ts
+++ b/apps/web/src/lib/__tests__/pwaUpdates.test.ts
@@ -1,0 +1,161 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+interface RegistrationCallbacks {
+  onNeedRefresh?: () => void;
+  onOfflineReady?: () => void;
+  onRegisteredSW?: (swUrl: string, registration: ServiceWorkerRegistration | undefined) => void;
+  onRegisterError?: (error: unknown) => void;
+}
+
+const updateServiceWorkerMock = vi.fn<(reload?: boolean) => Promise<void>>(async () => undefined);
+let registerOptions: RegistrationCallbacks = {};
+
+vi.mock('virtual:pwa-register', () => ({
+  registerSW: (options: RegistrationCallbacks) => {
+    registerOptions = options;
+    return updateServiceWorkerMock;
+  },
+}));
+
+class FakeServiceWorker extends EventTarget implements Partial<ServiceWorker> {
+  state: ServiceWorkerState = 'installing';
+
+  setState(state: ServiceWorkerState) {
+    this.state = state;
+    this.dispatchEvent(new Event('statechange'));
+  }
+}
+
+interface FakeRegistration {
+  installing: FakeServiceWorker | null;
+  waiting: FakeServiceWorker | null;
+  active: FakeServiceWorker | null;
+  update: ReturnType<typeof vi.fn>;
+}
+
+const buildFakeRegistration = (): FakeRegistration => ({
+  installing: null,
+  waiting: null,
+  active: null,
+  update: vi.fn().mockResolvedValue(undefined),
+});
+
+const loadPwaUpdates = async () => {
+  vi.resetModules();
+  registerOptions = {};
+  updateServiceWorkerMock.mockClear();
+  return import('../pwaUpdates');
+};
+
+describe('pwaUpdates', () => {
+  beforeEach(() => {
+    updateServiceWorkerMock.mockReset();
+    updateServiceWorkerMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not call updateServiceWorker when no installing or waiting worker is found', async () => {
+    const {initializePwaUpdates, applyServiceWorkerUpdate} = await loadPwaUpdates();
+    initializePwaUpdates();
+
+    const registration = buildFakeRegistration();
+    registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
+
+    const applied = await applyServiceWorkerUpdate();
+
+    expect(registration.update).toHaveBeenCalledTimes(1);
+    expect(updateServiceWorkerMock).not.toHaveBeenCalled();
+    expect(applied).toBe(false);
+  });
+
+  it('waits for an installing worker to finish before applying the update', async () => {
+    const {initializePwaUpdates, applyServiceWorkerUpdate} = await loadPwaUpdates();
+    initializePwaUpdates();
+
+    const registration = buildFakeRegistration();
+    const installingWorker = new FakeServiceWorker();
+    installingWorker.state = 'installing';
+    registration.installing = installingWorker;
+
+    registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
+
+    const pending = applyServiceWorkerUpdate();
+
+    // While the worker is still installing, neither updateServiceWorker
+    // nor the promise should resolve.
+    await Promise.resolve();
+    expect(updateServiceWorkerMock).not.toHaveBeenCalled();
+
+    // Simulate the worker finishing install: it transitions to 'installed'
+    // and the registration exposes it via `waiting`.
+    registration.installing = null;
+    registration.waiting = installingWorker;
+    installingWorker.setState('installed');
+
+    const applied = await pending;
+
+    expect(updateServiceWorkerMock).toHaveBeenCalledWith(true);
+    expect(applied).toBe(true);
+  });
+
+  it('falls through gracefully when the installing worker becomes redundant', async () => {
+    const {initializePwaUpdates, applyServiceWorkerUpdate} = await loadPwaUpdates();
+    initializePwaUpdates();
+
+    const registration = buildFakeRegistration();
+    const installingWorker = new FakeServiceWorker();
+    registration.installing = installingWorker;
+
+    registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
+
+    const pending = applyServiceWorkerUpdate();
+
+    registration.installing = null;
+    installingWorker.setState('redundant');
+
+    const applied = await pending;
+
+    expect(updateServiceWorkerMock).not.toHaveBeenCalled();
+    expect(applied).toBe(false);
+  });
+
+  it('applies the update immediately when a waiting worker is already present', async () => {
+    const {initializePwaUpdates, applyServiceWorkerUpdate} = await loadPwaUpdates();
+    initializePwaUpdates();
+
+    const registration = buildFakeRegistration();
+    registration.waiting = new FakeServiceWorker();
+    registration.waiting.state = 'installed';
+
+    registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
+
+    const applied = await applyServiceWorkerUpdate();
+
+    expect(updateServiceWorkerMock).toHaveBeenCalledWith(true);
+    expect(applied).toBe(true);
+  });
+
+  it('times out the install wait so the promise never hangs forever', async () => {
+    vi.useFakeTimers();
+
+    const {initializePwaUpdates, applyServiceWorkerUpdate} = await loadPwaUpdates();
+    initializePwaUpdates();
+
+    const registration = buildFakeRegistration();
+    registration.installing = new FakeServiceWorker();
+
+    registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
+
+    const pending = applyServiceWorkerUpdate();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    const applied = await pending;
+
+    expect(updateServiceWorkerMock).not.toHaveBeenCalled();
+    expect(applied).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/pwaUpdates.test.ts
+++ b/apps/web/src/lib/__tests__/pwaUpdates.test.ts
@@ -84,13 +84,9 @@ describe('pwaUpdates', () => {
 
     const pending = applyServiceWorkerUpdate();
 
-    // While the worker is still installing, neither updateServiceWorker
-    // nor the promise should resolve.
     await Promise.resolve();
     expect(updateServiceWorkerMock).not.toHaveBeenCalled();
 
-    // Simulate the worker finishing install: it transitions to 'installed'
-    // and the registration exposes it via `waiting`.
     registration.installing = null;
     registration.waiting = installingWorker;
     installingWorker.setState('installed');

--- a/apps/web/src/lib/pwaUpdates.ts
+++ b/apps/web/src/lib/pwaUpdates.ts
@@ -75,10 +75,54 @@ export const refreshServiceWorkerRegistration = async (): Promise<void> => {
   await snapshot.registration?.update();
 };
 
-export const applyServiceWorkerUpdate = async (): Promise<boolean> => {
-  await snapshot.registration?.update().catch(() => undefined);
+const SERVICE_WORKER_INSTALL_TIMEOUT_MS = 8000;
 
-  if ((snapshot.needRefresh || snapshot.registration?.waiting) && updateServiceWorker) {
+const waitForInstallingWorker = (worker: ServiceWorker, timeoutMs: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    if (worker.state !== 'installing') {
+      resolve();
+      return;
+    }
+
+    const handleStateChange = () => {
+      if (worker.state !== 'installing') {
+        cleanup();
+        resolve();
+      }
+    };
+
+    const cleanup = () => {
+      worker.removeEventListener('statechange', handleStateChange);
+      globalThis.clearTimeout(timeoutId);
+    };
+
+    const timeoutId = globalThis.setTimeout(() => {
+      cleanup();
+      resolve();
+    }, timeoutMs);
+
+    worker.addEventListener('statechange', handleStateChange);
+  });
+
+export const applyServiceWorkerUpdate = async (): Promise<boolean> => {
+  const registration = snapshot.registration;
+  if (!registration || !updateServiceWorker) {
+    return false;
+  }
+
+  await registration.update().catch(() => undefined);
+
+  // `registration.update()` resolves once the browser has *checked* for a new
+  // worker, but a freshly fetched worker is still in the `installing` state.
+  // Wait until it transitions out before deciding whether to apply the update,
+  // otherwise iOS PWAs reach the `location.reload()` fallback below while the
+  // new worker is still installing — serving the stale precached bundle and
+  // looping the splash → blank screen → reload cycle.
+  if (registration.installing) {
+    await waitForInstallingWorker(registration.installing, SERVICE_WORKER_INSTALL_TIMEOUT_MS);
+  }
+
+  if (snapshot.needRefresh || registration.waiting) {
     await updateServiceWorker(true);
     return true;
   }

--- a/apps/web/src/lib/pwaUpdates.ts
+++ b/apps/web/src/lib/pwaUpdates.ts
@@ -112,12 +112,9 @@ export const applyServiceWorkerUpdate = async (): Promise<boolean> => {
 
   await registration.update().catch(() => undefined);
 
-  // `registration.update()` resolves once the browser has *checked* for a new
-  // worker, but a freshly fetched worker is still in the `installing` state.
-  // Wait until it transitions out before deciding whether to apply the update,
-  // otherwise iOS PWAs reach the `location.reload()` fallback below while the
-  // new worker is still installing — serving the stale precached bundle and
-  // looping the splash → blank screen → reload cycle.
+  // `registration.update()` resolves before a freshly fetched worker leaves
+  // `installing`. Wait it out so the `waiting`/`needRefresh` check below
+  // doesn't false-negative and skip an available update.
   if (registration.installing) {
     await waitForInstallingWorker(registration.installing, SERVICE_WORKER_INSTALL_TIMEOUT_MS);
   }

--- a/apps/web/src/testing/virtualPwaRegisterStub.ts
+++ b/apps/web/src/testing/virtualPwaRegisterStub.ts
@@ -1,0 +1,16 @@
+// Test-only stub that satisfies the `virtual:pwa-register` import surface
+// used by `src/lib/pwaUpdates.ts`. Production builds resolve the virtual
+// module via vite-plugin-pwa; vitest aliases this file in instead so tests
+// can `vi.mock('virtual:pwa-register', …)` and capture the registration
+// callbacks.
+
+type RegisterOptions = {
+  onNeedRefresh?: () => void;
+  onOfflineReady?: () => void;
+  onRegisteredSW?: (swUrl: string, registration: ServiceWorkerRegistration | undefined) => void;
+  onRegisterError?: (error: unknown) => void;
+};
+
+type UpdateServiceWorker = (reload?: boolean) => Promise<void>;
+
+export const registerSW: (options?: RegisterOptions) => UpdateServiceWorker = () => async () => {};

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "virtual:pwa-register": path.resolve(__dirname, "./src/testing/virtualPwaRegisterStub.ts"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Wait for the installing service worker to leave the `installing` state (with an 8s timeout) before deciding whether to activate it. Previously `applyServiceWorkerUpdate` called `registration.update()` and immediately checked `needRefresh`/`waiting` — which were almost always still `false` because the new worker was still installing. The hard-update flow then fell through to `globalThis.location.reload()`, re-served the same stale precached bundle, and looped on iOS until the user force-killed the app.
- Drop the blind `globalThis.location.reload()` fallback in `runReloadToUpdate`. If no SW update can actually be applied, leave the `ForcedUpdateOverlay` visible — the next interval check / visibility-change event will pick the new worker up as soon as it installs.
- Persist the auto-reload version key in `sessionStorage` so a single tab can only auto-trigger the reload flow once per minimum-supported version, defending against any residual loop.
- Add a vitest alias + test stub for the `virtual:pwa-register` virtual module so `pwaUpdates.ts` can be unit-tested.
- Lock the new behaviour in with unit tests covering the install-wait, the redundant-worker path, the timeout, and the sessionStorage guard.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (all packages: 3 + 8 + 17 + 177 passing)
- [ ] Manual verification on iPhone PWA after a release with bumped `PWA_MINIMUM_SUPPORTED_VERSION` — open the app, confirm no splash → blank loop, and that the app eventually applies the new bundle (or surfaces `ForcedUpdateOverlay` with a working manual button).

## Notes

- The dev server doesn't replicate the SW activation race that caused the bug, so I relied on unit tests for verification — the manual iPhone check above is the conclusive step before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)