### PR TITLE
ci(deploy): use RELEASE_PUSH_TOKEN to push release commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           ref: main # Garantir qu'on est sur main pour la release
           fetch-depth: 0 # Full history is required for conventional-commit version calculation
+          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
       - uses: ./.github/actions/setup-node
 
       - name: Configure git author


### PR DESCRIPTION
The release job pushes a version-bump commit directly to main, but branch rules require status checks that the fresh commit hasn't run yet. Authenticate the checkout (and therefore the subsequent push) with an admin PAT that is on the ruleset bypass list.