### PR TITLE
fix(theme): make active-player ring visible in wool theme

### DIFF
--- a/apps/web/src/themes/wool.css
+++ b/apps/web/src/themes/wool.css
@@ -11,6 +11,7 @@
   ); /* deepened so muted body copy reaches ≥4.5:1 on wool's mid-steel secondary surfaces */
   --destructive: hsl(0 49% 49%);
   --destructive-foreground: #c9c9c9;
+  --active-turn-color: hsl(355 55% 40%); /* deep yarn-red — visible against the wool-grey background */
 
   --background: hsl(
     206 13% 72%
@@ -68,8 +69,9 @@
 
   .player-area.active-turn {
     box-shadow:
-      10px 10px 20px color-mix(in srgb, var(--background), black 25%),
-      -10px -10px 20px color-mix(in srgb, var(--background), white 70%);
+      0 0 0 3px var(--active-turn-color),
+      10px 10px 20px color-mix(in srgb, var(--background), black 15%),
+      -10px -10px 20px color-mix(in srgb, var(--background), white 35%);
   }
 
   .empty-card {


### PR DESCRIPTION
## Summary
- Wool theme's `.player-area.active-turn` overrode `box-shadow`, clobbering the Tailwind `ring-(--active-turn-color)` from `layout.css`.
- `--active-turn-color` was undefined and fell back to `--primary` (#c9c9c9), invisible on the wool-grey background.
- Define a deep yarn-red `--active-turn-color` and merge a 3px ring into the active-turn box-shadow stack alongside the existing neumorphic shadow.

## Test plan
- [x] Verified in browser via fixture `?fixture=ready-human` with `theme-wool`: active player area shows a clear red outline distinct from the inactive player and centre area.
- [ ] Sanity check other themes still render their active-turn indicator correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)