### PR TITLE
revert: drop Sentry boot test message

### DIFF
--- a/apps/realtime-api/src/monitoring/sentry.ts
+++ b/apps/realtime-api/src/monitoring/sentry.ts
@@ -21,7 +21,6 @@ if (sentryEnabled) {
     ...(process.env.SENTRY_RELEASE ? { release: process.env.SENTRY_RELEASE } : {}),
     ...(Number.isFinite(tracesSampleRate) ? { tracesSampleRate } : {}),
   });
-  Sentry.captureMessage('backend boot test', 'info');
 } else if (process.env.NODE_ENV !== 'production' && process.env.VITEST !== 'true') {
   console.info('[sentry] disabled: SENTRY_DSN is not set');
 }


### PR DESCRIPTION
## Summary
- Removes the temporary \`Sentry.captureMessage('backend boot test', 'info')\` from [apps/realtime-api/src/monitoring/sentry.ts](apps/realtime-api/src/monitoring/sentry.ts) added in #83.
- Backend Sentry pipeline confirmed working — diagnostic no longer needed.

## Test plan
- [ ] After deploy, no more \"backend boot test\" events appear in the \`skip-bo-backend\` project on Lambda cold starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)