### PR TITLE
fix(web): animate refilled slot when opponent empties hand online

### DIFF
--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -445,6 +445,35 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
                 const nextState = cloneGameStateFromView(message.view);
                 const drawTransitions = collectDrawTransitions(previousState, nextState);
                 const opponentTransition = inferOpponentTransition(previousState, nextState);
+                // When an opponent plays the last card of their hand, the slot
+                // it left behind gets refilled in the next snapshot. Comparing
+                // hand[index] before/after only catches null→card transitions,
+                // so the just-played slot would otherwise pop in without
+                // animation while its 4 siblings fly from the deck.
+                if (
+                  opponentTransition &&
+                  previousState.selectedCard?.source === 'hand' &&
+                  previousState.currentPlayerIndex !== 0
+                ) {
+                  const opponentIndex = previousState.currentPlayerIndex;
+                  const playedSlotIndex = previousState.selectedCard.index;
+                  const refilledCard = nextState.players[opponentIndex].hand[playedSlotIndex];
+                  const existing = drawTransitions.find((t) => t.playerIndex === opponentIndex);
+                  if (refilledCard && (!existing || !existing.handIndices.includes(playedSlotIndex))) {
+                    if (existing) {
+                      const insertAt = existing.handIndices.findIndex((i) => i > playedSlotIndex);
+                      const position = insertAt === -1 ? existing.handIndices.length : insertAt;
+                      existing.cards.splice(position, 0, { ...refilledCard });
+                      existing.handIndices.splice(position, 0, playedSlotIndex);
+                    } else {
+                      drawTransitions.push({
+                        cards: [{ ...refilledCard }],
+                        handIndices: [playedSlotIndex],
+                        playerIndex: opponentIndex,
+                      });
+                    }
+                  }
+                }
                 const turnChanged = previousView.currentPlayerIndex !== message.view.currentPlayerIndex;
                 const holdPreviousTurnPresentation = () => {
                   if (!turnChanged) {


### PR DESCRIPTION
## Summary
- When an online opponent played their last hand card, the slot it left behind was refilled instantly while its 4 siblings flew from the deck. The snapshot diff in `useOnlineSkipBoGame` only detected `null → card` transitions, missing the just-played slot.
- Added that slot to the draw transitions using `previousState.selectedCard.index`, inserted in `handIndex` order so the stagger stays consistent.

## Test plan
- [ ] Online multiplayer: opponent plays their last hand card; verify all 5 refill cards animate from deck.
- [ ] Local mode and human-side optimistic flow unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)