### PR TITLE
fix(web): batch opponent animations to remove play/completion race

### DIFF
--- a/apps/web/src/components/CenterArea.tsx
+++ b/apps/web/src/components/CenterArea.tsx
@@ -21,14 +21,26 @@ export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps
   // card it carries is already in completedBuildPiles in the committed view.
   // Hide it on the retreat pile until the play animation lands; otherwise it
   // flashes there before the play animation visually delivers it. This
-  // closes the microtask gap between commitView and
-  // triggerCompletedBuildPileAnimation in useOnlineSkipBoGame.
+  // closes the microtask gap that exists when the snapshot handler registers
+  // the play animation before the completion animations (e.g. in older paths
+  // or any future caller that doesn't batch them in one tick).
+  //
+  // When matching 'complete' animations are already registered for the same
+  // build pile, the play card is conceptually one of the cards being
+  // retreated (it ends up in completedBuildPiles right behind the others),
+  // so it would be double-counted with the 'complete' count below — skip it.
   const pendingCompletionPlayCount = activeAnimations.filter(
     (animation) =>
       animation.animationType === 'play' &&
       animation.targetSettledInState &&
       animation.targetInfo?.source === 'build' &&
-      animation.targetPileLength === 0,
+      animation.targetPileLength === 0 &&
+      !activeAnimations.some(
+        (other) =>
+          other.animationType === 'complete' &&
+          other.sourceInfo.source === 'build' &&
+          other.sourceInfo.index === animation.targetInfo?.index,
+      ),
   ).length;
   const pendingRetreatCardsCount =
     activeAnimations.filter((animation) => animation.animationType === 'complete').length + pendingCompletionPlayCount;
@@ -147,17 +159,16 @@ export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps
                       canBeGrabbed={false}
                       displayValue={visiblePileLength.toString()}
                     />
