### PR TITLE
fix(pwa): switch SW registration from autoUpdate to prompt

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       ...plugins,
       VitePWA({
-        registerType: 'autoUpdate',
+        registerType: 'prompt',
         includeAssets: [
           // any additional static assets you want copied as-is:
           'favicon.svg',


### PR DESCRIPTION
## Summary

- Switches `registerType` from `'autoUpdate'` to `'prompt'` in `apps/web/vite.config.ts`
- Fixes two related PWA upgrade failure modes on installed PWAs (especially iOS standalone)

## Problem

**White screen on upgrade**: In `autoUpdate` mode, the generated service worker calls `skipWaiting()` immediately on install. The vite-plugin-pwa runtime then fires `location.reload()` via the `controllerchange` event, outside of the app's control. On iOS standalone PWAs this triggers a splash → blank → reload loop.

**"Restart" button does nothing**: The soft-update banner appears when the server reports a new version, but `applyServiceWorkerUpdate()` only proceeds if `registration.waiting` is populated or `snapshot.needRefresh` is set. In `autoUpdate` mode the waiting worker self-activates immediately, so `registration.waiting` is null by the time the user clicks Restart — the function returns `false` silently and no reload occurs. There is intentionally no `location.reload()` fallback (see comment in `runReloadToUpdate`) to avoid the iOS loop, leaving the button inert.

## Fix

`prompt` mode keeps the new SW in the waiting state until `updateServiceWorker(true)` is called. This means:
- `registration.waiting` is reliably populated when `onNeedRefresh` fires
- The app's existing `applyServiceWorkerUpdate()` / `runReloadToUpdate()` path has full control over the reload timing
- No automatic `controllerchange`-triggered reload fires behind the scenes

## Test plan

- [ ] Build and install the PWA, deploy a new version, verify the update banner appears and "Recharger" successfully reloads to the new version
- [ ] Verify no white screen occurs on iOS standalone after upgrade
- [ ] Verify hard-update (`ForcedUpdateOverlay`) still auto-applies via `usePwaVersionGate`'s `isHardUpdateRequired` effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)