### PR TITLE
chore: switch commit convention from angular to conventional

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -19,7 +19,7 @@ Produce a formatted release-notes draft for the next version by doing the follow
 
 2. **Read context**
    - Read the top 80 lines of `CHANGELOG.md` to confirm scope and format conventions.
-   - Note the Angular conventional commit scopes used: `web`, `realtime-api`, `game-core`,
+   - Note the conventional commit scopes used: `web`, `realtime-api`, `game-core`,
      `multiplayer-protocol`, `ci`, `playwright`, `infra`.
 
 3. **Group commits** by type then by scope:

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,5 +1,5 @@
 {
-  "preset": "angular",
+  "preset": "conventionalcommits",
   "tagPrefix": "v",
   "releaseCommitMessageFormat": "chore(release): {{currentTag}} [skip ci]"
 }

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ['@commitlint/config-angular'],
+  extends: ['@commitlint/config-conventional'],
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.1",
-    "@commitlint/config-angular": "^21.0.1",
+    "@commitlint/config-conventional": "^21.0.1",
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.9.1",
     "@typescript-eslint/eslint-plugin": "^8.59.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
       '@commitlint/cli':
         specifier: ^21.0.1
         version: 21.0.1(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
-      '@commitlint/config-angular':
+      '@commitlint/config-conventional':
         specifier: ^21.0.1
         version: 21.0.1
       '@eslint/js':
@@ -925,12 +925,8 @@ packages:
     engines: {node: '>=22.12.0'}
     hasBin: true
 
-  '@commitlint/config-angular-type-enum@21.0.1':
-    resolution: {integrity: sha512-xTQlgHTaQyXfFpPI3w2dI7ppuTDWmF++1W/kgNohRpxhBzAoJxc6Q/2P7EjvJodtVl7+38xHyu0STtV4ERXdhg==}
-    engines: {node: '>=22.12.0'}
-
-  '@commitlint/config-angular@21.0.1':
-    resolution: {integrity: sha512-3e4HZ1JX8WkotNVuTJ1KYJcjLLkDmj6DCrjx+AFIiAIOUqUjbp1y+498A71J9kFBZIkiMZ45VKwB2yywztLreg==}
+  '@commitlint/config-conventional@21.0.1':
+    resolution: {integrity: sha512-gRorrkfWOh/+V5X8GYWWbQvrzPczopGMS4CCNrQdHkK4xWElv82BDvIsDhJZWTlI7TazOlYea6VATufCsFs+sw==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/config-validator@21.0.1':
@@ -2932,6 +2928,10 @@ packages:
   conventional-changelog-conventionalcommits@6.1.0:
     resolution: {integrity: sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==}
     engines: {node: '>=14'}
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-core@5.0.2:
     resolution: {integrity: sha512-RhQOcDweXNWvlRwUDCpaqXzbZemKPKncCWZG50Alth72WITVd6nhVk9MJ6w1k9PFNBcZ3YwkdkChE+8+ZwtUug==}
@@ -6303,11 +6303,10 @@ snapshots:
       - conventional-commits-parser
       - typescript
 
-  '@commitlint/config-angular-type-enum@21.0.1': {}
-
-  '@commitlint/config-angular@21.0.1':
+  '@commitlint/config-conventional@21.0.1':
     dependencies:
-      '@commitlint/config-angular-type-enum': 21.0.1
+      '@commitlint/types': 21.0.1
+      conventional-changelog-conventionalcommits: 9.3.1
 
   '@commitlint/config-validator@21.0.1':
     dependencies:
@@ -8246,6 +8245,10 @@ snapshots:
   conventional-changelog-config-spec@2.1.0: {}
 
   conventional-changelog-conventionalcommits@6.1.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
## Summary
- Swap `@commitlint/config-angular` → `@commitlint/config-conventional`
- Switch `commit-and-tag-version` preset from `angular` to `conventionalcommits`
- Update release-notes skill wording

## Test plan
- [ ] `pnpm exec commitlint` rejects bad messages and accepts conventional ones
- [ ] Next release generation via `commit-and-tag-version` produces expected changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)