### PR TITLE
fix(web): keep body background-color solid on themed pages

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,9 +4,8 @@
     {
       "name": "web",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@skipbo/web", "exec", "vite", "--host"],
-      "port": 5173,
-      "autoPort": true
+      "runtimeArgs": ["dev:web"],
+      "port": 5173
     },
     {
       "name": "realtime-api",

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,8 +4,9 @@
     {
       "name": "web",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["dev:web"],
-      "port": 5173
+      "runtimeArgs": ["--filter", "@skipbo/web", "exec", "vite", "--host"],
+      "port": 5173,
+      "autoPort": true
     },
     {
       "name": "realtime-api",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,8 @@
       "Bash(printenv)",
       "Bash(node *)",
       "Bash(curl *)",
-      "Bash(ps *)"
+      "Bash(ps *)",
+      "Bash(ipconfig *)"
     ]
   },
   "hooks": {

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -47,6 +47,18 @@ http://localhost:5173/?fixture=<name>
 
 This bypasses the game loop entirely — useful for isolated layout/visual work without playing to a specific state.
 
+## Theme Styling
+
+Each theme lives in `src/themes/<name>.css` and overrides CSS variables on a `.theme-<name>` class. The base body rule in `src/index.css` applies `bg-background` (= `var(--background)`), so every theme inherits a solid background-color.
+
+Two rules when adding decorative gradients/textures on `body` (or any element that needs to keep a solid color):
+
+1. **Use `background-image:` — never the `background:` shorthand.** The shorthand resets `background-color` to transparent. iOS Safari samples the body's background-color when tinting its top bar; a transparent body falls back to the system default (white in light mode), which is what made Neon's status bar look wrong even though the meta `theme-color` was correct. If you need `background-attachment: fixed`, set it on its own line.
+
+2. **Keep `--background` close to what's actually visible at the top of the page.** `useThemeColorMeta` writes `--background` into `<meta name="theme-color">`, and Tailwind's `bg-background` paints the body with the same value. A wildly off-base `--background` makes the iOS bar mismatch the page (Neon's `#0a0a0a` underneath a `#13002a → #0a0a0a` gradient is fine; Minecraft's old `#2f2418` was much darker than the dirt texture's `#866043` average — fix that, not the bar).
+
+Multi-image gradients must be **comma-separated**. Browsers silently drop a `background-image` declaration whose layers are space-separated; `candy.css` and `retro-space.css` shipped broken halos for this reason.
+
 ## Debug Buttons
 
 `DebugStrip` renders in `DEV` mode only, in both local and online game screens:

--- a/apps/web/src/themes/candy.css
+++ b/apps/web/src/themes/candy.css
@@ -55,7 +55,14 @@
 
   body {
     font-family: "Trebuchet MS", "Arial Rounded MT Bold", ui-rounded, sans-serif;
-    background: radial-gradient(circle at top, rgb(255 255 255 / 0.9) 0%, rgb(255 255 255 / 0) 28%) radial-gradient(circle at 16% 18%, rgb(255 132 177 / 0.34) 0 8%, transparent 8.5%) radial-gradient(circle at 82% 14%, rgb(115 225 189 / 0.3) 0 8%, transparent 8.5%) radial-gradient(circle at 22% 78%, rgb(255 213 111 / 0.26) 0 7%, transparent 7.5%) radial-gradient(circle at 84% 72%, rgb(181 147 255 / 0.26) 0 8%, transparent 8.5%) linear-gradient(180deg, #ffc9df 0%, #ffe7f2 44%, #f1fff8 100%) fixed;
+    background-image:
+      radial-gradient(circle at top, rgb(255 255 255 / 0.9) 0%, rgb(255 255 255 / 0) 28%),
+      radial-gradient(circle at 16% 18%, rgb(255 132 177 / 0.34) 0 8%, transparent 8.5%),
+      radial-gradient(circle at 82% 14%, rgb(115 225 189 / 0.3) 0 8%, transparent 8.5%),
+      radial-gradient(circle at 22% 78%, rgb(255 213 111 / 0.26) 0 7%, transparent 7.5%),
+      radial-gradient(circle at 84% 72%, rgb(181 147 255 / 0.26) 0 8%, transparent 8.5%),
+      linear-gradient(180deg, #ffc9df 0%, #ffe7f2 44%, #f1fff8 100%);
+    background-attachment: fixed;
   }
 
   #main {

--- a/apps/web/src/themes/minecraft.css
+++ b/apps/web/src/themes/minecraft.css
@@ -22,7 +22,7 @@
   --muted: hsl(30 12% 18%);
   --muted-foreground: hsl(0 0% 52%);
 
-  --background: #2f2418;                 /* base around dirt */
+  --background: #866043;                 /* avg of dirt.webp */
   --text-color: #e6e6e6;
   --title-color: #ffffff;
 

--- a/apps/web/src/themes/neon.css
+++ b/apps/web/src/themes/neon.css
@@ -149,7 +149,7 @@
   }
 
   body {
-    background: radial-gradient(ellipse 90% 55% at 50% 100%, #13002a 0%, #0a0a0a 65%);
+    background-image: radial-gradient(ellipse 90% 55% at 50% 100%, #13002a 0%, #0a0a0a 65%);
   }
 
   /* Synthwave perspective grid floor */

--- a/apps/web/src/themes/retro-space.css
+++ b/apps/web/src/themes/retro-space.css
@@ -58,7 +58,11 @@
 
   body {
     font-family: "Segoe UI", sans-serif;
-    background: radial-gradient(circle at 15% 12%, rgb(127 212 215 / 0.12) 0, transparent 18%) radial-gradient(circle at 84% 6%, rgb(241 149 77 / 0.12) 0, transparent 20%) radial-gradient(circle at 50% 100%, rgb(9 22 36 / 0.96) 0, rgb(5 12 21 / 0.98) 60%, #03070d 100%) fixed;
+    background-image:
+      radial-gradient(circle at 15% 12%, rgb(127 212 215 / 0.12) 0, transparent 18%),
+      radial-gradient(circle at 84% 6%, rgb(241 149 77 / 0.12) 0, transparent 20%),
+      radial-gradient(circle at 50% 100%, rgb(9 22 36 / 0.96) 0, rgb(5 12 21 / 0.98) 60%, #03070d 100%);
+    background-attachment: fixed;
   }
 
   body::before {

--- a/apps/web/src/themes/retro.css
+++ b/apps/web/src/themes/retro.css
@@ -7,7 +7,7 @@
   --success-foreground: hsl(0 0% 100%);
   --border: #e76f51;
 
-  --background: #f4f1de;
+  --background: #faf7ed;
   --text-color: #264653;
   --card-front-color: #f4a261;
   --card-border-color: #e76f51;
@@ -60,9 +60,10 @@
   --card-g3: #264653;
 
   body {
-    background:
+    background-image:
       radial-gradient(circle at top, rgb(255 255 255 / 0.32), transparent 34%),
       linear-gradient(180deg, #f7f3e4 0%, #f0e1b2 100%);
+    background-attachment: fixed;
   }
 
   h1,

--- a/apps/web/src/themes/wool.css
+++ b/apps/web/src/themes/wool.css
@@ -10,7 +10,7 @@
   --destructive: hsl(0 49% 49%);
   --destructive-foreground: #c9c9c9;
 
-  --background: hsl(206 13% 51%);
+  --background: hsl(206 13% 46%);
   --text-color: #333333;
   --title-color: #2b2b2b;
   --card-front-color: #ddd;


### PR DESCRIPTION
## Summary

- Fix iOS Safari top-bar mismatch on Neon (and three other themes): the `background:` shorthand on `body` reset `background-color` to transparent, so iOS sampled the system default white instead of the theme color.
- Restore the silently broken decorative halos on Bonbon and Retro Space (their multi-image gradients were space-separated, which is invalid CSS).
- Re-tune `--background` for Minecraft, Retro, and Wool to match what's actually visible at the top of the page (dirt-texture average, halo-composited gradient, grid-darkened wool).
- Anchor the Retro gradient with `background-attachment: fixed` so the visible top stays consistent during scroll.
- Document the rules in [apps/web/CLAUDE.md](apps/web/CLAUDE.md) so the next theme avoids the same trap.

Builds on [#34](https://github.com/klbsjpolp/skip-bo/pull/34) — the `useThemeColorMeta` hook was correct, but iOS Safari **also** samples the body's `background-color` when tinting its top bar, and the shorthand was silently zeroing it out.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm test` (177 unit tests) — passes
- [x] `pnpm test:visual` (chromium-desktop, 31 tests including theme-contract) — passes
- [x] `pnpm --filter @skipbo/web exec playwright test --project=chromium-mobile` — passes
- [ ] Verify on iPhone Safari (LAN dev server): Neon, Minecraft, Retro, Wool top-bar now matches the page background

## Notes

- Bonbon and Retro Space gain visible decorative halos that were broken before — pure visual upside, but worth flagging in case the original look needs to be preserved.
- `.claude/launch.json` adds `autoPort: true` and switches to `vite --host` so the preview server can coexist with manual `pnpm dev` runs and serve the LAN for on-device testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)