### PR TITLE
fix(ui): preserve safe-area gutters when Radix portals lock scroll

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -139,7 +139,7 @@
     --card-g3: #F0F; /* 9‑12 */
   }
 
-  body {
+  #root {
     padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
   }
 


### PR DESCRIPTION
## Summary

- Radix UI's `remove-scroll` injects inline styles on `<body>` when any portal (Select, Dialog, …) opens, overwriting the CSS `padding: env(safe-area-inset-*)` rule
- On iPhone in landscape mode this caused all elements to expand to full width (under the Dynamic Island) while any dropdown/dialog was open
- Fix: move the safe-area padding from `body` to `#root`, which Radix never touches — gutters are now stable regardless of portal state

## Test plan

- [ ] Open app on iPhone in landscape mode
- [ ] Open the theme selector dropdown — gutters should remain visible
- [ ] Open the New Game dialog — gutters should remain visible
- [ ] Close each — layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)