### PR TITLE
docs: claude.md notes + rainbow theme indentation cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,10 @@ In online mode, debug actions are allowed by the server only when `NODE_ENV !== 
 `AGENTS.md` has the full change matrix, mandatory validations, and durable invariants.  
 Read it before making cross-cutting changes.
 
+## Commit Messages
+
+Commitlint enforces a 72-character max on the header (first line). Keep titles short; put detail in the body.
+
 ## Key Environment Variables
 
 ```

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -47,6 +47,8 @@ http://localhost:5173/?fixture=<name>
 
 This bypasses the game loop entirely — useful for isolated layout/visual work without playing to a specific state.
 
+Cards render as `<div class="card normal-card" data-value="N">` for N=1–12 and `<div class="card skip-bo skipbo-text">` for Skip-Bo. Use `.card.normal-card[data-value="N"]` selectors for per-value theme styling (see `metro.css`, `rainbow.css`).
+
 ## Theme Styling
 
 Each theme lives in `src/themes/<name>.css` and overrides CSS variables on a `.theme-<name>` class. The base body rule in `src/index.css` applies `bg-background` (= `var(--background)`), so every theme inherits a solid background-color.
@@ -58,6 +60,8 @@ Two rules when adding decorative gradients/textures on `body` (or any element th
 2. **Keep `--background` close to what's actually visible at the top of the page.** `useThemeColorMeta` writes `--background` into `<meta name="theme-color">`, and Tailwind's `bg-background` paints the body with the same value. A wildly off-base `--background` makes the iOS bar mismatch the page (Neon's `#0a0a0a` underneath a `#13002a → #0a0a0a` gradient is fine; Minecraft's old `#2f2418` was much darker than the dirt texture's `#866043` average — fix that, not the bar).
 
 Multi-image gradients must be **comma-separated**. Browsers silently drop a `background-image` declaration whose layers are space-separated; `candy.css` and `retro-space.css` shipped broken halos for this reason.
+
+When overriding a multi-layer `background-image`, the matching `background-size` and `background-repeat` lists must have the **same number of entries** as the layers — CSS cycles shorter lists, so a layer can silently inherit `repeat` + a tile size meant for another layer. (Rainbow's lightning shipped with the sun glow tiling four times because of this.)
 
 ## Debug Buttons
 

--- a/apps/web/src/themes/rainbow.css
+++ b/apps/web/src/themes/rainbow.css
@@ -250,18 +250,18 @@
 }
 
 @keyframes sky-time-drift {
-0% {
-  /* Dawn Warm */
-  background-color: #ffb59d;
-}
-50% {
-  /* Midday Blue */
-  background-color: #87ceeb;
-}
-100% {
-  /* Dusk Pink */
-  background-color: #f4a8c0;
-}
+    0% {
+      /* Dawn Warm */
+      background-color: #ffb59d;
+    }
+    50% {
+      /* Midday Blue */
+      background-color: #87ceeb;
+    }
+    100% {
+      /* Dusk Pink */
+      background-color: #f4a8c0;
+    }
 }
 
 @keyframes rainbow-lightning {


### PR DESCRIPTION
## Summary
- Add three short notes to CLAUDE.md files (root + apps/web) capturing lessons learned while implementing the rainbow theme rework (PR #90):
  - Commitlint enforces a 72-char header max
  - Cards expose `data-value="N"` — the natural hook for per-value theme styling
  - Multi-layer `background-image` cycles shorter `background-size`/`background-repeat` lists, which silently mis-assigns repeat/size to wrong layers
- Normalize indentation inside the `sky-time-drift` keyframes block in `rainbow.css` to match the rest of the file (no functional change)

## Test plan
- [x] Docs-only + whitespace-only changes; no test runs needed
- [x] `pnpm lint` (no lint impact on whitespace inside CSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)