### PR TITLE
ci: rename Sentry project slug to skip-bo-frontend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -247,7 +247,7 @@ jobs:
           NODE_ENV: production
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: pierre-luc
-          SENTRY_PROJECT: skip-bo
+          SENTRY_PROJECT: skip-bo-frontend
           VITE_APP_VERSION: ${{ needs.release.outputs.release_tag }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
 


### PR DESCRIPTION
## Summary
- Update `SENTRY_PROJECT` in deploy.yml from `skip-bo` to `skip-bo-frontend` to match the renamed Sentry project.
- Pairs with new `BACKEND_SENTRY_DSN` GitHub secret pointing at the new `skip-bo-backend` (AWS Lambda Node) project so backend events finally show up.

## Test plan
- [ ] Next deploy uploads source maps to the renamed `skip-bo-frontend` project without errors.
- [ ] After deploy, trigger a backend error and confirm it appears in `skip-bo-backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)