-                  ) : buildPileIsCompleting ? (
-                    // Pile cleared in state before animation runs — keep showing the
-                    // completed "12" card as a static backdrop while cards fly off.
-                    <Card
-                      hint={`Construction pile ${index + 1}`}
-                      card={{ value: gameState.config.CARD_VALUES_MAX, isSkipBo: false }}
-                      isRevealed={true}
-                      canBeGrabbed={false}
-                      displayValue={gameState.config.CARD_VALUES_MAX.toString()}
-                    />
                   ) : shouldMaskIncomingPlay && pile.length === 0 ? (
+                    // A play animation is in flight toward this build pile,
+                    // and the committed view already shows it cleared by the
+                    // upcoming completion (targetPileLength === 0). Show the
+                    // pre-completion "11" backdrop until the play animation
+                    // visually delivers the final card. This branch wins over
+                    // `buildPileIsCompleting` because the play animation
+                    // hasn't yet landed — switching to the "12" backdrop now
+                    // would make the final card appear on the pile before
+                    // the card it is being carried by arrives.
                     <Card
                       hint={`Construction pile ${index + 1}`}
                       card={{
@@ -167,6 +178,16 @@ export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps
                       isRevealed={true}
                       canBeGrabbed={false}
                       displayValue={(gameState.config.CARD_VALUES_MAX - 1).toString()}
+                    />
+                  ) : buildPileIsCompleting ? (
+                    // Pile cleared in state before animation runs — keep showing the
+                    // completed "12" card as a static backdrop while cards fly off.
+                    <Card
+                      hint={`Construction pile ${index + 1}`}
+                      card={{ value: gameState.config.CARD_VALUES_MAX, isSkipBo: false }}
+                      isRevealed={true}
+                      canBeGrabbed={false}
+                      displayValue={gameState.config.CARD_VALUES_MAX.toString()}
                     />
                   ) : (
                     <EmptyCard

--- a/apps/web/src/components/__tests__/OnlineAnimationMasking.test.tsx
+++ b/apps/web/src/components/__tests__/OnlineAnimationMasking.test.tsx
@@ -253,6 +253,156 @@ describe('Online animation masking', () => {
     expect(visibleCardValues).toEqual(['3', '7']);
   });
 
+  test('keeps the pre-completion "11" backdrop on the build pile while a completing play animation is still in flight', () => {
+    // Scenario: opponent just played a 12 that completes build pile 0. Both
+    // the play animation AND the staggered completion animations are
+    // registered synchronously by the snapshot handler. The play card is
+    // still mid-flight. The build pile must keep showing the "11" backdrop
+    // until the play animation lands — switching to the "12" backdrop while
+    // the carrying card is still flying makes the value appear at the
+    // destination prematurely (user-reported bug).
+    const gameState = createGameState();
+    gameState.buildPiles[0] = [];
+    gameState.completedBuildPiles = Array.from({ length: 12 }, (_, index) => card(index + 1));
+
+    const playAnimation: CardAnimationData = {
+      ...createSettledIncomingBuildAnimation(0, 0),
+      card: card(12),
+    };
+
+    const completeAnimations: CardAnimationData[] = Array.from({ length: 12 }, (_, index) => ({
+      id: `complete-${index}`,
+      card: card(index + 1),
+      startPosition: { x: 0, y: 0 },
+      endPosition: { x: 200, y: 200 },
+      animationType: 'complete',
+      sourceRevealed: true,
+      targetRevealed: true,
+      initialDelay: 300 + index * 100, // baseDelay = play duration, then staggered
+      duration: 400,
+      sourceInfo: {
+        playerIndex: 1,
+        source: 'build',
+        index: 0,
+      },
+    }));
+
+    render(
+      <CardAnimationContext.Provider value={createAnimationContext([playAnimation, ...completeAnimations])}>
+        <CenterArea
+          gameState={gameState}
+          playCard={vi.fn(async () => ({ success: true, message: 'ok' }))}
+          canPlayCard={vi.fn(() => false)}
+        />
+      </CardAnimationContext.Provider>,
+    );
+
+    const buildPile = screen.getByLabelText('Pile de construction 1');
+
+    // Build pile shows the "11" backdrop, NOT the "12" backdrop.
+    expect(buildPile.querySelector('.card[data-value="11"]')).not.toBeNull();
+    expect(buildPile.querySelector('.card[data-value="12"]')).toBeNull();
+    expect(buildPile.querySelector('.empty-card')).toBeNull();
+  });
+
+  test('switches the build pile to the "12" backdrop once the play animation has landed', () => {
+    // After the play animation finishes, AnimatedCard calls removeAnimation
+    // and the play entry is gone — only the staggered "complete" animations
+    // remain. At that point the build pile should show the "12" backdrop
+    // while the cards retreat.
+    const gameState = createGameState();
+    gameState.buildPiles[0] = [];
+    gameState.completedBuildPiles = Array.from({ length: 12 }, (_, index) => card(index + 1));
+
+    const completeAnimations: CardAnimationData[] = Array.from({ length: 12 }, (_, index) => ({
+      id: `complete-${index}`,
+      card: card(index + 1),
+      startPosition: { x: 0, y: 0 },
+      endPosition: { x: 200, y: 200 },
+      animationType: 'complete',
+      sourceRevealed: true,
+      targetRevealed: true,
+      initialDelay: index * 100,
+      duration: 400,
+      sourceInfo: {
+        playerIndex: 1,
+        source: 'build',
+        index: 0,
+      },
+    }));
+
+    render(
+      <CardAnimationContext.Provider value={createAnimationContext(completeAnimations)}>
+        <CenterArea
+          gameState={gameState}
+          playCard={vi.fn(async () => ({ success: true, message: 'ok' }))}
+          canPlayCard={vi.fn(() => false)}
+        />
+      </CardAnimationContext.Provider>,
+    );
+
+    const buildPile = screen.getByLabelText('Pile de construction 1');
+
+    expect(buildPile.querySelector('.card[data-value="12"]')).not.toBeNull();
+    expect(buildPile.querySelector('.card[data-value="11"]')).toBeNull();
+  });
+
+  test('does not leak previously-completed retreat cards while play + completion animations are active', () => {
+    // pendingCompletionPlayCount must not double-count when 'complete'
+    // animations are already registered for the same pile. Otherwise the
+    // retreat pile would hide one extra card from the existing stack while
+    // the new completion sequence runs.
+    const gameState = createGameState();
+    gameState.buildPiles[0] = [];
+    // 5 previously-completed cards + 12 newly completed (last one is the 12).
+    const previouslyCompleted = [card(5), card(6), card(7), card(8), card(9)];
+    const newlyCompleted = Array.from({ length: 12 }, (_, index) => card(index + 1));
+    gameState.completedBuildPiles = [...previouslyCompleted, ...newlyCompleted];
+
+    const playAnimation: CardAnimationData = {
+      ...createSettledIncomingBuildAnimation(0, 0),
+      card: card(12),
+    };
+    const completeAnimations: CardAnimationData[] = newlyCompleted.map((cardData, index) => ({
+      id: `complete-${index}`,
+      card: cardData,
+      startPosition: { x: 0, y: 0 },
+      endPosition: { x: 200, y: 200 },
+      animationType: 'complete',
+      sourceRevealed: true,
+      targetRevealed: true,
+      initialDelay: 300 + index * 100,
+      duration: 400,
+      sourceInfo: { playerIndex: 1, source: 'build', index: 0 },
+    }));
+
+    render(
+      <CardAnimationContext.Provider value={createAnimationContext([playAnimation, ...completeAnimations])}>
+        <CenterArea
+          gameState={gameState}
+          playCard={vi.fn(async () => ({ success: true, message: 'ok' }))}
+          canPlayCard={vi.fn(() => false)}
+        />
+      </CardAnimationContext.Provider>,
+    );
+
+    const retreatPile = screen.getByTestId('retreat-pile');
+    const visibleValues = Array.from(retreatPile.querySelectorAll<HTMLElement>('.card[data-value]')).map(
+      (element) => element.dataset.value,
+    );
+
+    // All 5 previously-completed cards (or up to RETREAT_PILE_PREVIEW_LIMIT
+    // of them) must remain visible. None of the 12 newly-retreated cards
+    // should be on screen yet — they're still on the build pile waiting to
+    // fly away.
+    expect(visibleValues).toContain('9');
+    // The newly-completed cards have values 1..12; the 5 previously-completed
+    // ones are 5..9. We assert no card with value 10, 11 or 12 leaks through.
+    expect(visibleValues).not.toContain('10');
+    expect(visibleValues).not.toContain('11');
+    expect(visibleValues).not.toContain('12');
+  });
+
   test('hides the just-completed 12 on the retreat pile while the play animation is still in flight', () => {
     // Scenario: an opponent just played a 12 that completed build pile 0.
     // The snapshot has landed (commitView already happened), so:

--- a/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
+++ b/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
@@ -28,7 +28,7 @@ const {
   calculateMultipleDrawAnimationDuration: vi.fn(() => 0),
   removeAnimation: vi.fn(),
   startAnimation: vi.fn(),
-  triggerAIAnimation: vi.fn(async () => 0),
+  triggerAIAnimation: vi.fn(() => 0),
   triggerCompletedBuildPileAnimation: vi.fn(() => 0),
   triggerMultipleDrawAnimations: vi.fn(async () => 0),
   waitForAnimations: vi.fn(async () => undefined),
@@ -399,7 +399,7 @@ describe('useOnlineSkipBoGame', () => {
     removeAnimation.mockClear();
     startAnimation.mockClear();
     triggerAIAnimation.mockClear();
-    triggerAIAnimation.mockImplementation(async () => 0);
+    triggerAIAnimation.mockImplementation(() => 0);
     triggerCompletedBuildPileAnimation.mockClear();
     triggerCompletedBuildPileAnimation.mockImplementation(() => 0);
     triggerMultipleDrawAnimations.mockClear();
@@ -764,14 +764,9 @@ describe('useOnlineSkipBoGame', () => {
     const { previousState, nextState } = createOpponentDiscardHandoffStates();
     const previousView = createOnlineView(previousState, 1);
     const nextView = createOnlineView(nextState, 2);
-    let resolveOpponentAnimation: (() => void) | null = null;
 
-    triggerAIAnimation.mockImplementationOnce(
-      () =>
-        new Promise<number>((resolve) => {
-          resolveOpponentAnimation = () => resolve(200);
-        }),
-    );
+    triggerAIAnimation.mockImplementationOnce(() => 200);
+    // Slowest pending animation drives the turn-presentation timer.
     calculateMultipleDrawAnimationDuration.mockReturnValueOnce(700);
 
     const { result } = renderHook(() => useOnlineSkipBoGame(session));
@@ -795,16 +790,14 @@ describe('useOnlineSkipBoGame', () => {
       socket.emitMessage({ type: 'snapshot', view: nextView });
     });
 
-    expect(result.current.gameState.message).toBe(previousView.message);
-    expect(result.current.gameState.currentPlayerIndex).toBe(previousView.currentPlayerIndex);
-
-    await act(async () => {
-      resolveOpponentAnimation?.();
-      await Promise.resolve();
-    });
-
+    // Synchronous registration: as soon as the snapshot is applied, the play
+    // and draw animations are queued together — so triggerMultipleDrawAnimations
+    // is invoked in the same tick. The turn-presentation override holds the
+    // previous opponent's message until the slowest animation completes.
+    expect(triggerAIAnimation).toHaveBeenCalledTimes(1);
     expect(triggerMultipleDrawAnimations).toHaveBeenCalledTimes(1);
     expect(result.current.gameState.message).toBe(previousView.message);
+    expect(result.current.gameState.currentPlayerIndex).toBe(previousView.currentPlayerIndex);
 
     await act(async () => {
       vi.advanceTimersByTime(699);
@@ -1125,7 +1118,7 @@ describe('useOnlineSkipBoGame', () => {
       const nextView = createOnlineView(nextState, 2);
 
       const PLAY_DURATION = 320;
-      triggerAIAnimation.mockImplementationOnce(async () => PLAY_DURATION);
+      triggerAIAnimation.mockImplementationOnce(() => PLAY_DURATION);
 
       renderHook(() => useOnlineSkipBoGame(session));
 
@@ -1185,6 +1178,106 @@ describe('useOnlineSkipBoGame', () => {
       const playOrder = triggerAIAnimation.mock.invocationCallOrder[0];
       const completionOrder = triggerCompletedBuildPileAnimation.mock.invocationCallOrder[0];
       expect(playOrder).toBeLessThan(completionOrder);
+    });
+
+    it('registers play and completion animations in the same synchronous tick (no microtask gap)', async () => {
+      // Regression: previously triggerAIAnimation was async, and completion
+      // was scheduled in a .then() microtask after it. That one-microtask gap
+      // let React paint a frame where the play animation was registered but
+      // completion wasn't — causing the "12" backdrop to appear on the build
+      // pile, and the just-retreated cards to briefly leak onto the retreat
+      // pile, before the play animation visually landed. The animations must
+      // now register synchronously so both land in the same React commit as
+      // the snapshot's commitView.
+      const session = createSession();
+      const { previousState, nextState } = createOpponentCompletionStates();
+      const previousView = createOnlineView(previousState, 1);
+      const nextView = createOnlineView(nextState, 2);
+
+      triggerAIAnimation.mockImplementationOnce(() => 300);
+
+      renderHook(() => useOnlineSkipBoGame(session));
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+
+      const socket = MockWebSocket.instances[0];
+
+      await act(async () => {
+        socket.open();
+        socket.emitMessage({ type: 'snapshot', view: previousView });
+        await Promise.resolve();
+      });
+
+      // Emit the snapshot synchronously, WITHOUT awaiting any microtasks
+      // afterwards inside the act() callback. We then assert from outside
+      // act() that both animations were already registered.
+      await act(async () => {
+        socket.emitMessage({ type: 'snapshot', view: nextView });
+      });
+
+      // Without flushing microtasks, both calls must already have fired.
+      expect(triggerAIAnimation).toHaveBeenCalledTimes(1);
+      expect(triggerCompletedBuildPileAnimation).toHaveBeenCalledTimes(1);
+    });
+
+    it('schedules opponent hand refill with baseDelay equal to the play animation duration', async () => {
+      // When the opponent plays the LAST card from their hand and the
+      // refilled slot must animate in, the draw animations should be queued
+      // so their initialDelay equals the play (+ completion) duration —
+      // otherwise the refilled card pops into the opponent's hand before
+      // (or while) the played card is still in flight.
+      const previousState = initialGameState();
+      previousState.currentPlayerIndex = 1;
+      previousState.players[1].isAI = false;
+      previousState.players[1].hand = [null, null, null, null, card(7)];
+      previousState.deck = [card(2), card(3), card(4), card(5), card(8)];
+      previousState.buildPiles = [[card(1), card(2), card(3), card(4), card(5), card(6)], [], [], []];
+      previousState.selectedCard = {
+        card: card(7),
+        source: 'hand',
+        index: 4,
+      };
+      previousState.message = 'Sélectionnez une destination';
+
+      const nextState = gameReducer(previousState, { type: 'PLAY_CARD', buildPile: 0 });
+
+      const session = createSession();
+      const previousView = createOnlineView(previousState, 1);
+      const nextView = createOnlineView(nextState, 2);
+
+      const PLAY_DURATION = 280;
+      triggerAIAnimation.mockImplementationOnce(() => PLAY_DURATION);
+
+      renderHook(() => useOnlineSkipBoGame(session));
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+
+      const socket = MockWebSocket.instances[0];
+
+      await act(async () => {
+        socket.open();
+        socket.emitMessage({ type: 'snapshot', view: previousView });
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        socket.emitMessage({ type: 'snapshot', view: nextView });
+      });
+
+      // The hand refill must be queued exactly once for the opponent, with
+      // baseDelay = play duration so the refilled card appears AFTER the
+      // played card has landed on the build pile.
+      expect(triggerMultipleDrawAnimations).toHaveBeenCalledTimes(1);
+      const args = triggerMultipleDrawAnimations.mock.calls[0] as unknown as [number, Card[], number[], number, number];
+      const [opponentIndex, , handIndices, , baseDelay] = args;
+      expect(opponentIndex).toBe(1);
+      // The slot the opponent emptied (index 4) must be refilled.
+      expect(handIndices).toContain(4);
+      expect(baseDelay).toBe(PLAY_DURATION);
     });
   });
 });

--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -513,38 +513,41 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
                   // visible as a brief card-back flash before the new top
                   // appears.
                   commitView(message.view);
-                  void triggerAIAnimation(previousState, opponentTransition.action, {
+                  // Register play, completion, draw refill, and the turn
+                  // presentation timer SYNCHRONOUSLY so they all batch into
+                  // the same React commit as the new view. A microtask gap
+                  // here (e.g. awaiting triggerAIAnimation) lets React paint
+                  // a frame where the play animation is registered but the
+                  // completion / draw animations are not — causing visible
+                  // glitches like the "12" backdrop appearing on the build
+                  // pile before the play card lands, or completed cards
+                  // leaking onto the retreat pile while the play is still
+                  // in flight.
+                  const opponentAnimationDuration = triggerAIAnimation(previousState, opponentTransition.action, {
                     cardOverride: opponentTransition.animationCard,
                     sourceRevealedOverride: opponentTransition.sourceRevealed,
                     targetSettledInStateOverride: true,
                     targetPileLengthOverride: opponentTransition.targetPileLength,
                     targetRevealedOverride: true,
-                  }).then((opponentAnimationDuration) => {
-                    if (opponentTransition.completedCards && opponentTransition.completedBuildPileIndex !== undefined) {
-                      // Register completion animations immediately with
-                      // baseDelay=opponentAnimationDuration so the cards are
-                      // tracked as in-flight as soon as state lands. Otherwise
-                      // CenterArea would briefly render the new top card on
-                      // the retreat pile during the play animation, before
-                      // the retreat animation begins.
-                      triggerCompletedBuildPileAnimation(
-                        previousState,
-                        opponentTransition.completedBuildPileIndex,
-                        opponentTransition.completedCards,
-                        previousState.completedBuildPiles.length,
-                        100,
-                        opponentAnimationDuration,
-                      );
-                    }
-
-                    scheduleDrawAnimations(drawTransitions, opponentAnimationDuration);
-                    applyTurnPresentationDelay(
-                      Math.max(
-                        opponentAnimationDuration,
-                        getMaxDrawAnimationDuration(drawTransitions, opponentAnimationDuration),
-                      ),
-                    );
                   });
+                  if (opponentTransition.completedCards && opponentTransition.completedBuildPileIndex !== undefined) {
+                    triggerCompletedBuildPileAnimation(
+                      previousState,
+                      opponentTransition.completedBuildPileIndex,
+                      opponentTransition.completedCards,
+                      previousState.completedBuildPiles.length,
+                      100,
+                      opponentAnimationDuration,
+                    );
+                  }
+
+                  scheduleDrawAnimations(drawTransitions, opponentAnimationDuration);
+                  applyTurnPresentationDelay(
+                    Math.max(
+                      opponentAnimationDuration,
+                      getMaxDrawAnimationDuration(drawTransitions, opponentAnimationDuration),
+                    ),
+                  );
                 } else {
                   const drawAnimationDuration = getMaxDrawAnimationDuration(drawTransitions);
                   if (drawAnimationDuration > 0) {

--- a/apps/web/src/services/aiAnimationService.ts
+++ b/apps/web/src/services/aiAnimationService.ts
@@ -30,12 +30,23 @@ export const setGlobalAnimationContext = (context: typeof globalAnimationContext
   globalAnimationContext = context;
 };
 
-// Function to trigger AI animations
-export const triggerAIAnimation = async (
+// Function to trigger AI animations.
+//
+// This function is intentionally synchronous: it reads DOM layout, registers a
+// single animation with the global animation context, and returns the computed
+// duration. Callers rely on synchronous behavior to register follow-up
+// animations (e.g. completion retreat, hand refill draws) in the SAME tick so
+// React commits them all in one render. Introducing a microtask boundary here
+// causes a one-frame flash where the play animation is registered against a
+// view that already shows completion side-effects (e.g. the 12 backdrop on a
+// just-cleared build pile, or completed cards leaking onto the retreat pile).
+// See useOnlineSkipBoGame snapshot handling for the call site that depends on
+// this contract.
+export const triggerAIAnimation = (
   gameState: GameState,
   action: GameAction,
   options: TriggerAIAnimationOptions = {},
-): Promise<number> => {
+): number => {
   if (!globalAnimationContext) {
     console.warn('Animation context not available for AI action');
     return 0;

--- a/apps/web/src/state/gameMachine.ts
+++ b/apps/web/src/state/gameMachine.ts
@@ -343,9 +343,10 @@ export const gameMachine = createMachine(
 
         // Check if PLAY_CARD will empty the hand and trigger draw animations
         if (action.type === 'PLAY_CARD' && willPlayCardEmptyHand(input.G)) {
-          // First trigger the play card animation
+          // First trigger the play card animation. triggerAIAnimation is
+          // synchronous — the actual wait happens via waitForAnimations().
           if (input.G.selectedCard) {
-            await triggerAIAnimation(input.G, action);
+            triggerAIAnimation(input.G, action);
             await animationServiceBridge.waitForAnimations();
           }
 
@@ -383,9 +384,11 @@ export const gameMachine = createMachine(
             }
           }
         } else {
-          // Trigger animation for other AI actions that need it
+          // Trigger animation for other AI actions that need it.
+          // triggerAIAnimation is synchronous — the actual wait happens via
+          // waitForAnimations().
           if ((action.type === 'PLAY_CARD' || action.type === 'DISCARD_CARD') && input.G.selectedCard) {
-            await triggerAIAnimation(input.G, action);
+            triggerAIAnimation(input.G, action);
             await animationServiceBridge.waitForAnimations();
           }
 


### PR DESCRIPTION
## Summary

- Fix the bug where the 12/Skip-Bo (or backdrop) appears on the construction pile **before** the opponent's play animation lands. Root cause: `triggerAIAnimation` was declared `async` but had no awaits, so completion + draw animations were scheduled in a `.then()` microtask. React painted a frame where the play animation was registered against a state that already showed completion side-effects.
- Make `triggerAIAnimation` synchronous and register play, completion, draw refill, and the turn-presentation timer in one synchronous block in `useOnlineSkipBoGame`'s snapshot handler — so they all land in the same React commit as `commitView`.
- Reorder `CenterArea` render branches so the pre-completion "11" backdrop wins over the "12" backdrop while a completing play animation is still in flight. Fix `pendingCompletionPlayCount` to avoid double-counting against matching `'complete'` animations on the same pile (would have briefly hidden one previously-completed card on the retreat pile).

## Test plan

- [x] `pnpm --filter @skipbo/web test` — 192 tests pass, including 5 new ones:
  - Build pile shows "11" backdrop while play + completion are both registered
  - Build pile switches to "12" backdrop once the play animation is removed
  - Retreat pile does not leak previously-completed cards during play + completion
  - Snapshot handler registers play + completion in the same synchronous tick
  - Opponent hand refill uses `baseDelay === playDuration` so the refilled slot appears only after the card lands
- [x] `pnpm --filter @skipbo/web typecheck`
- [x] `pnpm --filter @skipbo/web lint`
- [ ] Manual verification in two-browser local multiplayer: opponent plays 12 / Skip-Bo to complete a build pile and the value no longer appears on the construction or retreat pile before the play animation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)