### PR TITLE
ci: emit Sentry boot message to verify backend pipeline

### DIFF
--- a/apps/realtime-api/src/monitoring/sentry.ts
+++ b/apps/realtime-api/src/monitoring/sentry.ts
@@ -21,6 +21,7 @@ if (sentryEnabled) {
     ...(process.env.SENTRY_RELEASE ? { release: process.env.SENTRY_RELEASE } : {}),
     ...(Number.isFinite(tracesSampleRate) ? { tracesSampleRate } : {}),
   });
+  Sentry.captureMessage('backend boot test', 'info');
 } else if (process.env.NODE_ENV !== 'production' && process.env.VITEST !== 'true') {
   console.info('[sentry] disabled: SENTRY_DSN is not set');
 }


### PR DESCRIPTION
## Summary
- Adds a single \`Sentry.captureMessage('backend boot test', 'info')\` call right after \`Sentry.init()\` in [apps/realtime-api/src/monitoring/sentry.ts](apps/realtime-api/src/monitoring/sentry.ts).
- Purpose: backend Sentry events haven't appeared in the new \`skip-bo-backend\` project after switching DSNs. This boot-time message will fire once per Lambda cold start and tell us whether the pipeline is alive.

## Test plan
- [ ] After merge + deploy, trigger any cold start (or wait a couple minutes after deploy) and confirm a \"backend boot test\" event appears in the \`skip-bo-backend\` Sentry project, tagged with the current release.
- [ ] Once verified, revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)