### PR TITLE
feat(game-core): allow discarding Skip-Bo cards per official rules

### DIFF
--- a/.claude/agents/game-rules-invariant-checker.md
+++ b/.claude/agents/game-rules-invariant-checker.md
@@ -28,7 +28,7 @@ Read `docs/architecture/runtime-invariants.md` in full. The seven invariants tha
 1. **Fixed-length hands** — hand arrays keep `null` holes; cards are never spliced out.
 2. **Selection before play** — all card interactions resolve through selection first, then play or discard.
 3. **`selectedCard` destination** — kept long enough for AI resolution before clearing.
-4. **Skip-Bo wildcard rule** — `Skip-Bo` cards are playable as wildcards and are non-discardable.
+4. **Skip-Bo wildcard rule** — `Skip-Bo` cards are playable as wildcards and may be discarded (per official rules).
 5. **Start-of-turn draw timing** — draw logic is outside `END_TURN`; it runs at turn start.
 6. **Server-authoritative online play** — from the client perspective the server snapshot is canonical.
 7. **Player order ≠ render order** — `players[0]`/`players[1]` (state) differ from rendered board order.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Canonical wording lives in [docs/architecture/runtime-invariants.md](docs/archit
 - hands remain fixed-length arrays with `null` holes
 - card interactions still resolve through selection first, then play or discard
 - `selectedCard` keeps planned destinations long enough for AI resolution
-- `Skip-Bo` cards remain playable as wildcards and non-discardable
+- `Skip-Bo` cards remain playable as wildcards and may be discarded (official rule)
 - start-of-turn draws stay outside `END_TURN`
 - online play remains server-authoritative from the client perspective
 - local player order and rendered player order are not the same thing

--- a/apps/realtime-api/src/services/gameState.ts
+++ b/apps/realtime-api/src/services/gameState.ts
@@ -174,10 +174,6 @@ export const validateOnlineAction = (gameState: GameState, action: GameAction): 
         return 'Vous devez défausser une carte de votre main';
       }
 
-      if (selectedCard.card.isSkipBo) {
-        return 'Vous ne pouvez pas défausser une carte Skip-Bo';
-      }
-
       if (!hasValidSelectedSource(player, selectedCard) || !hasValidDiscardPileIndex(player, action.discardPile)) {
         return 'Défausse invalide';
       }

--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -952,11 +952,6 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
           return;
         }
 
-        if (currentState.selectedCard.card.isSkipBo) {
-          resolve({ success: false, message: 'Vous ne pouvez pas défausser une carte Skip-Bo' });
-          return;
-        }
-
         setInteractionLocked(true);
 
         // Trigger discard animation, then commit the optimistic view and send the

--- a/apps/web/src/hooks/useSkipBoGame.ts
+++ b/apps/web/src/hooks/useSkipBoGame.ts
@@ -296,10 +296,6 @@ export function useSkipBoGame() {
         return { success: false, message: 'Vous devez défausser une carte de votre main' };
       }
 
-      if (currentState.selectedCard.card.isSkipBo) {
-        return { success: false, message: 'Vous ne pouvez pas défausser une carte Skip-Bo' };
-      }
-
       interactionLockRef.current = true;
 
       // Trigger discard animation, then dispatch immediately. The animation runs

--- a/apps/web/src/state/__tests__/gameReducer.test.ts
+++ b/apps/web/src/state/__tests__/gameReducer.test.ts
@@ -273,10 +273,16 @@ describe('gameReducer', () => {
       expect(result.message).toContain('Aucune carte sélectionnée');
     });
 
