### PR TITLE
fix(drag): allow dragging Skip-Bo wildcard onto discard piles

### DIFF
--- a/apps/web/src/hooks/useDraggableCard.ts
+++ b/apps/web/src/hooks/useDraggableCard.ts
@@ -24,7 +24,7 @@ const computeValidTargets = (card: Card, source: DragSource, gameState: GameStat
     if (canPlayCard(card, i, gameState)) validBuildPiles.add(i);
   }
   const validDiscardPiles = new Set<number>();
-  if (source.kind === 'hand' && !card.isSkipBo) {
+  if (source.kind === 'hand') {
     for (let i = 0; i < gameState.config.DISCARD_PILES_COUNT; i++) {
       validDiscardPiles.add(i);
     }


### PR DESCRIPTION
## Summary
- Remove `!card.isSkipBo` guard in `computeValidTargets` so dragging a Skip-Bo wildcard from hand onto a discard pile is treated as a valid drop target, matching the click-flow behavior.

## Test plan
- [ ] Start a local game, get a Skip-Bo wildcard in hand, drag it onto a discard pile — verify the card lands instead of requiring a click.
- [ ] Drag a regular numbered card onto a discard pile — still works.
- [ ] Click flow for discarding (both Skip-Bo and numbered) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)