### PR TITLE
fix(web): keep deck back visible during staggered draw animations

### DIFF
--- a/apps/web/src/components/CenterArea.tsx
+++ b/apps/web/src/components/CenterArea.tsx
@@ -19,6 +19,12 @@ export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps
   const pendingRetreatCardsCount = activeAnimations.filter(
     (animation) => animation.animationType === 'complete',
   ).length;
+  // Keep the deck back visible while draw animations are still leaving the
+  // deck. In online mode the server snapshot drops deck.length to 0 before
+  // the staggered draw animations finish, which would otherwise flash "Vide".
+  const deckIsDealing = activeAnimations.some(
+    (animation) => animation.sourceInfo.source === 'deck' && !animation.hasStarted,
+  );
   const visibleCompletedBuildPileCount = Math.max(gameState.completedBuildPiles.length - pendingRetreatCardsCount, 0);
   const visibleCompletedBuildPiles =
     visibleCompletedBuildPileCount === gameState.completedBuildPiles.length
@@ -36,7 +42,7 @@ export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps
             Pioche ({gameState.deck.length})
           </h2>
           <div className="deck">
-            {gameState.deck.length > 0 ? (
+            {gameState.deck.length > 0 || deckIsDealing ? (
               <Card hint="Deck" card={{ value: 0, isSkipBo: false }} isRevealed={false} canBeGrabbed={false} />
             ) : (
               <EmptyCard canDropCard={false} />


### PR DESCRIPTION
## Summary
- In online mode, the server snapshot zeroes `deck.length` before the staggered draw animations finish, causing the "Vide" placeholder to flash while cards are still flying from the deck position.
- Mirror the existing `buildPileIsCompleting` masking pattern: treat the deck as non-empty while any active draw animation sourced from `'deck'` is still pending (`!hasStarted`).

## Test plan
- [ ] In a multiplayer game, drain the deck through dealing and confirm "Vide" no longer appears under the flying cards
- [ ] Once all draw animations finish and the deck is truly empty, the "Vide" placeholder still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)