-    it('should not discard Skip-Bo cards', () => {
-      // Create state with Skip-Bo card selected
+    it('should allow discarding Skip-Bo cards (official rule)', () => {
       const stateWithSkipBo = {
         ...initialState,
+        players: [
+          {
+            ...initialState.players[0],
+            hand: [{ value: 0, isSkipBo: true }, null, null, null, null],
+          },
+          initialState.players[1],
+        ],
         selectedCard: {
           card: { value: 0, isSkipBo: true },
           source: 'hand' as const,
@@ -286,7 +292,10 @@ describe('gameReducer', () => {
 
       const result = gameReducer(stateWithSkipBo, { type: 'DISCARD_CARD', discardPile: 0 });
 
-      expect(result.message).toContain('Skip-Bo');
+      expect(result.players[0].discardPiles[0]).toHaveLength(1);
+      expect(result.players[0].discardPiles[0][0].isSkipBo).toBe(true);
+      expect(result.currentPlayerIndex).toBe(1);
+      expect(result.selectedCard).toBeNull();
     });
 
     it('should discard a valid card and end turn', () => {

--- a/docs/architecture/runtime-invariants.md
+++ b/docs/architecture/runtime-invariants.md
@@ -14,7 +14,7 @@
 - Hands are fixed-length arrays. Empty slots are represented by `null`, and removing a hand card means writing `null` rather than splicing the array.
 - Most card interactions are two-step: `SELECT_CARD`, then `PLAY_CARD` or `DISCARD_CARD`.
 - `selectedCard` can carry `plannedBuildPileIndex` and `plannedDiscardPileIndex`, and AI flow depends on those planned targets surviving between selection and resolution.
-- `Skip-Bo` cards can be played as wildcards and must never be discarded.
+- `Skip-Bo` cards can be played as wildcards and may also be discarded to a discard pile (per official Skip-Bo rules).
 - Completed build piles move into `completedBuildPiles` and are reshuffled back into `deck` when more draw cards are needed.
 - Start-of-turn draws belong to the local state machine draw service. `END_TURN` only flips `currentPlayerIndex`.
 - Online rooms are server-authoritative. The browser treats incoming snapshots as canonical in online mode.

--- a/packages/game-core/CLAUDE.md
+++ b/packages/game-core/CLAUDE.md
@@ -12,7 +12,7 @@ Pure game logic package shared by all apps. No UI, no network dependencies.
 
 - Hands are fixed-length arrays; removed cards become `null`, never spliced out
 - Card interactions are two-step: `SELECT_CARD` → `PLAY_CARD` or `DISCARD_CARD`
-- Skip-Bo cards are wildcards and are **non-discardable**
+- Skip-Bo cards are wildcards and **may be discarded** (per official Skip-Bo rules)
 - Start-of-turn draws happen **outside** `END_TURN`
 - `players[0]`/`players[1]` are state-array order, **not** render order; in online mode the protocol layer rotates the array so the viewer is always `players[0]`
 - `DEBUG_WIN` sets the winner to `currentPlayerIndex`, not a hardcoded seat — intentional

--- a/packages/game-core/src/lib/config.ts
+++ b/packages/game-core/src/lib/config.ts
@@ -4,7 +4,6 @@ export const MESSAGES = {
   INVALID_MOVE_NO_SELECTION: 'Mouvement invalide: Aucune carte sélectionnée',
   INVALID_MOVE_CANNOT_PLAY: 'Mouvement invalide: Vous ne pouvez pas jouer cette carte',
   INVALID_MOVE_MUST_DISCARD_FROM_HAND: 'Mouvement invalide: Vous devez défausser une carte de votre main',
-  INVALID_MOVE_CANNOT_DISCARD_SKIP_BO: 'Mouvement invalide: Vous ne pouvez pas défausser une carte Skip-Bo',
   CARD_PLAYED: 'Carte jouée',
   TURN_ENDED: 'Tour terminé',
   GAME_WON: 'La partie est gagnée par {player} !',

--- a/packages/game-core/src/state/gameReducer.ts
+++ b/packages/game-core/src/state/gameReducer.ts
@@ -313,11 +313,6 @@ export const gameReducer = produce((draft: GameState, action: GameAction) => {
         return;
       }
 
-      if (selectedCard.card.isSkipBo) {
-        draft.message = MESSAGES.INVALID_MOVE_CANNOT_DISCARD_SKIP_BO;
-        return;
-      }
-
       if (selectedCard.card.value === undefined) {
         draft.message = 'Error: Invalid card value';
         return;


### PR DESCRIPTION
## Summary
- Skip-Bo wildcards can now be placed on a player's discard pile, matching the official Skip-Bo rulebook
- Removed the `isSkipBo` guard from the reducer (`gameReducer.ts`), the server-side validator (`gameState.ts`), and both client hooks (`useSkipBoGame.ts`, `useOnlineSkipBoGame.ts`)
- Dropped the now-unused `INVALID_MOVE_CANNOT_DISCARD_SKIP_BO` message
- Updated the gameReducer test to assert that discarding a Skip-Bo succeeds, lands on the pile, and ends the turn
- Updated the invariant docs (`runtime-invariants.md`, `AGENTS.md`, `game-core/CLAUDE.md`, `game-rules-invariant-checker.md`) — the old "non-discardable" rule was incorrect

Note: AI strategy (`apps/web/src/ai/discardUtils.ts`) still avoids discarding wildcards by choice — that's a strategic preference, not a rule, so it was left alone.

## Test plan
- [x] `pnpm --filter @skipbo/game-core test`
- [x] `pnpm --filter @skipbo/web test -- src/state/__tests__/gameReducer.test.ts`
- [x] `pnpm --filter @skipbo/realtime-api test`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Manual: drag a Skip-Bo card from hand onto a discard pile in local play; verify it lands and ends the turn
- [ ] Manual: same flow in online play; verify server accepts the discard and snapshot reconciles

🤖 Generated with [Claude Code](https://claude.com/claude-code)