### PR TITLE
fix(web): allow drag-and-drop on unselected cards in multiplayer

### DIFF
--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -800,7 +800,11 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
 
   const playCard = useCallback(
     async (buildPile: number): Promise<MoveResult> => {
-      const currentState = gameState;
+      const currentView = viewRef.current;
+      if (!currentView) {
+        return { success: false, message: 'Aucune carte sélectionnée' };
+      }
+      const currentState = cloneGameStateFromView(currentView);
       const completedBuildPileCards = getCompletedBuildPileCards(currentState, buildPile);
 
       if (isInteractionBlocked()) {
@@ -920,13 +924,18 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
       setInteractionLocked(false);
       return { success: true, message: 'Carte jouée' };
     },
-    [commitView, gameState, isInteractionBlocked, sendAction, setInteractionLocked, startAnimation],
+    [commitView, isInteractionBlocked, sendAction, setInteractionLocked, startAnimation],
   );
 
   const discardCard = useCallback(
     (discardPile: number): Promise<MoveResult> =>
       new Promise((resolve) => {
-        const currentState = gameState;
+        const currentView = viewRef.current;
+        if (!currentView) {
+          resolve({ success: false, message: 'Aucune carte sélectionnée' });
+          return;
+        }
+        const currentState = cloneGameStateFromView(currentView);
 
         if (isInteractionBlocked()) {
           resolve({ success: false, message: 'Action en cours' });
@@ -1017,7 +1026,7 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
         setInteractionLocked(false);
         resolve({ success: true, message: 'Carte défaussée' });
       }),
-    [commitView, gameState, isInteractionBlocked, sendAction, setInteractionLocked, startAnimation],
+    [commitView, isInteractionBlocked, sendAction, setInteractionLocked, startAnimation],
   );
 
   const sendSetReady = useCallback((playerName?: string): void => {


### PR DESCRIPTION
## Summary
- In online mode, drag-and-drop only worked when the card was already selected via a prior click. Grabbing an unselected card and dragging it to a valid pile silently failed with "Aucune carte sélectionnée".
- Root cause: `playCard` / `discardCard` in [useOnlineSkipBoGame.ts](apps/web/src/hooks/useOnlineSkipBoGame.ts) read `currentState` from the memoized `gameState` closure, captured before the drag started. The drag handler's threshold-time `selectCard` only writes to React state (async commit), so the subsequent pointerup play saw a stale `selectedCard: null`.
- Fix: read `currentState` from `viewRef.current` (synchronously up to date inside `updateView` / `commitView`) via the existing `cloneGameStateFromView` helper — mirrors the local-mode pattern that uses `stateRef.current`.

## Test plan
- [x] `pnpm --filter @skipbo/web typecheck`
- [x] `pnpm --filter @skipbo/web lint`
- [x] `pnpm --filter @skipbo/web test -- src/hooks` (180 passing)
- [ ] Manual: in an online room, drag an unselected hand / stock / discard card directly onto a valid build pile — it should play
- [ ] Manual: drag an unselected hand card onto a discard pile — it should discard
- [ ] Manual regression: click-then-drag and plain click-flow still work; local mode unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)