### PR TITLE
fix(web): land discard animation on empty pile placeholder center

### DIFF
--- a/apps/web/src/utils/cardPositions.ts
+++ b/apps/web/src/utils/cardPositions.ts
@@ -158,7 +158,7 @@ export const getDiscardTopCardPosition = (discardContainer: HTMLElement, pileInd
   }
 
   const allCards = Array.from(pileElement.querySelectorAll<HTMLElement>('.card'));
-  const realCards = allCards.filter((el) => !el.classList.contains('opacity-50'));
+  const realCards = allCards.filter((el) => !el.classList.contains('empty-card'));
 
   if (realCards.length === 0) {
     const placeholder = allCards[0];
@@ -178,9 +178,9 @@ export const getNextDiscardCardPosition = (discardContainer: HTMLElement, pileIn
     return getElementCenter(discardContainer);
   }
 
-  // Determine how many real cards are in the pile (exclude placeholder which has opacity-50)
+  // Determine how many real cards are in the pile (exclude the empty-card placeholder)
   const allCards = Array.from(pileElement.querySelectorAll<HTMLElement>('.card'));
-  const realCards = allCards.filter((el) => !el.classList.contains('opacity-50'));
+  const realCards = allCards.filter((el) => !el.classList.contains('empty-card'));
 
   if (realCards.length === 0) {
     // Empty pile: land on the base position (placeholder center)


### PR DESCRIPTION
## Summary
- The empty-pile placeholder card gets its 50% opacity via `@apply opacity-50` inside the `.card.empty-card` CSS rule, so the literal `opacity-50` class is never present on the DOM element.
- `getNextDiscardCardPosition` / `getDiscardTopCardPosition` used `!classList.contains('opacity-50')` to filter the placeholder out — that filter always failed, so the placeholder was counted as a real card and the next-card position landed 20px below it (second-card stacking offset).
- Switched the filter to `.empty-card`, which is the actual marker class.

## Test plan
- [x] Verified on a `?fixture=ready-human` page: with the old filter the empty pile's `realCount` was 1 (bug); with the new filter it is 0 (correct — empty branch taken).
- [ ] Manually discard a card from hand to an empty discard pile in local play; animation target should align with the placeholder, not 20px below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)