### PR TITLE
Implement drag-and-drop with animated card transitions

### DIFF
--- a/apps/web/src/Root.tsx
+++ b/apps/web/src/Root.tsx
@@ -1,10 +1,12 @@
 import App from "@/App.tsx";
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ThemeProvider } from 'next-themes'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {ThemeProvider} from 'next-themes'
 import type {Theme} from "@/types";
-import { themes} from "@/types";
+import {themes} from "@/types";
 import {CardAnimationProvider} from "@/contexts/CardAnimationContext.tsx";
+import {DragProvider} from "@/contexts/DragContext.tsx";
 import {CardAnimationLayer} from "@/components/CardAnimationLayer.tsx";
+import {DragGhost} from "@/components/DragGhost.tsx";
 import React from "react";
 
 const queryClient = new QueryClient()
@@ -18,8 +20,11 @@ function Root() {
                 themes={themes.map(t => t.value)}
             >
                 <CardAnimationProvider>
-                    <App />
-                    <CardAnimationLayer />
+                    <DragProvider>
+                        <App/>
+                        <CardAnimationLayer/>
+                        <DragGhost/>
+                    </DragProvider>
                 </CardAnimationProvider>
             </ThemeProvider>
         </QueryClientProvider>

--- a/apps/web/src/components/Card.tsx
+++ b/apps/web/src/components/Card.tsx
@@ -14,7 +14,9 @@ interface CardProps {
   stackIndex?: number,
   overlapIndex?: number,
   displayValue?: string,
-  hint?: string
+  hint?: string,
+  /** Extra props to spread on the root element — used by drag bindings (onPointerDown, data-*). */
+  extraProps?: HTMLAttributes<HTMLDivElement>
 }
 
 function getTextAndColourForCard(card: CardType | null, overriddenDisplayValue: string | undefined, isRevealed: boolean) {
@@ -41,6 +43,7 @@ const CardComponent: React.FC<CardProps> = ({
                                               overlapIndex = undefined,
                                               displayValue: overriddenDisplayValue,
                                               hint,
+                                              extraProps,
                                             }) => {
   // When a Skip-Bo card is rendered with a displayValue (e.g. settled on a build
   // pile), morph from the Skip-Bo face to the numeric value. Start in 'yes' via
@@ -124,6 +127,7 @@ const CardComponent: React.FC<CardProps> = ({
         className='card-morph-wrapper'
         style={style}
         {...interactiveProps}
+        {...extraProps}
       >
         {/* FROM (Skip-Bo) layer */}
         <div
@@ -170,6 +174,7 @@ const CardComponent: React.FC<CardProps> = ({
         style={style}
         data-value={card.value}
         {...interactiveProps}
+        {...extraProps}
       >
         {content}
       </div>

--- a/apps/web/src/components/CenterArea.tsx
+++ b/apps/web/src/components/CenterArea.tsx
@@ -3,6 +3,7 @@ import {Card} from '@/components/Card';
 import {EmptyCard} from "@/components/EmptyCard.tsx";
 import {cn} from '@/lib/utils';
 import {useCardAnimation} from '@/contexts/useCardAnimation.ts';
+import {useDrag} from '@/contexts/useDrag';
 import {getRetreatPileAngle, RETREAT_PILE_PREVIEW_LIMIT,} from '@/lib/retreatPile';
 
 interface CenterAreaProps {
@@ -13,6 +14,8 @@ interface CenterAreaProps {
 
 export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps) {
   const { activeAnimations } = useCardAnimation();
+  const {session: dragSession} = useDrag();
+  const isDragActive = dragSession !== null;
   const pendingRetreatCardsCount = activeAnimations.filter(
     (animation) => animation.animationType === 'complete',
   ).length;
@@ -58,11 +61,16 @@ export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps
           </h2>
           <div className="build-piles">
             {gameState.buildPiles.map((pile, index) => {
-              const canDropSelectedCard = Boolean(
+              const canDropFromSelection = Boolean(
                 gameState.selectedCard &&
                 gameState.currentPlayerIndex === 0 &&
                 canPlayCard(gameState.selectedCard.card, index, gameState)
               );
+              const canDropFromDrag = isDragActive && dragSession.validBuildPiles.has(index);
+              const canDropSelectedCard = isDragActive ? canDropFromDrag : canDropFromSelection;
+              const isDragOver = canDropFromDrag
+                  && dragSession.hovered?.kind === 'build'
+                  && dragSession.hovered.index === index;
               const incomingPlayAnimation = activeAnimations.find(
                 (animation) =>
                   animation.animationType === 'play' &&
@@ -101,12 +109,15 @@ export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps
                 <div
                   key={`build-${index}`}
                   data-build-pile={index}
+                  data-drop-target={canDropFromDrag ? 'build' : undefined}
+                  data-drop-index={canDropFromDrag ? index : undefined}
                   role={canDropSelectedCard ? 'button' : undefined}
                   tabIndex={canDropSelectedCard ? 0 : undefined}
                   aria-label={`Pile de construction ${index + 1}`}
                   className={cn(
                     "relative drop-indicator build-pile",
-                    canDropSelectedCard && 'can-drop'
+                      canDropSelectedCard && 'can-drop',
+                      isDragOver && 'is-drag-over'
                   )}
                   onClick={(e) => {
                     e.stopPropagation();

--- a/apps/web/src/components/DragGhost.tsx
+++ b/apps/web/src/components/DragGhost.tsx
@@ -1,0 +1,29 @@
+import {createPortal} from 'react-dom';
+import {Card} from '@/components/Card';
+import {useDrag} from '@/contexts/useDrag';
+
+export function DragGhost() {
+  const { session } = useDrag();
+  if (!session) return null;
+
+  const { card, pointer } = session;
+
+  return createPortal(
+    <div
+      aria-hidden="true"
+      data-testid="drag-ghost"
+      style={{
+        position: 'fixed',
+        left: 0,
+        top: 0,
+        transform: `translate3d(${pointer.x}px, ${pointer.y}px, 0) translate(-50%, -50%)`,
+        pointerEvents: 'none',
+        zIndex: 1100,
+        willChange: 'transform',
+      }}
+    >
+      <Card card={card} isRevealed canBeGrabbed={false} className="card-drag-ghost" />
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/EmptyCard.tsx
+++ b/apps/web/src/components/EmptyCard.tsx
@@ -5,9 +5,12 @@ interface EmptyCardProps {
   onClick?: MouseEventHandler;
   canDropCard?: boolean;
   className?: string;
+  /** Hide the "Vide" text — useful when the placeholder sits behind another
+   *  card (e.g. the deck) and is only visible during a draw animation. */
+  hideLabel?: boolean;
 }
 
-export function EmptyCard({onClick, canDropCard = false, className}: EmptyCardProps) {
+export function EmptyCard({onClick, canDropCard = false, className, hideLabel = false}: EmptyCardProps) {
   return (
     <div
       className={cn(
@@ -18,7 +21,7 @@ export function EmptyCard({onClick, canDropCard = false, className}: EmptyCardPr
       )}
       onClick={onClick}
     >
-      Vide
+      {hideLabel ? null : 'Vide'}
     </div>
   );
 }

--- a/apps/web/src/components/GameBoard.tsx
+++ b/apps/web/src/components/GameBoard.tsx
@@ -1,7 +1,7 @@
-import type {GameState, Card as CardType} from '@/types';
-import { PlayerArea } from '@/components/PlayerArea';
-import { CenterArea } from '@/components/CenterArea';
-import { cn } from '@/lib/utils';
+import type {Card as CardType, GameState} from '@/types';
+import {PlayerArea} from '@/components/PlayerArea';
+import {CenterArea} from '@/components/CenterArea';
+import {cn} from '@/lib/utils';
 
 export interface GameBoardProps {
   gameState: GameState;
@@ -38,13 +38,14 @@ export function GameBoard({
         isWinner={gameState.winnerIndex === 1}
         gameState={gameState}
         selectCard={selectCard}
+        playCard={playCard}
         discardCard={discardCard}
         clearSelection={clearSelection}
       />
 
       {/* Center Game Area */}
-      <CenterArea 
-        gameState={gameState} 
+      <CenterArea
+          gameState={gameState}
         playCard={playCard}
         canPlayCard={canPlayCard}
       />
@@ -62,6 +63,7 @@ export function GameBoard({
         isWinner={gameState.winnerIndex === 0}
         gameState={gameState}
         selectCard={selectCard}
+        playCard={playCard}
         discardCard={discardCard}
         clearSelection={clearSelection}
       />

--- a/apps/web/src/components/OnlineGameBoard.tsx
+++ b/apps/web/src/components/OnlineGameBoard.tsx
@@ -1,15 +1,16 @@
-import { CenterArea } from '@/components/CenterArea';
-import { GameBoard } from '@/components/GameBoard';
-import { DiscardPiles, HandSection, PlayerArea, StockPile } from '@/components/PlayerArea';
-import type { GameBoardProps } from '@/components/GameBoard';
-import { VictoryEffects } from '@/components/VictoryEffects';
-import { cn } from '@/lib/utils';
+import {CenterArea} from '@/components/CenterArea';
+import type {GameBoardProps} from '@/components/GameBoard';
+import {GameBoard} from '@/components/GameBoard';
+import {DiscardPiles, HandSection, PlayerArea, StockPile} from '@/components/PlayerArea';
+import {VictoryEffects} from '@/components/VictoryEffects';
+import {cn} from '@/lib/utils';
 
 type OnlineGameBoardProps = GameBoardProps;
 
 interface RemoteSeatProps {
   clearSelection: OnlineGameBoardProps['clearSelection'];
   discardCard: OnlineGameBoardProps['discardCard'];
+  playCard: OnlineGameBoardProps['playCard'];
   gameState: OnlineGameBoardProps['gameState'];
   isCurrentPlayer: boolean;
   isWinner: boolean;
@@ -22,6 +23,7 @@ interface RemoteSeatProps {
 function RemoteSeat({
   clearSelection,
   discardCard,
+                      playCard,
   gameState,
   isCurrentPlayer,
   isWinner,
@@ -62,6 +64,8 @@ function RemoteSeat({
           isCurrentPlayer={isCurrentPlayer}
           gameState={gameState}
           selectCard={selectCard}
+          playCard={playCard}
+          discardCard={discardCard}
           clearSelection={clearSelection}
         />
 
@@ -72,6 +76,8 @@ function RemoteSeat({
             isCurrentPlayer={isCurrentPlayer}
             gameState={gameState}
             selectCard={selectCard}
+            playCard={playCard}
+            discardCard={discardCard}
             clearSelection={clearSelection}
           />
         </div>
@@ -85,6 +91,7 @@ function RemoteSeat({
             isCurrentPlayer={isCurrentPlayer}
             gameState={gameState}
             discardCard={discardCard}
+            playCard={playCard}
             selectCard={selectCard}
             clearSelection={clearSelection}
           />
@@ -139,6 +146,7 @@ export function OnlineGameBoard({
                 key={`remote-seat-${player.seatIndex ?? playerIndex}`}
                 clearSelection={clearSelection}
                 discardCard={discardCard}
+                playCard={playCard}
                 gameState={gameState}
                 isCurrentPlayer={gameState.currentPlayerIndex === playerIndex}
                 isWinner={gameState.winnerIndex === playerIndex}
@@ -172,6 +180,7 @@ export function OnlineGameBoard({
         isWinner={gameState.winnerIndex === 0}
         gameState={gameState}
         selectCard={selectCard}
+        playCard={playCard}
         discardCard={discardCard}
         clearSelection={clearSelection}
       />

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -1,10 +1,12 @@
-import type {Card as CardType, GameState, Player} from '@/types';
+import type {Card as CardType, GameState, MoveResult, Player} from '@/types';
 import {Card} from '@/components/Card';
 import {cn} from '@/lib/utils';
 import {EmptyCard} from "@/components/EmptyCard.tsx";
 import type {MouseEventHandler} from "react";
 import {Fragment} from "react";
 import {useCardAnimation} from "@/contexts/useCardAnimation.ts";
+import {useDrag, useIsDragSource} from '@/contexts/useDrag';
+import {useDraggableCard} from '@/hooks/useDraggableCard';
 import {VictoryEffects} from '@/components/VictoryEffects';
 import {HAND_Y_OFFSETS} from '@/utils/cardPositions';
 
@@ -15,7 +17,8 @@ export interface PlayerAreaProps {
   isWinner: boolean;
   gameState: GameState;
   selectCard: (source: 'hand' | 'stock' | 'discard', index: number, discardPileIndex?: number) => void;
-  discardCard: (discardPileIndex: number) => Promise<{ success: boolean; message: string }>;
+    playCard: (buildPileIndex: number) => Promise<MoveResult>;
+    discardCard: (discardPileIndex: number) => Promise<MoveResult>;
   clearSelection: () => void;
 }
 
@@ -26,6 +29,7 @@ export function PlayerArea({
                              isWinner,
                              gameState,
                              selectCard,
+                               playCard,
                              discardCard,
                              clearSelection
                            }: PlayerAreaProps) {
@@ -46,13 +50,16 @@ export function PlayerArea({
       <div className="content-layer flex items-center gap-2 lg:gap-4 h-full flex-wrap">
           {player.name && <h2 className="vertical-text border-l border-primary">{player.name}</h2>}
         <StockPile player={player} playerIndex={playerIndex} isCurrentPlayer={isCurrentPlayer} gameState={gameState}
-                   selectCard={selectCard} clearSelection={clearSelection}/>
+                   selectCard={selectCard} playCard={playCard} discardCard={discardCard}
+                   clearSelection={clearSelection}/>
         <HandSection player={player} playerIndex={playerIndex} isCurrentPlayer={isCurrentPlayer} gameState={gameState}
-                     selectCard={selectCard} clearSelection={clearSelection}/>
+                     selectCard={selectCard} playCard={playCard} discardCard={discardCard}
+                     clearSelection={clearSelection}/>
         {/* Grow - blank space */}
         <div className="grow"></div>
         <DiscardPiles player={player} playerIndex={playerIndex} isCurrentPlayer={isCurrentPlayer} gameState={gameState}
-                      discardCard={discardCard} selectCard={selectCard} clearSelection={clearSelection}/>
+                      playCard={playCard} discardCard={discardCard} selectCard={selectCard}
+                      clearSelection={clearSelection}/>
       </div>
     </div>
   );
@@ -64,7 +71,8 @@ interface DiscardPileProps {
   isCurrentPlayer: boolean,
   gameState: GameState,
   selectCard: (source: 'hand' | 'stock' | 'discard', index: number, discardPileIndex?: number) => void,
-  discardCard: (discardPileIndex: number) => Promise<{ success: boolean; message: string }>,
+    playCard: (buildPileIndex: number) => Promise<MoveResult>,
+    discardCard: (discardPileIndex: number) => Promise<MoveResult>,
   clearSelection: () => void,
   pile: CardType[],
   pileIndex: number
@@ -78,10 +86,12 @@ function DiscardPile({
                        isCurrentPlayer,
                        gameState,
                        selectCard,
+                         playCard,
                        discardCard,
                        clearSelection
                      }: DiscardPileProps) {
   const {activeAnimations, isCardBeingAnimated} = useCardAnimation();
+    const {session: dragSession} = useDrag();
   const isHuman = !player.isAI;
   const hasIncomingDiscardAnimation = activeAnimations.some(
     (animation) =>
@@ -124,10 +134,25 @@ function DiscardPile({
     }
   };
 
-  return <div className={cn(
-    "drop-indicator discard-pile-stack",
-    isHuman && isCurrentPlayer && gameState.selectedCard?.source === 'hand' && "can-drop"
+    const canDropFromSelection =
+        isHuman && isCurrentPlayer && gameState.selectedCard?.source === 'hand';
+    const isDragActive = dragSession !== null;
+    const canDropFromDrag = isDragActive
+        && dragSession.validDiscardPiles.has(pileIndex)
+        && playerIndex === gameState.currentPlayerIndex
+        && isHuman;
+    const canDrop = isDragActive ? canDropFromDrag : canDropFromSelection;
+    const isDragOver = canDropFromDrag
+        && dragSession?.hovered?.kind === 'discard'
+        && dragSession.hovered.index === pileIndex;
+
+    return <div className={cn(
+        "drop-indicator discard-pile-stack relative",
+        canDrop && "can-drop",
+        isDragOver && "is-drag-over"
   )} data-pile-index={pileIndex}
+                data-drop-target={canDropFromDrag ? 'discard' : undefined}
+                data-drop-index={canDropFromDrag ? pileIndex : undefined}
     role={canInteract ? 'button' : undefined}
     tabIndex={canInteract ? 0 : undefined}
     aria-label={`Défausse ${pileIndex + 1}`}
@@ -147,7 +172,7 @@ function DiscardPile({
     }}
     style={{height: `calc(var(--card-height) + ${(pile.length <= 1 ? 0 : pile.length - 1) * 20}px)`}}
   >
-    {computedPiles.length === 0 && <EmptyCard/>}
+        <EmptyCard canDropCard={computedPiles.length === 0} className="absolute inset-0"/>
     {computedPiles.map(({card, cardIdx, isAnimated, key}) => {
       if (isAnimated) {
         const fakeCard = <div key={key} className="card opacity-0 pointer-events-none"
@@ -159,7 +184,23 @@ function DiscardPile({
           </Fragment>
         else
           return fakeCard
-      } else
+      }
+        const isTop = cardIdx === pile.length - 1;
+        if (isTop && isHuman && isCurrentPlayer) {
+            return (
+                <DraggableDiscardTop
+                    key={`discard-${pileIndex}-card-${cardIdx}`}
+                    card={card}
+                    pileIndex={pileIndex}
+                    cardIndex={cardIdx}
+                    playerIndex={playerIndex}
+                    gameState={gameState}
+                    selectCard={selectCard}
+                    playCard={playCard}
+                    discardCard={discardCard}
+                />
+            );
+        }
         return <Card
           hint={`discard pile ${pileIndex + 1}, card ${cardIdx + 1}`}
           key={`discard-${pileIndex}-card-${cardIdx}`}
@@ -171,12 +212,61 @@ function DiscardPile({
             gameState.currentPlayerIndex === playerIndex &&
             cardIdx === pile.length - 1
           }
-          canBeGrabbed={isHuman && isCurrentPlayer && cardIdx === pile.length - 1}
+          canBeGrabbed={isHuman && isCurrentPlayer && isTop}
           stackIndex={cardIdx}
-          // Remove onClick from Card to avoid nested handlers
-        />
+        />;
     })}
   </div>;
+}
+
+interface DraggableDiscardTopProps {
+    card: CardType;
+    pileIndex: number;
+    cardIndex: number;
+    playerIndex: number;
+    gameState: GameState;
+    selectCard: DiscardPileProps['selectCard'];
+    playCard: DiscardPileProps['playCard'];
+    discardCard: DiscardPileProps['discardCard'];
+}
+
+function DraggableDiscardTop({
+                                 card,
+                                 pileIndex,
+                                 cardIndex,
+                                 playerIndex,
+                                 gameState,
+                                 selectCard,
+                                 playCard,
+                                 discardCard,
+                             }: DraggableDiscardTopProps) {
+    const source = {kind: 'discard' as const, index: cardIndex, discardPileIndex: pileIndex};
+    const draggable = useDraggableCard({
+        source,
+        card,
+        enabled: true,
+        gameState,
+        selectCard,
+        playCard,
+        discardCard,
+    });
+    const isDragging = useIsDragSource(source);
+    const isSelected =
+        gameState.selectedCard?.source === 'discard' &&
+        gameState.selectedCard.discardPileIndex === pileIndex &&
+        gameState.currentPlayerIndex === playerIndex;
+    return (
+        <Card
+            hint={`discard pile ${pileIndex + 1}, card ${cardIndex + 1}`}
+            card={card}
+            isRevealed={true}
+            isSelected={isSelected}
+            canBeGrabbed={true}
+            stackIndex={cardIndex}
+            className={isDragging ? 'is-drag-source' : undefined}
+            extraProps={draggable}
+        />
+    );
 }
 
 interface DiscardPilesProps {
@@ -185,7 +275,8 @@ interface DiscardPilesProps {
   isCurrentPlayer: boolean;
   gameState: GameState;
   selectCard: (source: 'hand' | 'stock' | 'discard', index: number, discardPileIndex?: number) => void;
-  discardCard: (discardPileIndex: number) => Promise<{ success: boolean; message: string }>;
+    playCard: (buildPileIndex: number) => Promise<MoveResult>;
+    discardCard: (discardPileIndex: number) => Promise<MoveResult>;
   clearSelection: () => void;
 }
 
@@ -195,6 +286,7 @@ export function DiscardPiles({
                         isCurrentPlayer,
                         gameState,
                         selectCard,
+                                 playCard,
                         discardCard,
                         clearSelection
                       }: DiscardPilesProps) {
@@ -206,6 +298,7 @@ export function DiscardPiles({
       {player.discardPiles.map((pile, pileIndex) => (
         <DiscardPile key={`discard-${pileIndex}`} pile={pile} pileIndex={pileIndex} playerIndex={playerIndex}
                      isCurrentPlayer={isCurrentPlayer} gameState={gameState} selectCard={selectCard}
+                     playCard={playCard}
                      discardCard={discardCard} clearSelection={clearSelection} player={player}/>
       ))}
     </div>
@@ -218,6 +311,8 @@ interface StockPileProps {
   isCurrentPlayer: boolean;
   gameState: GameState;
   selectCard: (source: 'hand' | 'stock' | 'discard', index: number, discardPileIndex?: number) => void;
+    playCard: (buildPileIndex: number) => Promise<MoveResult>;
+    discardCard: (discardPileIndex: number) => Promise<MoveResult>;
   clearSelection: () => void;
 }
 
@@ -230,6 +325,8 @@ export function StockPile({
                             isCurrentPlayer,
                             gameState,
                             selectCard,
+                              playCard,
+                              discardCard,
                             clearSelection
                           }: StockPileProps) {
   const {isCardBeingAnimated} = useCardAnimation();
@@ -260,6 +357,12 @@ export function StockPile({
       <h2 className="vertical-text">Talon ({player.stockPile.length})</h2>
     {player.stockPile.length > 0 ? (
       <div className="relative w-(--card-width) stock-pile">
+          {/* Placeholder slot behind the stock top card so the slot stays
+            visible while the top card is animating to a build / discard
+            pile. The label is hidden because there's a real card on top in
+            the normal case; the empty-pile case has its own EmptyCard
+            below. */}
+          <EmptyCard canDropCard={false} hideLabel className="absolute inset-0"/>
         {/* Show the top card unless it's being animated */}
         {isCardBeingAnimated(playerIndex, 'stock', player.stockPile.length - 1)
           ? (player.stockPile.length > 1 ? (
@@ -269,23 +372,36 @@ export function StockPile({
               isRevealed={!isHiddenMultiplayerCard(player.stockPile[player.stockPile.length - 2])}
               canBeGrabbed={false}
             />
-          ) : (
-            <EmptyCard/>
-          ))
+            ) : null)
           : (
-            <Card
-              hint={player.stockPile.length === 1 ? 'Top card in stock' : 'Top card in stock (hidden)'}
-              card={player.stockPile[player.stockPile.length - 1]}
-              isRevealed={true}
-              onClick={stockPileOnClick}
-              isSelected={
-                gameState.selectedCard?.source === 'stock' &&
-                gameState.selectedCard.index === player.stockPile.length - 1 &&
-                gameState.currentPlayerIndex === playerIndex
-              }
-              canBeGrabbed={isHuman && isCurrentPlayer}
-              className="relative z-10"
-            />
+                isHuman && isCurrentPlayer && player.stockPile[player.stockPile.length - 1]
+                    ? (
+                        <DraggableStockTop
+                            card={player.stockPile[player.stockPile.length - 1]}
+                            stockTopIndex={player.stockPile.length - 1}
+                            playerIndex={playerIndex}
+                            gameState={gameState}
+                            selectCard={selectCard}
+                            playCard={playCard}
+                            discardCard={discardCard}
+                            onClick={stockPileOnClick}
+                        />
+                    )
+                    : (
+                        <Card
+                            hint={player.stockPile.length === 1 ? 'Top card in stock' : 'Top card in stock (hidden)'}
+                            card={player.stockPile[player.stockPile.length - 1]}
+                            isRevealed={true}
+                            onClick={stockPileOnClick}
+                            isSelected={
+                                gameState.selectedCard?.source === 'stock' &&
+                                gameState.selectedCard.index === player.stockPile.length - 1 &&
+                                gameState.currentPlayerIndex === playerIndex
+                            }
+                            canBeGrabbed={isHuman && isCurrentPlayer}
+                            className="relative z-10"
+                        />
+                    )
           )}
       </div>
     ) : (
@@ -303,12 +419,64 @@ export function StockPile({
   </div>;
 }
 
+interface DraggableStockTopProps {
+    card: CardType;
+    stockTopIndex: number;
+    playerIndex: number;
+    gameState: GameState;
+    selectCard: StockPileProps['selectCard'];
+    playCard: StockPileProps['playCard'];
+    discardCard: StockPileProps['discardCard'];
+    onClick: MouseEventHandler;
+}
+
+function DraggableStockTop({
+                               card,
+                               stockTopIndex,
+                               playerIndex,
+                               gameState,
+                               selectCard,
+                               playCard,
+                               discardCard,
+                               onClick,
+                           }: DraggableStockTopProps) {
+    const source = {kind: 'stock' as const, index: stockTopIndex};
+    const draggable = useDraggableCard({
+        source,
+        card,
+        enabled: true,
+        gameState,
+        selectCard,
+        playCard,
+        discardCard,
+    });
+    const isDragging = useIsDragSource(source);
+    return (
+        <Card
+            hint="Top card in stock"
+            card={card}
+            isRevealed={true}
+            onClick={onClick}
+            isSelected={
+                gameState.selectedCard?.source === 'stock' &&
+                gameState.selectedCard.index === stockTopIndex &&
+                gameState.currentPlayerIndex === playerIndex
+            }
+            canBeGrabbed={true}
+            className={cn('relative z-10', isDragging && 'is-drag-source')}
+            extraProps={draggable}
+        />
+    );
+}
+
 interface HandSectionProps {
   player: Player;
   playerIndex: number;
   isCurrentPlayer: boolean;
   gameState: GameState;
   selectCard: (source: 'hand' | 'stock' | 'discard', index: number, discardPileIndex?: number) => void;
+    playCard: (buildPileIndex: number) => Promise<MoveResult>;
+    discardCard: (discardPileIndex: number) => Promise<MoveResult>;
   clearSelection: () => void;
 }
 
@@ -318,6 +486,8 @@ export function HandSection({
                               isCurrentPlayer,
                               gameState,
                               selectCard,
+                                playCard,
+                                discardCard,
                               clearSelection
                             }: HandSectionProps) {
   const {isCardBeingAnimated} = useCardAnimation();
@@ -372,22 +542,91 @@ export function HandSection({
               } : undefined}
             />
           ) : (
-            <Card
-              hint={`Hand card ${index + 1}`}
-              card={card}
-              isRevealed={isHuman}
-              onClick={handCardOnClick}
-              isSelected={
-                gameState.selectedCard?.source === 'hand' &&
-                gameState.selectedCard.index === index &&
-                gameState.currentPlayerIndex === playerIndex
-              }
-              canBeGrabbed={isHuman && isCurrentPlayer}
-              overlapIndex={handOverlaps ? index : undefined}
-            />
+              isHuman && isCurrentPlayer && card
+                  ? (
+                      <DraggableHandCard
+                          card={card}
+                          index={index}
+                          playerIndex={playerIndex}
+                          gameState={gameState}
+                          selectCard={selectCard}
+                          playCard={playCard}
+                          discardCard={discardCard}
+                          onClick={handCardOnClick}
+                          overlapIndex={handOverlaps ? index : undefined}
+                      />
+                  )
+                  : (
+                      <Card
+                          hint={`Hand card ${index + 1}`}
+                          card={card}
+                          isRevealed={isHuman}
+                          onClick={handCardOnClick}
+                          isSelected={
+                              gameState.selectedCard?.source === 'hand' &&
+                              gameState.selectedCard.index === index &&
+                              gameState.currentPlayerIndex === playerIndex
+                          }
+                          canBeGrabbed={isHuman && isCurrentPlayer}
+                          overlapIndex={handOverlaps ? index : undefined}
+                      />
+                  )
           )}
         </div>
       ))}
     </div>
   </div>;
+}
+
+interface DraggableHandCardProps {
+    card: CardType;
+    index: number;
+    playerIndex: number;
+    gameState: GameState;
+    selectCard: HandSectionProps['selectCard'];
+    playCard: HandSectionProps['playCard'];
+    discardCard: HandSectionProps['discardCard'];
+    onClick: MouseEventHandler;
+    overlapIndex?: number;
+}
+
+function DraggableHandCard({
+                               card,
+                               index,
+                               playerIndex,
+                               gameState,
+                               selectCard,
+                               playCard,
+                               discardCard,
+                               onClick,
+                               overlapIndex,
+                           }: DraggableHandCardProps) {
+    const source = {kind: 'hand' as const, index};
+    const draggable = useDraggableCard({
+        source,
+        card,
+        enabled: true,
+        gameState,
+        selectCard,
+        playCard,
+        discardCard,
+    });
+    const isDragging = useIsDragSource(source);
+    return (
+        <Card
+            hint={`Hand card ${index + 1}`}
+            card={card}
+            isRevealed
+            onClick={onClick}
+            isSelected={
+                gameState.selectedCard?.source === 'hand' &&
+                gameState.selectedCard.index === index &&
+                gameState.currentPlayerIndex === playerIndex
+            }
+            canBeGrabbed
+            overlapIndex={overlapIndex}
+            className={isDragging ? 'is-drag-source' : undefined}
+            extraProps={draggable}
+        />
+    );
 }

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -172,7 +172,7 @@ function DiscardPile({
     }}
     style={{height: `calc(var(--card-height) + ${(pile.length <= 1 ? 0 : pile.length - 1) * 20}px)`}}
   >
-        <EmptyCard canDropCard={computedPiles.length === 0} className="absolute inset-0"/>
+        <EmptyCard canDropCard={computedPiles.length === 0} hideLabel={computedPiles.length > 0} className="absolute inset-0"/>
     {computedPiles.map(({card, cardIdx, isAnimated, key}) => {
       if (isAnimated) {
         const fakeCard = <div key={key} className="card opacity-0 pointer-events-none"

--- a/apps/web/src/components/__tests__/DragSelection.test.tsx
+++ b/apps/web/src/components/__tests__/DragSelection.test.tsx
@@ -1,0 +1,253 @@
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import {describe, expect, test, vi} from 'vitest';
+
+import {PlayerArea} from '@/components/PlayerArea';
+import {DragProvider} from '@/contexts/DragContext';
+import {CardAnimationProvider} from '@/contexts/CardAnimationContext';
+import type {Card, GameConfig, GameState, MoveResult, Player, SelectedCard} from '@/types';
+
+type SelectCardFn = (source: 'hand' | 'stock' | 'discard', index: number, discardPileIndex?: number) => void;
+type PlayCardFn = (buildPileIndex: number) => Promise<MoveResult>;
+type DiscardCardFn = (discardPileIndex: number) => Promise<MoveResult>;
+type ClearSelectionFn = () => void;
+
+interface MockHandlers {
+  selectCard: ReturnType<typeof vi.fn> & SelectCardFn;
+  playCard: PlayCardFn;
+  discardCard: DiscardCardFn;
+  clearSelection: ClearSelectionFn;
+}
+
+const createHandlers = (): MockHandlers => ({
+  selectCard: vi.fn() as ReturnType<typeof vi.fn> & SelectCardFn,
+  playCard: vi.fn(async () => ({ success: true, message: 'ok' })) as unknown as PlayCardFn,
+  discardCard: vi.fn(async () => ({ success: true, message: 'ok' })) as unknown as DiscardCardFn,
+  clearSelection: vi.fn() as unknown as ClearSelectionFn,
+});
+
+const FIXTURE_CONFIG: GameConfig = {
+  DECK_SIZE: 162,
+  SKIP_BO_CARDS: 18,
+  HAND_SIZE: 5,
+  STOCK_SIZE: 30,
+  BUILD_PILES_COUNT: 4,
+  DISCARD_PILES_COUNT: 4,
+  CARD_VALUES_MIN: 1,
+  CARD_VALUES_MAX: 12,
+  CARD_VALUES_SKIP_BO: 0,
+};
+
+const card = (value: number, isSkipBo = false): Card => ({ value, isSkipBo });
+
+const createPlayer = (overrides: Partial<Player> = {}): Player => ({
+  isAI: false,
+  stockPile: [card(11), card(12)],
+  hand: [card(3), card(4), card(5), card(6), card(7)],
+  discardPiles: [[card(8), card(9)], [], [], []],
+  ...overrides,
+});
+
+const createGameState = (selectedCard: SelectedCard | null): GameState => ({
+  deck: [],
+  buildPiles: [[], [], [], []],
+  completedBuildPiles: [],
+  players: [createPlayer(), createPlayer({ isAI: true })],
+  currentPlayerIndex: 0,
+  gameIsOver: false,
+  winnerIndex: null,
+  selectedCard,
+  message: '',
+  config: FIXTURE_CONFIG,
+});
+
+const renderHumanPlayer = (gameState: GameState, handlers: MockHandlers) =>
+  render(
+    <CardAnimationProvider>
+      <DragProvider>
+        <PlayerArea
+          player={gameState.players[0]}
+          playerIndex={0}
+          isCurrentPlayer
+          isWinner={false}
+          gameState={gameState}
+          selectCard={handlers.selectCard}
+          playCard={handlers.playCard}
+          discardCard={handlers.discardCard}
+          clearSelection={handlers.clearSelection}
+        />
+      </DragProvider>
+    </CardAnimationProvider>,
+  );
+
+describe('Drag selection', () => {
+  test('starting a drag from a discard top while a hand card is selected switches the selection to the discard source', () => {
+    const handlers = createHandlers();
+    // Hand card at index 0 is currently selected.
+    const gameState = createGameState({
+      card: card(3),
+      source: 'hand',
+      index: 0,
+      discardPileIndex: undefined,
+    });
+    renderHumanPlayer(gameState, handlers);
+
+    // Top of discard pile 0 (value 9). It's the rendered draggable top card.
+    const discardPile = screen.getByLabelText('Défausse 1');
+    const topCard = Array.from(
+      discardPile.querySelectorAll<HTMLElement>('.card[data-value]'),
+    ).pop();
+    expect(topCard, 'expected a top discard card to drag').toBeTruthy();
+
+    // Simulate a real drag: pointerdown then a pointermove past the 5px threshold.
+    act(() => {
+      fireEvent.pointerDown(topCard!, {
+        pointerId: 1,
+        pointerType: 'mouse',
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      });
+      // Window-level pointermove triggers the drag's threshold check.
+      fireEvent(
+        window,
+        new PointerEvent('pointermove', {
+          pointerId: 1,
+          pointerType: 'mouse',
+          buttons: 1,
+          clientX: 200,
+          clientY: 100,
+          bubbles: true,
+        }),
+      );
+    });
+
+    expect(handlers.selectCard).toHaveBeenCalled();
+    // The drag handler must replace the prior hand selection with the discard
+    // source — never leave it on `hand` and never call it for `stock`.
+    const lastCall = handlers.selectCard.mock.calls.at(-1)!;
+    expect(lastCall[0]).toBe('discard');
+    expect(lastCall[2]).toBe(0); // discardPileIndex of pile 0
+
+    // discardCard must NOT have been triggered as a side-effect (otherwise the
+    // hand card would have been discarded instead of the drag starting).
+    expect((handlers.discardCard as unknown as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+
+    // Cleanup so the drag listeners (and the post-drop swallow-click capture
+    // listener) don't leak between tests.
+    act(() => {
+      fireEvent(
+        window,
+        new PointerEvent('pointerup', {
+          pointerId: 1,
+          pointerType: 'mouse',
+          clientX: 200,
+          clientY: 100,
+          bubbles: true,
+        }),
+      );
+      // Consume the swallow-click listener that the drag hook installs after
+      // a successful drag-end so it doesn't eat the *next* test's click.
+      fireEvent.click(window);
+    });
+  });
+
+  test('a plain tap on a discard pile while a hand card is selected discards the hand card (legacy click flow)', () => {
+    const handlers = createHandlers();
+    const gameState = createGameState({
+      card: card(3),
+      source: 'hand',
+      index: 0,
+      discardPileIndex: undefined,
+    });
+    renderHumanPlayer(gameState, handlers);
+
+    const discardPile = screen.getByLabelText('Défausse 1');
+    const topCard = Array.from(
+      discardPile.querySelectorAll<HTMLElement>('.card[data-value]'),
+    ).pop()!;
+
+    // Plain tap (pointerdown → pointerup with no movement → click). Drag must
+    // NOT start, and the click must reach the discard-pile-stack's handler.
+    act(() => {
+      fireEvent.pointerDown(topCard, {
+        pointerId: 3,
+        pointerType: 'mouse',
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      });
+    });
+    act(() => {
+      fireEvent(
+        window,
+        new PointerEvent('pointerup', {
+          pointerId: 3,
+          pointerType: 'mouse',
+          clientX: 100,
+          clientY: 100,
+          bubbles: true,
+        }),
+      );
+      // The trailing click is what the browser would dispatch after a tap.
+      fireEvent.click(topCard);
+    });
+
+    // No selection switch — pointerdown without a real drag must be silent.
+    expect(handlers.selectCard).not.toHaveBeenCalled();
+    // The legacy click affordance fires: discard the selected hand card here.
+    expect((handlers.discardCard as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(0);
+  });
+
+  test('starting a drag from a hand card while another hand card is selected switches the selection', () => {
+    const handlers = createHandlers();
+    const gameState = createGameState({
+      card: card(3),
+      source: 'hand',
+      index: 0,
+      discardPileIndex: undefined,
+    });
+    renderHumanPlayer(gameState, handlers);
+
+    // Drag hand card index 2 (value 5).
+    const otherHandSlot = document.querySelector('[data-card-index="2"] .card') as HTMLElement;
+    expect(otherHandSlot).toBeTruthy();
+
+    act(() => {
+      fireEvent.pointerDown(otherHandSlot, {
+        pointerId: 2,
+        pointerType: 'mouse',
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      });
+      fireEvent(
+        window,
+        new PointerEvent('pointermove', {
+          pointerId: 2,
+          pointerType: 'mouse',
+          buttons: 1,
+          clientX: 100,
+          clientY: 200,
+          bubbles: true,
+        }),
+      );
+    });
+
+    const lastCall = handlers.selectCard.mock.calls.at(-1)!;
+    expect(lastCall[0]).toBe('hand');
+    expect(lastCall[1]).toBe(2);
+
+    act(() => {
+      fireEvent(
+        window,
+        new PointerEvent('pointerup', {
+          pointerId: 2,
+          pointerType: 'mouse',
+          clientX: 100,
+          clientY: 200,
+          bubbles: true,
+        }),
+      );
+    });
+  });
+});

--- a/apps/web/src/components/__tests__/OnlineAnimationMasking.test.tsx
+++ b/apps/web/src/components/__tests__/OnlineAnimationMasking.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, test, vi } from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {describe, expect, test, vi} from 'vitest';
 
-import { CenterArea } from '@/components/CenterArea';
-import { PlayerArea } from '@/components/PlayerArea';
-import type { AnimationContextType, CardAnimationData } from '@/contexts/CardAnimationContext';
-import { CardAnimationContext } from '@/contexts/useCardAnimation';
-import type { Card, GameConfig, GameState, Player } from '@/types';
+import {CenterArea} from '@/components/CenterArea';
+import {PlayerArea} from '@/components/PlayerArea';
+import type {AnimationContextType, CardAnimationData} from '@/contexts/CardAnimationContext';
+import {CardAnimationContext} from '@/contexts/useCardAnimation';
+import type {Card, GameConfig, GameState, Player} from '@/types';
 
 const FIXTURE_CONFIG: GameConfig = {
   DECK_SIZE: 162,
@@ -194,6 +194,7 @@ describe('Online animation masking', () => {
           isWinner={false}
           gameState={gameState}
           selectCard={vi.fn()}
+          playCard={vi.fn(async () => ({success: true, message: 'ok'}))}
           discardCard={vi.fn(async () => ({ success: true, message: 'ok' }))}
           clearSelection={vi.fn()}
         />
@@ -221,6 +222,7 @@ describe('Online animation masking', () => {
           isWinner={false}
           gameState={gameState}
           selectCard={vi.fn()}
+          playCard={vi.fn(async () => ({success: true, message: 'ok'}))}
           discardCard={vi.fn(async () => ({ success: true, message: 'ok' }))}
           clearSelection={vi.fn()}
         />
@@ -248,6 +250,7 @@ describe('Online animation masking', () => {
           isWinner={false}
           gameState={gameState}
           selectCard={vi.fn()}
+          playCard={vi.fn(async () => ({success: true, message: 'ok'}))}
           discardCard={vi.fn(async () => ({ success: true, message: 'ok' }))}
           clearSelection={vi.fn()}
         />
@@ -275,6 +278,7 @@ describe('Online animation masking', () => {
           isWinner={false}
           gameState={gameState}
           selectCard={vi.fn()}
+          playCard={vi.fn(async () => ({success: true, message: 'ok'}))}
           discardCard={vi.fn(async () => ({ success: true, message: 'ok' }))}
           clearSelection={vi.fn()}
         />

--- a/apps/web/src/contexts/DragContext.tsx
+++ b/apps/web/src/contexts/DragContext.tsx
@@ -1,0 +1,47 @@
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import type {FC, ReactNode} from 'react';
+import {DragContext, type DragContextValue, type DragSession} from '@/contexts/useDrag';
+
+interface DragProviderProps {
+  children: ReactNode;
+}
+
+export const DragProvider: FC<DragProviderProps> = ({ children }) => {
+  const [session, setSession] = useState<DragSession | null>(null);
+
+  const beginDrag = useCallback<DragContextValue['beginDrag']>((init) => {
+    setSession({
+      source: init.source,
+      card: init.card,
+      validBuildPiles: init.validBuildPiles,
+      validDiscardPiles: init.validDiscardPiles,
+      pointer: init.pointer,
+      hovered: init.hovered ?? null,
+    });
+  }, []);
+
+  const updateDrag = useCallback<DragContextValue['updateDrag']>((pointer, hovered) => {
+    setSession((prev) => (prev ? { ...prev, pointer, hovered } : prev));
+  }, []);
+
+  const endDrag = useCallback(() => {
+    setSession(null);
+  }, []);
+
+  // Toggle a body data-attribute so CSS can light up valid drop targets globally
+  // while a drag is active.
+  useEffect(() => {
+    if (session) {
+      document.body.setAttribute('data-drag-active', 'true');
+      return () => document.body.removeAttribute('data-drag-active');
+    }
+    return undefined;
+  }, [session]);
+
+  const value = useMemo<DragContextValue>(
+    () => ({ session, beginDrag, updateDrag, endDrag }),
+    [session, beginDrag, updateDrag, endDrag],
+  );
+
+  return <DragContext.Provider value={value}>{children}</DragContext.Provider>;
+};

--- a/apps/web/src/contexts/useDrag.ts
+++ b/apps/web/src/contexts/useDrag.ts
@@ -1,0 +1,54 @@
+import {createContext, useContext} from 'react';
+import type {Card} from '@/types';
+
+export type DragSource =
+  | { kind: 'hand'; index: number }
+  | { kind: 'stock'; index: number }
+  | { kind: 'discard'; index: number; discardPileIndex: number };
+
+export type DragTargetId =
+  | { kind: 'build'; index: number }
+  | { kind: 'discard'; index: number };
+
+export interface DragSession {
+  source: DragSource;
+  card: Card;
+  validBuildPiles: ReadonlySet<number>;
+  validDiscardPiles: ReadonlySet<number>;
+  pointer: { x: number; y: number };
+  hovered: DragTargetId | null;
+}
+
+export interface DragContextValue {
+  session: DragSession | null;
+  beginDrag: (init: Omit<DragSession, 'hovered'> & { hovered?: DragTargetId | null }) => void;
+  updateDrag: (pointer: { x: number; y: number }, hovered: DragTargetId | null) => void;
+  endDrag: () => void;
+}
+
+// A no-op default keeps the hook usable in tests / fixtures that don't mount a
+// DragProvider. The drag feature is purely UI sugar — failing closed (no drag,
+// no highlights) is the right behavior when the provider is absent.
+const NOOP_DRAG_CONTEXT: DragContextValue = {
+  session: null,
+  beginDrag: () => undefined,
+  updateDrag: () => undefined,
+  endDrag: () => undefined,
+};
+
+export const DragContext = createContext<DragContextValue>(NOOP_DRAG_CONTEXT);
+
+export const useDrag = (): DragContextValue => useContext(DragContext);
+
+const sourcesMatch = (a: DragSource, b: DragSource): boolean => {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'discard' && b.kind === 'discard') {
+    return a.index === b.index && a.discardPileIndex === b.discardPileIndex;
+  }
+  return a.index === b.index;
+};
+
+export const useIsDragSource = (source: DragSource): boolean => {
+  const { session } = useDrag();
+  return session !== null && sourcesMatch(session.source, source);
+};

--- a/apps/web/src/hooks/__tests__/useSkipBoGame.test.tsx
+++ b/apps/web/src/hooks/__tests__/useSkipBoGame.test.tsx
@@ -28,9 +28,13 @@ const {
   const workingState = {
     current: null as GameState | null,
   };
+  const actorRef = {
+    getSnapshot: () => ({ context: { G: workingState.current } }),
+  };
   const useMachineMock = vi.fn(() => ([
     { context: { G: workingState.current } },
     send,
+    actorRef,
   ] as const));
 
   return {

--- a/apps/web/src/hooks/useDraggableCard.ts
+++ b/apps/web/src/hooks/useDraggableCard.ts
@@ -1,0 +1,228 @@
+import {useCallback, useRef} from 'react';
+import type {PointerEvent as ReactPointerEvent} from 'react';
+import type {Card, GameState, MoveResult} from '@/types';
+import {canPlayCard} from '@/lib/validators';
+import {useDrag, type DragSource, type DragTargetId} from '@/contexts/useDrag';
+import {setDragCommitOverride} from '@/services/dragCommitOverride';
+
+const DRAG_THRESHOLD_PX = 5;
+
+interface UseDraggableCardOptions {
+  source: DragSource;
+  card: Card | null;
+  enabled: boolean;
+  gameState: GameState;
+  selectCard: (source: 'hand' | 'stock' | 'discard', index: number, discardPileIndex?: number) => void;
+  playCard: (buildPileIndex: number) => Promise<MoveResult>;
+  discardCard: (discardPileIndex: number) => Promise<MoveResult>;
+  isInteractionBlocked?: () => boolean;
+}
+
+const computeValidTargets = (card: Card, source: DragSource, gameState: GameState) => {
+  const validBuildPiles = new Set<number>();
+  for (let i = 0; i < gameState.buildPiles.length; i++) {
+    if (canPlayCard(card, i, gameState)) validBuildPiles.add(i);
+  }
+  const validDiscardPiles = new Set<number>();
+  if (source.kind === 'hand' && !card.isSkipBo) {
+    for (let i = 0; i < gameState.config.DISCARD_PILES_COUNT; i++) {
+      validDiscardPiles.add(i);
+    }
+  }
+  return { validBuildPiles, validDiscardPiles };
+};
+
+const hitTest = (
+  x: number,
+  y: number,
+  validBuild: ReadonlySet<number>,
+  validDiscard: ReadonlySet<number>,
+): DragTargetId | null => {
+  // Guard: jsdom-based unit tests don't implement elementFromPoint.
+  if (typeof document.elementFromPoint !== 'function') return null;
+  const el = document.elementFromPoint(x, y);
+  if (!el) return null;
+  const target = (el as HTMLElement).closest<HTMLElement>('[data-drop-target]');
+  if (!target) return null;
+  const kind = target.getAttribute('data-drop-target');
+  const idxAttr = target.getAttribute('data-drop-index');
+  if (idxAttr === null) return null;
+  const index = Number.parseInt(idxAttr, 10);
+  if (Number.isNaN(index)) return null;
+  if (kind === 'build' && validBuild.has(index)) return { kind: 'build', index };
+  if (kind === 'discard' && validDiscard.has(index)) return { kind: 'discard', index };
+  return null;
+};
+
+
+export interface DraggableCardBindings {
+  onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+  'data-drag-source': string;
+  'data-drag-source-index': string;
+  'data-drag-source-discard-index'?: string;
+}
+
+export function useDraggableCard(options: UseDraggableCardOptions): DraggableCardBindings {
+  const {
+    source,
+    card,
+    enabled,
+    gameState,
+    selectCard,
+    playCard,
+    discardCard,
+    isInteractionBlocked,
+  } = options;
+  const { beginDrag, updateDrag, endDrag } = useDrag();
+  // Track whether the most recent pointerdown produced a drag. We use this to
+  // suppress the click event that would otherwise trigger after pointerup and
+  // toggle the click-flow selection back off.
+  const wasDraggingRef = useRef(false);
+
+  const onPointerDown = useCallback((event: ReactPointerEvent<HTMLElement>) => {
+    if (!enabled || !card) return;
+    if (event.button !== 0 && event.pointerType === 'mouse') return;
+    if (isInteractionBlocked?.()) return;
+
+    // Stop the browser from starting a native text-selection drag from the card.
+    if (event.pointerType === 'mouse') {
+      event.preventDefault();
+    }
+
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const pointerId = event.pointerId;
+    const targetEl = event.currentTarget;
+    let started = false;
+    let validBuild: Set<number> = new Set();
+    let validDiscard: Set<number> = new Set();
+    wasDraggingRef.current = false;
+
+    // Selection is deferred until the drag actually begins (movement crosses
+    // the threshold). This way a plain tap falls straight through to the
+    // legacy click-flow handlers — e.g. tapping a discard pile while a hand
+    // card is selected discards the hand card to that pile, which is the
+    // intended click affordance. Only a real drag swaps the selection.
+
+    try {
+      targetEl.setPointerCapture(pointerId);
+    } catch {
+      /* safari/iOS sometimes throws on capture; fall back to document listeners */
+    }
+
+    const onMove = (moveEvent: PointerEvent) => {
+      if (moveEvent.pointerId !== pointerId) return;
+      const dx = moveEvent.clientX - startX;
+      const dy = moveEvent.clientY - startY;
+      if (!started) {
+        if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+        // Now we know it's a real drag — select the source so a mid-air release
+        // leaves the card in the .selected state and lets the click flow
+        // finish the move.
+        selectCard(source.kind, source.index, source.kind === 'discard' ? source.discardPileIndex : undefined);
+        const sets = computeValidTargets(card, source, gameState);
+        validBuild = sets.validBuildPiles;
+        validDiscard = sets.validDiscardPiles;
+        beginDrag({
+          source,
+          card,
+          validBuildPiles: validBuild,
+          validDiscardPiles: validDiscard,
+          pointer: { x: moveEvent.clientX, y: moveEvent.clientY },
+          hovered: null,
+        });
+        started = true;
+        wasDraggingRef.current = true;
+      }
+      const hovered = hitTest(moveEvent.clientX, moveEvent.clientY, validBuild, validDiscard);
+      updateDrag({ x: moveEvent.clientX, y: moveEvent.clientY }, hovered);
+    };
+
+    const cleanup = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onCancel);
+      window.removeEventListener('keydown', onKey);
+      try {
+        targetEl.releasePointerCapture(pointerId);
+      } catch {
+        /* no-op */
+      }
+    };
+
+    const swallowNextClick = () => {
+      const swallow = (clickEvent: MouseEvent) => {
+        clickEvent.stopPropagation();
+        clickEvent.preventDefault();
+      };
+      window.addEventListener('click', swallow, { capture: true, once: true });
+      // Fallback in case no click event follows (e.g. touch + scroll cancel).
+      window.setTimeout(() => {
+        window.removeEventListener('click', swallow, { capture: true });
+      }, 50);
+    };
+
+    function onUp(upEvent: PointerEvent) {
+      if (upEvent.pointerId !== pointerId) return;
+      cleanup();
+      if (!started) {
+        endDrag();
+        return;
+      }
+      const hovered = hitTest(upEvent.clientX, upEvent.clientY, validBuild, validDiscard);
+      endDrag();
+      swallowNextClick();
+      if (!hovered) return;
+      // Start the play/discard animation from where the user dropped the
+      // ghost rather than from the source DOM position.
+      setDragCommitOverride({
+        startPosition: { x: upEvent.clientX, y: upEvent.clientY },
+      });
+      if (hovered.kind === 'build') {
+        void playCard(hovered.index);
+      } else if (hovered.kind === 'discard') {
+        void discardCard(hovered.index);
+      }
+    }
+
+    function onCancel(cancelEvent: PointerEvent) {
+      if (cancelEvent.pointerId !== pointerId) return;
+      cleanup();
+      if (started) swallowNextClick();
+      endDrag();
+    }
+
+    function onKey(keyEvent: KeyboardEvent) {
+      if (keyEvent.key !== 'Escape') return;
+      cleanup();
+      if (started) swallowNextClick();
+      endDrag();
+    }
+
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onCancel);
+    window.addEventListener('keydown', onKey);
+  }, [
+    enabled,
+    card,
+    source,
+    gameState,
+    selectCard,
+    playCard,
+    discardCard,
+    isInteractionBlocked,
+    beginDrag,
+    updateDrag,
+    endDrag,
+  ]);
+
+  return {
+    onPointerDown,
+    'data-drag-source': source.kind,
+    'data-drag-source-index': String(source.index),
+    ...(source.kind === 'discard'
+      ? { 'data-drag-source-discard-index': String(source.discardPileIndex) }
+      : {}),
+  };
+}

--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -1,10 +1,26 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
-import { canPlayCard, gameReducer, getCompletedBuildPileCards, initialGameState, type Card, type GameState, type MoveResult } from '@skipbo/game-core';
-import { serializeClientGameView, type ClientGameView, type CreateRoomResponse, type DisconnectedSeatInfo, type LobbySeatInfo, type LobbyReadyState, type ServerMessage } from '@skipbo/multiplayer-protocol';
+import {
+  canPlayCard,
+  type Card,
+  gameReducer,
+  type GameState,
+  getCompletedBuildPileCards,
+  initialGameState,
+  type MoveResult
+} from '@skipbo/game-core';
+import {
+  type ClientGameView,
+  type CreateRoomResponse,
+  type DisconnectedSeatInfo,
+  type LobbyReadyState,
+  type LobbySeatInfo,
+  serializeClientGameView,
+  type ServerMessage
+} from '@skipbo/multiplayer-protocol';
 
-import type { GameAction } from '@/state/gameActions';
-import { useCardAnimation } from '@/contexts/useCardAnimation';
+import type {GameAction} from '@/state/gameActions';
+import {useCardAnimation} from '@/contexts/useCardAnimation';
 import {
   setGlobalCompletedPileAnimationContext,
   triggerCompletedBuildPileAnimation,
@@ -14,7 +30,8 @@ import {
   setGlobalDrawAnimationContext,
   triggerMultipleDrawAnimations,
 } from '@/services/drawAnimationService';
-import { setGlobalAnimationContext, triggerAIAnimation } from '@/services/aiAnimationService';
+import {setGlobalAnimationContext, triggerAIAnimation} from '@/services/aiAnimationService';
+import {consumeDragCommitOverride} from '@/services/dragCommitOverride';
 import {
   calculateAnimationDuration,
   getBuildPilePosition,
@@ -24,7 +41,7 @@ import {
   getNextDiscardCardPosition,
   getStockCardPosition,
 } from '@/utils/cardPositions';
-import { clearOnlineSession } from '@/state/sessionPersistence';
+import {clearOnlineSession} from '@/state/sessionPersistence';
 
 type ConnectionStatus = 'connected' | 'connecting' | 'disconnected';
 
@@ -820,6 +837,7 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     // The optimistic view is committed immediately afterwards so the user can
     // continue selecting / playing while everything animates in parallel.
     let playAnimationDuration = 0;
+    const dragOverride = consumeDragCommitOverride();
     try {
       const playerAreaElement = document.querySelector<HTMLElement>('.player-area[data-player-index="0"]');
       const centerAreaElement = document.querySelector('.center-area') as HTMLElement;
@@ -844,6 +862,12 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
           if (discardContainer && currentState.selectedCard.discardPileIndex !== undefined) {
             startPosition = getDiscardTopCardPosition(discardContainer, currentState.selectedCard.discardPileIndex);
           }
+        }
+
+        // Drag-and-drop commit: start the play animation from the drop point.
+        if (dragOverride?.startPosition) {
+          startPosition = dragOverride.startPosition;
+          startAngleDeg = undefined;
         }
 
         const endPosition = getBuildPilePosition(centerAreaElement, buildPile);
@@ -940,13 +964,16 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     // input — they can already select / play another card while this discard
     // is still flying. The discard ends the human turn server-side, so any
     // further play attempt is rejected (and the snapshot reconciles).
+    const dragOverride = consumeDragCommitOverride();
+
     try {
       const playerAreaElement = document.querySelector<HTMLElement>('.player-area[data-player-index="0"]');
 
       if (playerAreaElement) {
         const handContainer = playerAreaElement.querySelector('.hand-area') as HTMLElement;
         if (handContainer) {
-          const startPosition = getHandCardPosition(handContainer, currentState.selectedCard.index);
+          const startPosition = dragOverride?.startPosition
+              ?? getHandCardPosition(handContainer, currentState.selectedCard.index);
           const discardContainer = playerAreaElement.querySelector('.discard-piles') as HTMLElement;
           if (discardContainer) {
             const endPosition = getNextDiscardCardPosition(discardContainer, discardPile);
@@ -965,7 +992,9 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
               targetRevealed: true,
               initialDelay: 0,
               duration: animationDuration,
-              startAngleDeg: getHandCardAngle(handContainer, currentState.selectedCard.index),
+              startAngleDeg: dragOverride?.startPosition
+                  ? undefined
+                  : getHandCardAngle(handContainer, currentState.selectedCard.index),
               targetSettledInState: true,
               targetPileLength: previousDiscardPileLength + 1,
               sourceInfo: {

--- a/apps/web/src/hooks/useSkipBoGame.ts
+++ b/apps/web/src/hooks/useSkipBoGame.ts
@@ -41,9 +41,8 @@ const willPlayCardEmptyHand = (gameState: GameState): boolean => {
 };
 
 export function useSkipBoGame() {
-  const [snapshot, send, actorRef] = useMachine(gameMachine);
+  const [snapshot, dispatch, actorRef] = useMachine(gameMachine);
   const state = snapshot.context.G;
-  const dispatch = send;                     // alias pour préserver la suite du code
   const stateRef = useRef<GameState>(state);
   const interactionLockRef = useRef(false);
   const { startAnimation, removeAnimation, waitForAnimations } = useCardAnimation();
@@ -92,7 +91,7 @@ export function useSkipBoGame() {
     // playCard from pointerup) read the updated selectedCard instead of the
     // stale snapshot that React hasn't committed yet.
     stateRef.current = actorRef.getSnapshot().context.G;
-  }, [dispatch, isInteractionBlocked, actorRef]);
+  }, [dispatch, isInteractionBlocked]);
 
   const playCard = useCallback(async (buildPile: number): Promise<MoveResult> => {
     const currentState = stateRef.current;

--- a/apps/web/src/hooks/useSkipBoGame.ts
+++ b/apps/web/src/hooks/useSkipBoGame.ts
@@ -91,7 +91,7 @@ export function useSkipBoGame() {
     // playCard from pointerup) read the updated selectedCard instead of the
     // stale snapshot that React hasn't committed yet.
     stateRef.current = actorRef.getSnapshot().context.G;
-  }, [dispatch, isInteractionBlocked]);
+  }, [dispatch, isInteractionBlocked, actorRef]);
 
   const playCard = useCallback(async (buildPile: number): Promise<MoveResult> => {
     const currentState = stateRef.current;

--- a/apps/web/src/hooks/useSkipBoGame.ts
+++ b/apps/web/src/hooks/useSkipBoGame.ts
@@ -41,7 +41,7 @@ const willPlayCardEmptyHand = (gameState: GameState): boolean => {
 };
 
 export function useSkipBoGame() {
-  const [snapshot, send] = useMachine(gameMachine);
+  const [snapshot, send, actorRef] = useMachine(gameMachine);
   const state = snapshot.context.G;
   const dispatch = send;                     // alias pour préserver la suite du code
   const stateRef = useRef<GameState>(state);
@@ -86,7 +86,13 @@ export function useSkipBoGame() {
     }
 
     dispatch({ type: 'SELECT_CARD', source, index, discardPileIndex });
-  }, [dispatch, isInteractionBlocked]);
+    // XState processes events synchronously, so the actor already has the new
+    // state. Eagerly sync stateRef so that playCard/discardCard called in the
+    // same synchronous turn (e.g. drag-drop: selectCard then immediately
+    // playCard from pointerup) read the updated selectedCard instead of the
+    // stale snapshot that React hasn't committed yet.
+    stateRef.current = actorRef.getSnapshot().context.G;
+  }, [dispatch, isInteractionBlocked, actorRef]);
 
   const playCard = useCallback(async (buildPile: number): Promise<MoveResult> => {
     const currentState = stateRef.current;

--- a/apps/web/src/hooks/useSkipBoGame.ts
+++ b/apps/web/src/hooks/useSkipBoGame.ts
@@ -23,6 +23,7 @@ import {
   triggerCompletedBuildPileAnimation,
 } from '@/services/completedBuildPileAnimationService';
 import {useCardAnimation} from "@/contexts/useCardAnimation.ts";
+import {consumeDragCommitOverride} from '@/services/dragCommitOverride';
 import {getCompletedBuildPileCards} from '@/lib/retreatPile';
 import {planHandRefill} from '@/lib/handRefill';
 
@@ -132,6 +133,10 @@ export function useSkipBoGame() {
     // `isCardBeingAnimated` in PlayerArea/CenterArea.
     let playAnimationDuration = 0;
 
+
+    const dragOverride = consumeDragCommitOverride();
+
+    // Trigger play animation first
     try {
       const playerAreaElement = document.querySelector<HTMLElement>(`.player-area[data-player-index="${currentState.currentPlayerIndex}"]`);
       const centerAreaElement = document.querySelector('.center-area') as HTMLElement;
@@ -157,6 +162,15 @@ export function useSkipBoGame() {
           if (discardContainer && currentState.selectedCard.discardPileIndex !== undefined) {
             startPosition = getDiscardTopCardPosition(discardContainer, currentState.selectedCard.discardPileIndex);
           }
+        }
+
+        // If the play was committed via drag-and-drop, override the start
+        // position with where the user released the pointer so the fly-to-target
+        // animation continues from the ghost rather than jumping back to the
+        // source slot.
+        if (dragOverride?.startPosition) {
+          startPosition = dragOverride.startPosition;
+          startAngleDeg = undefined;
         }
 
         // Calculate end position (build pile)
@@ -287,13 +301,17 @@ export function useSkipBoGame() {
     // their visual animations because the animationGate keeps waiting on
     // `waitForAnimations()` until the queue is empty.
     let discardAnimationDuration = 0;
+    const dragOverride = consumeDragCommitOverride();
+
+    // Trigger animation before state change
     try {
       const playerAreaElement = document.querySelector<HTMLElement>(`.player-area[data-player-index="${currentState.currentPlayerIndex}"]`);
 
       if (playerAreaElement) {
         const handContainer = playerAreaElement.querySelector('.hand-area') as HTMLElement;
         if (handContainer) {
-          const startPosition = getHandCardPosition(handContainer, currentState.selectedCard.index);
+          const startPosition = dragOverride?.startPosition
+              ?? getHandCardPosition(handContainer, currentState.selectedCard.index);
           const discardContainer = playerAreaElement.querySelector('.discard-piles') as HTMLElement;
           if (discardContainer) {
             const endPosition = getNextDiscardCardPosition(discardContainer, discardPile);
@@ -311,7 +329,9 @@ export function useSkipBoGame() {
               targetRevealed: true,
               initialDelay: 0,
               duration: discardAnimationDuration,
-              startAngleDeg: getHandCardAngle(handContainer, currentState.selectedCard.index),
+              startAngleDeg: dragOverride?.startPosition
+                  ? undefined
+                  : getHandCardAngle(handContainer, currentState.selectedCard.index),
               targetSettledInState: true,
               targetPileLength: previousDiscardPileLength + 1,
               sourceInfo: {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -728,6 +728,87 @@
         border-(--drop-indicator-color) border-dashed border-2;
     }
   }
+
+  /* While a drag is in progress, every valid target lights up — even without a hover. */
+  body[data-drag-active="true"] &.can-drop {
+    @apply -translate-y-0.5 shadow-(--can-drop-shadow);
+
+    &::before {
+      @apply content-[''] absolute z-10 opacity-80 -inset-0.5 animate-pulse rounded-[calc(var(--card-radius)+2px)]
+      border-(--drop-indicator-color) border-dashed border-2;
+    }
+  }
+
+  /* Stronger highlight on the target the dragged card is currently over. */
+  &.is-drag-over {
+    @apply -translate-y-1 shadow-(--can-drop-shadow);
+
+    &::after {
+      @apply content-['↓'] absolute -top-6.25 left-1/2 text-lg -translate-x-1/2
+      text-(--drop-indicator-color) font-bold z-20 animate-bounce;
+    }
+
+    &::before {
+      @apply content-[''] absolute z-10 opacity-100 -inset-1 rounded-[calc(var(--card-radius)+4px)]
+      border-(--drop-indicator-color) border-solid border-2;
+    }
+  }
+}
+
+/* Suppress hover-effects on the source card while a drag is active so the
+   under-pointer card doesn't flash hoverable states. */
+body[data-drag-active="true"] {
+  cursor: grabbing;
+  /* Stop the browser from selecting page text when the user drags a card. */
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+body[data-drag-active="true"] .hoverable-card:hover {
+  transform: none;
+  box-shadow: var(--card-shadow);
+}
+
+/* Cards never need text-selection — keep this on always so the user can't
+   accidentally start a text-selection drag from a card label. */
+.card {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* On touch devices, the default `touch-action` lets the browser scroll the
+   page when the finger moves vertically on a card — which cancels the
+   pointer event stream and kills our drag (the user can only drag
+   horizontally because horizontal pan-x isn't a default scroll axis). With
+   `touch-action: none` we own every touch gesture that originates on a
+   draggable card; the user can still scroll the page by starting the touch
+   on any non-draggable area. */
+[data-drag-source] {
+  touch-action: none;
+}
+
+.card-drag-ghost {
+  cursor: grabbing;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35) !important;
+  transform: scale(1.05) rotate(-2deg);
+}
+
+/* The card the user is currently holding is rendered in the floating
+   ghost — hide the original in place so its slot stays the right size but
+   the card visually "leaves" the source. Lives inside `@layer utilities`
+   so it participates in the Tailwind utilities cascade alongside `.card`
+   and the layered `!important` reliably beats it. */
+@layer utilities {
+  /* Hide the source card while the ghost follows the pointer. The descendant
+     selector is needed because `.card-corner-number` declares `lg:visible`,
+     which would otherwise re-show the corner number even when the parent is
+     hidden. */
+  .card.is-drag-source,
+  .card.is-drag-source * {
+    visibility: hidden !important;
+    pointer-events: none !important;
+    transition: none !important;
+  }
 }
 
 @utility drop-target-hover {

--- a/apps/web/src/services/dragCommitOverride.ts
+++ b/apps/web/src/services/dragCommitOverride.ts
@@ -1,0 +1,22 @@
+import type {CardPosition} from '@/utils/cardPositions';
+
+/**
+ * One-shot override for the *start position* of the next play/discard animation.
+ *
+ * The drag-and-drop flow sets this immediately before invoking
+ * `playCard()` / `discardCard()` so the fly-to-target animation starts at the
+ * point where the user released the pointer rather than at the card's source
+ * DOM element. The hook consumes the value and clears it on read so a
+ * subsequent click-flow play isn't accidentally affected.
+ */
+let pending: { startPosition: CardPosition } | null = null;
+
+export const setDragCommitOverride = (override: { startPosition: CardPosition } | null) => {
+  pending = override;
+};
+
+export const consumeDragCommitOverride = (): { startPosition: CardPosition } | null => {
+  const value = pending;
+  pending = null;
+  return value;
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "pnpm --filter @skipbo/game-core build && pnpm --filter @skipbo/multiplayer-protocol build && pnpm --filter @skipbo/realtime-api build && pnpm --filter @skipbo/web build",
     "commit": "cz",
-    "dev": "pnpm dev:web",
+    "dev": "pnpm dev:web --host",
     "dev:api": "pnpm --filter @skipbo/realtime-api dev",
     "dev:web": "pnpm --filter @skipbo/web dev",
     "lint": "pnpm --filter @skipbo/game-core lint && pnpm --filter @skipbo/multiplayer-protocol lint && pnpm --filter @skipbo/realtime-api lint && pnpm --filter @skipbo/web lint",


### PR DESCRIPTION
### Description

This pull request introduces drag-and-drop functionality for cards with seamless animated transitions. Key additions include:

- `DragContext` and `useDraggableCard` hook to manage drag state and interactions.
- `DragGhost` component for rendering ghost cards during drag operations.
- Animated card transitions with fly-to-target effects.
- Visual enhancements to highlight valid drop targets and disable hover effects during drag.