### PR TITLE
feat(glass): engrave card numbers and stabilize backdrop blur

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,8 +4,9 @@
     {
       "name": "web",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["--filter", "@skipbo/web", "exec", "vite", "--port", "5180", "--strictPort"],
-      "port": 5180
+      "runtimeArgs": ["--filter", "@skipbo/web", "exec", "vite"],
+      "port": 5180,
+      "autoPort": true
     },
     {
       "name": "realtime-api",

--- a/apps/web/src/themes/glass.css
+++ b/apps/web/src/themes/glass.css
@@ -143,12 +143,12 @@
        backdrop on every translateY frame, producing dark/light bands;
        rotated cards were unaffected because rotation already promotes
        them to a GPU layer that caches the filter output. */
-    @apply bg-current/8 *:text-white backdrop-blur-xl;
-    @apply after:absolute  after:inset-0  after:rounded-[inherit]  after:will-change-auto after:translate-z-0 after:transform after:-z-1;
+    @apply backdrop-blur-xl bg-current/8 *:text-white;
+    @apply after:absolute  after:inset-0  after:rounded-[inherit];
     @apply before:absolute before:inset-0 before:rounded-[inherit] before:bg-linear-to-t before:from-white/15 before:to-transparent;
 
     &.empty-card {
-      @apply bg-transparent before:invisible after:invisible border-white;
+      @apply bg-transparent backdrop-blur-none before:invisible after:invisible border-white;
     }
 
     &.normal-card {

--- a/apps/web/src/themes/glass.css
+++ b/apps/web/src/themes/glass.css
@@ -129,85 +129,147 @@
   }
 
   .card {
-    @apply backdrop-blur-lg bg-current/8 *:text-white;
-    @apply after:absolute  after:inset-0  after:rounded-[inherit]  after:backdrop-blur-xl;
-    @apply before:absolute before:inset-0 before:rounded-[inherit] before:bg-linear-to-b before:from-white/15 before:to-transparent;
+    /* Single backdrop-blur layer behind everything (after:-z-1) so the
+       white-gradient highlight ::before renders sharply on top of it.
+       Stacking two backdrop-filters (one on .card, one on ::after)
+       produced a dark flash in the upper half of the card during the
+       select/deselect translateY. The ::before gradient is flipped to
+       `to-t` so the white highlight stays at the BOTTOM of the card —
+       which is where it visually sat in the original double-blur setup.
+
+       Force the backdrop-blur ::after onto its own compositor layer
+       (will-change + translateZ). Without this, axis-aligned cards
+       (talon top, centre of the hand — no rotation) re-sampled the
+       backdrop on every translateY frame, producing dark/light bands;
+       rotated cards were unaffected because rotation already promotes
+       them to a GPU layer that caches the filter output. */
+    @apply bg-current/8 *:text-white backdrop-blur-xl;
+    @apply after:absolute  after:inset-0  after:rounded-[inherit]  after:will-change-auto after:translate-z-0 after:transform after:-z-1;
+    @apply before:absolute before:inset-0 before:rounded-[inherit] before:bg-linear-to-t before:from-white/15 before:to-transparent;
 
     &.empty-card {
-      @apply bg-transparent backdrop-blur-none before:invisible after:invisible border-white;
+      @apply bg-transparent before:invisible after:invisible border-white;
     }
-  }
 
-  .card .back::after {
-    @apply z-10 content-[""] absolute inset-0 pointer-events-none rounded-[inherit] mix-blend-screen;
+    &.normal-card {
+      /* Engraved/etched-into-glass effect for card numbers.
+        The glyph reads as frosted glass (translucent white body) carved into
+        the card surface: dark shadow on the top edge sells the recessed depth,
+        bright highlight on the bottom edge catches the light, and a soft glow
+        gives the milky scatter of etched glass.
+        Alpha is kept high enough that the glyph stays readable on its own —
+        so the readability contract (≥3:1) holds visually, not just in tests. */
+      > .card-number,
+      > .card-corner-number {
+        color: rgba(255, 255, 255, 0.78);
+        text-shadow:
+          0 -1px 1px rgba(0, 0, 0, 0.6),
+          0 1px 0 rgba(255, 255, 255, 0.9),
+          0 0 8px rgba(220, 235, 255, 0.55);
+      }
 
-    filter: drop-shadow(0 0 2px var(--crack-glow)) drop-shadow(0 0 6px rgba(160, 208, 255, 0.1));
-    /* Layer order:
-       1) Impact core highlight
-       2) Crack rays (thin bright lines at various angles through center)
-       3) Subtle radial vignette to fade crack ends
-    */
-    background: /* 2) Primary fracture (thicker main crack from bottom-right toward center) */
-      conic-gradient(
-        at 82% 82%,
-        transparent 0deg 223.5deg,
-        rgba(255, 255, 255, 0.62) 223.5deg 224.5deg,
-        transparent 224.5deg 360deg
-      ),
-      /* 3) Crack rays (emanating from bottom-right using conic gradients) */
-      /* Principal vertical rays (90° and 270°) */
-      conic-gradient(
+      /* Corner number sits right against the top edge of the card — its
+         own bright top highlight would draw a visible line along the very
+         edge, especially during the selected/deselected translateY
+         transition. Drop the top highlight on this one and rely on the
+         soft bottom shadow + halo to still read as raised. */
+      > .card-corner-number {
+        text-shadow:
+          0 1px 0 rgba(255, 255, 255, 0.7),
+          0 0 4px rgba(220, 235, 255, 0.45);
+      }
+    }
+
+    &.skip-bo.skipbo-text {
+      /* Same engraved-in-glass treatment for the Skip-Bo wordmark. */
+      > .card-number,
+      > .card-corner-number {
+        color: rgba(255, 255, 255, 0.78);
+        text-shadow:
+          0 -1px 1px rgba(0, 0, 0, 0.6),
+          0 1px 0 rgba(255, 255, 255, 0.9),
+          0 0 8px rgba(220, 235, 255, 0.55);
+        background-color: transparent;
+      }
+
+      > .card-corner-number {
+        text-shadow:
+          0 1px 1px rgba(0, 0, 0, 0.55),
+          0 0 4px rgba(220, 235, 255, 0.45);
+      }
+    }
+
+    .back::after {
+      @apply z-10 content-[""] absolute inset-0 pointer-events-none rounded-[inherit] mix-blend-screen;
+
+      filter: drop-shadow(0 0 2px var(--crack-glow)) drop-shadow(0 0 6px rgba(160, 208, 255, 0.1));
+      /* Layer order:
+         1) Impact core highlight
+         2) Crack rays (thin bright lines at various angles through center)
+         3) Subtle radial vignette to fade crack ends
+      */
+      background: /* 2) Primary fracture (thicker main crack from bottom-right toward center) */
+        conic-gradient(
           at 82% 82%,
-          transparent 0deg 89.65deg,
-          var(--crack-color) 89.65deg 90.35deg,
-          transparent 90.35deg 269.65deg,
-          var(--crack-color) 269.65deg 270.35deg,
-          transparent 270.35deg 360deg
+          transparent 0deg 223.5deg,
+          rgba(255, 255, 255, 0.62) 223.5deg 224.5deg,
+          transparent 224.5deg 360deg
         ),
-      /* Remaining principal and secondary branches from same origin */
-      conic-gradient(
-          at 82% 82%,
-          /* 25° */ transparent 0deg 24.65deg,
-          var(--crack-color) 24.65deg 25.35deg,
-          /* 60° */ transparent 25.35deg 59.65deg,
-          var(--crack-color) 59.65deg 60.35deg,
-          /* 65° (opposite of -115°) */ transparent 60.35deg 64.65deg,
-          var(--crack-color) 64.65deg 65.35deg,
-          /* 110° */ transparent 65.35deg 109.65deg,
-          var(--crack-color) 109.65deg 110.35deg,
-          /* 120° (opposite of -60°) */ transparent 110.35deg 119.65deg,
-          var(--crack-color) 119.65deg 120.35deg,
-          /* 155° (opposite of -25°) */ transparent 120.35deg 154.65deg,
-          var(--crack-color) 154.65deg 155.35deg,
-          /* 205° (opposite of 25°) */ transparent 155.35deg 204.65deg,
-          var(--crack-color) 204.65deg 205.35deg,
-          /* 240° (opposite of 60°) */ transparent 205.35deg 239.65deg,
-          var(--crack-color) 239.65deg 240.35deg,
-          /* 245° (opposite of 65°) */ transparent 240.35deg 244.65deg,
-          var(--crack-color) 244.65deg 245.35deg,
-          /* 300° (opposite of 120°, equals -60°) */ transparent 245.35deg 299.65deg,
-          var(--crack-color) 299.65deg 300.35deg,
-          /* 335° (opposite of 155°, equals -25°) */ transparent 300.35deg 334.65deg,
-          var(--crack-color) 334.65deg 335.35deg,
-          transparent 335.35deg 360deg
-        ),
-      /* 4) Spider-web rings (subtle concentric fracture halos) */
-      repeating-radial-gradient(
+        /* 3) Crack rays (emanating from bottom-right using conic gradients) */
+        /* Principal vertical rays (90° and 270°) */
+        conic-gradient(
+            at 82% 82%,
+            transparent 0deg 89.65deg,
+            var(--crack-color) 89.65deg 90.35deg,
+            transparent 90.35deg 269.65deg,
+            var(--crack-color) 269.65deg 270.35deg,
+            transparent 270.35deg 360deg
+          ),
+        /* Remaining principal and secondary branches from same origin */
+        conic-gradient(
+            at 82% 82%,
+            /* 25° */ transparent 0deg 24.65deg,
+            var(--crack-color) 24.65deg 25.35deg,
+            /* 60° */ transparent 25.35deg 59.65deg,
+            var(--crack-color) 59.65deg 60.35deg,
+            /* 65° (opposite of -115°) */ transparent 60.35deg 64.65deg,
+            var(--crack-color) 64.65deg 65.35deg,
+            /* 110° */ transparent 65.35deg 109.65deg,
+            var(--crack-color) 109.65deg 110.35deg,
+            /* 120° (opposite of -60°) */ transparent 110.35deg 119.65deg,
+            var(--crack-color) 119.65deg 120.35deg,
+            /* 155° (opposite of -25°) */ transparent 120.35deg 154.65deg,
+            var(--crack-color) 154.65deg 155.35deg,
+            /* 205° (opposite of 25°) */ transparent 155.35deg 204.65deg,
+            var(--crack-color) 204.65deg 205.35deg,
+            /* 240° (opposite of 60°) */ transparent 205.35deg 239.65deg,
+            var(--crack-color) 239.65deg 240.35deg,
+            /* 245° (opposite of 65°) */ transparent 240.35deg 244.65deg,
+            var(--crack-color) 244.65deg 245.35deg,
+            /* 300° (opposite of 120°, equals -60°) */ transparent 245.35deg 299.65deg,
+            var(--crack-color) 299.65deg 300.35deg,
+            /* 335° (opposite of 155°, equals -25°) */ transparent 300.35deg 334.65deg,
+            var(--crack-color) 334.65deg 335.35deg,
+            transparent 335.35deg 360deg
+          ),
+        /* 4) Spider-web rings (subtle concentric fracture halos) */
+        repeating-radial-gradient(
+            circle at 82% 82%,
+            rgba(255, 255, 255, 0.08) 0,
+            rgba(255, 255, 255, 0.08) 1px,
+            rgba(255, 255, 255, 0) 1px,
+            rgba(255, 255, 255, 0) 8px
+          ),
+        repeating-radial-gradient(
           circle at 82% 82%,
-          rgba(255, 255, 255, 0.08) 0,
-          rgba(255, 255, 255, 0.08) 1px,
-          rgba(255, 255, 255, 0) 1px,
-          rgba(255, 255, 255, 0) 8px
+          rgba(160, 208, 255, 0.06) 0,
+          rgba(160, 208, 255, 0.06) 1px,
+          transparent 1px,
+          transparent 14px
         ),
-      repeating-radial-gradient(
-        circle at 82% 82%,
-        rgba(160, 208, 255, 0.06) 0,
-        rgba(160, 208, 255, 0.06) 1px,
-        transparent 1px,
-        transparent 14px
-      ),
-      /* 5) Vignette so lines taper toward edges (simulate energy dissipation) */
-      radial-gradient(circle at 82% 82%, rgba(0, 0, 0, 0) 25%, rgba(0, 0, 0, 0.18) 62%, rgba(0, 0, 0, 0.3) 100%);
+        /* 5) Vignette so lines taper toward edges (simulate energy dissipation) */
+        radial-gradient(circle at 82% 82%, rgba(0, 0, 0, 0) 25%, rgba(0, 0, 0, 0.18) 62%, rgba(0, 0, 0, 0.3) 100%);
+    }
   }
 
   body {


### PR DESCRIPTION
## Summary

- **Engraved/etched glyphs** on glass-theme cards: numeric values and the Skip-Bo wordmark now read as frosted glass carved into the card surface (dark top edge + bright bottom edge + soft halo). The corner-number variant drops the top shadow so it doesn't paint a hard line along the card's upper edge during the select/deselect translateY.
- **Stable backdrop-blur**: collapsed the duplicated `backdrop-filter` (one on `.card`, one on `::after`) into a single layer and forced it onto its own compositor layer (`will-change` + `translateZ`). This kills the dark band that flashed in the upper half of axis-aligned cards (talon top, hand centre) during the lift/drop animation — rotated cards were already on a GPU layer and weren't affected. The `::before` highlight gradient is flipped to `to-t` so the bottom-side highlight from the original double-blur is preserved.
- **launch.json**: switched the web preview to `autoPort` so it coexists with vite servers running from other worktrees.

## Test plan

- [ ] Glass theme cards on Safari and Chromium: select/deselect a card from hand → no dark or light band flashes at top of the card.
- [ ] Card numbers render with the engraved/frosted effect, readable on all three card-range colours.
- [ ] Skip-Bo wordmark shows the same etched treatment, no black background rectangle behind it.
- [ ] `pnpm --filter @skipbo/web exec playwright test tests/ui/readability.spec.ts --project=chromium-desktop` still passes (contrast ≥ 3:1).
- [ ] `pnpm --filter @skipbo/web exec playwright test tests/ui/theme-contract.spec.ts --project=chromium-desktop` — update baselines if intentional visual drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)