### PR TITLE
feat(debug): add button to fill hand with Skip-Bos

### DIFF
--- a/apps/realtime-api/src/services/gameState.ts
+++ b/apps/realtime-api/src/services/gameState.ts
@@ -64,7 +64,10 @@ const isCardSelectable = (gameState: GameState, action: Extract<GameAction, { ty
 };
 
 export const isDebugAction = (action: GameAction): boolean =>
-  action.type === 'DEBUG_SET_AI_HAND' || action.type === 'DEBUG_FILL_BUILD_PILE' || action.type === 'DEBUG_WIN';
+  action.type === 'DEBUG_SET_AI_HAND' ||
+  action.type === 'DEBUG_FILL_BUILD_PILE' ||
+  action.type === 'DEBUG_FILL_HAND_SKIPBO' ||
+  action.type === 'DEBUG_WIN';
 
 const isSupportedOnlineAction = (action: GameAction): boolean => {
   if (
@@ -189,6 +192,7 @@ export const validateOnlineAction = (gameState: GameState, action: GameAction): 
       return 'Cette action n’est pas autorisée en multijoueur';
     case 'DEBUG_SET_AI_HAND':
     case 'DEBUG_FILL_BUILD_PILE':
+    case 'DEBUG_FILL_HAND_SKIPBO':
     case 'DEBUG_WIN':
       return null;
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -138,8 +138,16 @@ function LocalGameScreen({
   onStartOnlineGame,
   updateNotice,
 }: SessionScreenProps) {
-  const { clearSelection, debugFillBuildPile, debugWin, discardCard, gameState, playCard, selectCard } =
-    useLocalSkipBoGame();
+  const {
+    clearSelection,
+    debugFillBuildPile,
+    debugFillHandSkipBo,
+    debugWin,
+    discardCard,
+    gameState,
+    playCard,
+    selectCard,
+  } = useLocalSkipBoGame();
   const gameBoard = (
     <LocalGameBoard
       gameState={gameState}
@@ -153,7 +161,13 @@ function LocalGameScreen({
 
   return (
     <AppShell
-      debugStrip={<DebugStrip debugFillBuildPile={() => debugFillBuildPile(0)} debugWin={debugWin} />}
+      debugStrip={
+        <DebugStrip
+          debugFillBuildPile={() => debugFillBuildPile(0)}
+          debugFillHandSkipBo={debugFillHandSkipBo}
+          debugWin={debugWin}
+        />
+      }
       gameBoard={gameBoard}
       isGameOver={gameState.gameIsOver}
       onJoinOnlineGame={onJoinOnlineGame}
@@ -185,6 +199,7 @@ function OnlineGameScreen({
     connectedSeats,
     connectionStatus,
     debugFillBuildPile,
+    debugFillHandSkipBo,
     debugWin,
     discardCard,
     disconnectedSeats,
@@ -253,7 +268,13 @@ function OnlineGameScreen({
         seatCapacity={seatCapacity}
       />
       <AppShell
-        debugStrip={<DebugStrip debugFillBuildPile={() => debugFillBuildPile(0)} debugWin={debugWin} />}
+        debugStrip={
+          <DebugStrip
+            debugFillBuildPile={() => debugFillBuildPile(0)}
+            debugFillHandSkipBo={debugFillHandSkipBo}
+            debugWin={debugWin}
+          />
+        }
         gameBoard={gameBoard}
         isGameOver={gameState.gameIsOver}
         onJoinOnlineGame={onJoinOnlineGame}

--- a/apps/web/src/components/DebugStrip.tsx
+++ b/apps/web/src/components/DebugStrip.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/ui/button.tsx';
 
 interface DebugStripProps {
   debugFillBuildPile: () => void;
+  debugFillHandSkipBo: () => void;
   debugWin: () => void;
 }
 
@@ -16,6 +17,16 @@ export function DebugStrip(props: DebugStripProps) {
           data-testid="debug-fill-build-pile-button"
         >
           Fill build pile
+        </Button>
+      ) : null}
+      {props.debugFillHandSkipBo ? (
+        <Button
+          variant="destructive"
+          size="xs"
+          onClick={props.debugFillHandSkipBo}
+          data-testid="debug-fill-hand-skipbo-button"
+        >
+          Fill hand Skip-Bo
         </Button>
       ) : null}
       {props.debugWin ? (

--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -719,6 +719,10 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     [sendAction],
   );
 
+  const debugFillHandSkipBo = useCallback((): void => {
+    sendAction({ type: 'DEBUG_FILL_HAND_SKIPBO' });
+  }, [sendAction]);
+
   const debugWin = useCallback((): void => {
     sendAction({ type: 'DEBUG_WIN' });
   }, [sendAction]);
@@ -1093,6 +1097,7 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     connectedSeats,
     connectionStatus,
     debugFillBuildPile,
+    debugFillHandSkipBo,
     debugWin,
     disconnectedSeats,
     gameState,

--- a/apps/web/src/hooks/useSkipBoGame.ts
+++ b/apps/web/src/hooks/useSkipBoGame.ts
@@ -70,6 +70,10 @@ export function useSkipBoGame() {
     [dispatch],
   );
 
+  const debugFillHandSkipBo = useCallback(() => {
+    dispatch({ type: 'DEBUG_FILL_HAND_SKIPBO' });
+  }, [dispatch]);
+
   const debugWin = useCallback(() => {
     dispatch({ type: 'DEBUG_WIN' });
   }, [dispatch]);
@@ -386,6 +390,7 @@ export function useSkipBoGame() {
     gameState: state,
     initializeGame,
     debugFillBuildPile,
+    debugFillHandSkipBo,
     debugWin,
     selectCard,
     playCard,

--- a/apps/web/src/state/gameMachine.ts
+++ b/apps/web/src/state/gameMachine.ts
@@ -110,6 +110,10 @@ export const gameMachine = createMachine(
                 actions: 'apply',
                 guard: 'isHumanAction',
               },
+              DEBUG_FILL_HAND_SKIPBO: {
+                actions: 'apply',
+                guard: 'isHumanAction',
+              },
               RESET: {
                 actions: 'apply',
                 target: '#skipbo.setup',

--- a/packages/game-core/src/state/gameActions.ts
+++ b/packages/game-core/src/state/gameActions.ts
@@ -19,4 +19,5 @@ export type GameAction =
   | { type: 'RESET' }
   | { type: 'DEBUG_SET_AI_HAND'; hand: Card[] }
   | { type: 'DEBUG_FILL_BUILD_PILE'; buildPile: number }
+  | { type: 'DEBUG_FILL_HAND_SKIPBO' }
   | { type: 'DEBUG_WIN' };

--- a/packages/game-core/src/state/gameReducer.ts
+++ b/packages/game-core/src/state/gameReducer.ts
@@ -153,6 +153,17 @@ export const gameReducer = produce((draft: GameState, action: GameAction) => {
       return;
     }
 
+    case 'DEBUG_FILL_HAND_SKIPBO': {
+      const player = draft.players[draft.currentPlayerIndex];
+      player.hand = Array.from({ length: draft.config.HAND_SIZE }, () => ({
+        value: 0,
+        isSkipBo: true,
+      }));
+      draft.selectedCard = null;
+      draft.message = 'Main remplie de Skip-Bo (debug)';
+      return;
+    }
+
     case 'DEBUG_WIN': {
       const winnerIndex = draft.currentPlayerIndex;
       const winner = draft.players[winnerIndex];

--- a/packages/multiplayer-protocol/src/schemas/websocket.ts
+++ b/packages/multiplayer-protocol/src/schemas/websocket.ts
@@ -43,6 +43,7 @@ export const gameActionSchema = z.discriminatedUnion('type', [
     type: z.literal('DEBUG_FILL_BUILD_PILE'),
     buildPile: z.number().int().min(0),
   }),
+  z.object({ type: z.literal('DEBUG_FILL_HAND_SKIPBO') }),
   z.object({ type: z.literal('DEBUG_WIN') }),
 ]);
 


### PR DESCRIPTION
## Summary
- New `DEBUG_FILL_HAND_SKIPBO` game action that replaces the current player's hand with 5 Skip-Bo wildcards
- New **Fill hand Skip-Bo** button in `DebugStrip` (DEV-only), wired into both local and online game screens
- Mirrors the existing `DEBUG_FILL_BUILD_PILE` pattern end-to-end: reducer → protocol schema → realtime-api validator → xstate machine → hooks → UI

## Why
Speeds up manual testing of Skip-Bo wildcard behaviors (placement on any build pile, discard-pile drops, etc.) without having to replay until a Skip-Bo is dealt.

## Test plan
- [x] `pnpm typecheck` passes across all 4 packages
- [x] Verified in browser: clicking the button replaces the hand with 5 Skip-Bo cards and sets the status message "Main remplie de Skip-Bo (debug)"
- [ ] Smoke-test in online mode (server already allows debug actions when `NODE_ENV !== 'production'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)