### PR TITLE
fix(web): mask retreat pile during opponent build-pile completion

### DIFF
--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -498,14 +498,20 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
                       opponentTransition.completedCards &&
                       opponentTransition.completedBuildPileIndex !== undefined
                     ) {
-                      window.setTimeout(() => {
-                        triggerCompletedBuildPileAnimation(
-                          previousState,
-                          opponentTransition.completedBuildPileIndex!,
-                          opponentTransition.completedCards!,
-                          previousState.completedBuildPiles.length,
-                        );
-                      }, opponentAnimationDuration);
+                      // Register completion animations immediately with
+                      // baseDelay=opponentAnimationDuration so the cards are
+                      // tracked as in-flight as soon as state lands. Otherwise
+                      // CenterArea would briefly render the new top card on
+                      // the retreat pile during the play animation, before
+                      // the retreat animation begins.
+                      triggerCompletedBuildPileAnimation(
+                        previousState,
+                        opponentTransition.completedBuildPileIndex,
+                        opponentTransition.completedCards,
+                        previousState.completedBuildPiles.length,
+                        100,
+                        opponentAnimationDuration,
+                      );
                     }
 
                     scheduleDrawAnimations(drawTransitions, opponentAnimationDuration);


### PR DESCRIPTION
## Summary
- Fix multiplayer display glitch where the top card of a completed build pile (12 or Skip-Bo) briefly appeared on the opponent's retreat pile before the retreat animation began.
- Register the completion animation immediately after `commitView` with `baseDelay = opponentAnimationDuration` instead of deferring via `setTimeout`. `pendingRetreatCardsCount` in `CenterArea` then masks the cards as in-flight as soon as state lands.
- Aligns the opponent flow with the existing local-play pattern (`useOnlineSkipBoGame.ts:858-866`).

## Test plan
- [ ] Online multiplayer: opponent completes a build pile — verify no flash of the top card on the retreat pile before the cards fly over.
- [ ] Local play: regression check that completion animation still triggers correctly.
- [ ] `pnpm --filter @skipbo/web typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)