### PR TITLE
fix(release): drop explicit conventionalcommits preset

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,5 +1,4 @@
 {
-  "preset": "conventionalcommits",
   "tagPrefix": "v",
   "releaseCommitMessageFormat": "chore(release): {{currentTag}} [skip ci]"
 }


### PR DESCRIPTION
## Summary

- Removes `"preset": "conventionalcommits"` from `.versionrc.json`.
- Fixes the Deploy workflow's `release` job silently skipping version bumps since commit `49746a1` (switch from angular → conventionalcommits).

## Why

`commit-and-tag-version@12.7.3` already bundles `conventional-changelog-conventionalcommits@6.1.0`, but its [`preset-loader.js`](https://github.com/absolute-version/commit-and-tag-version/blob/v12.7.3/lib/preset-loader.js) only resolves the preset to a full package path when **no** `preset` is configured. With `"preset": "conventionalcommits"` set, the bare string was passed to `conventional-recommended-bump`, which couldn't resolve it and silently returned zero commits → `✔ no commits found, so not bumping version` → no release commit, no tag.

Effect on production: the Deploy workflow kept running on every merge, but `git describe --tags --abbrev=0` stayed at `v1.38.0`, so `VITE_APP_VERSION` and the Sentry release never advanced even though five PRs had landed.

The default preset is already `conventionalcommits` — removing the key takes the code path that resolves to the bundled package, which works.

## Test plan

- [x] `pnpm release:dry-run` now reports `bumping version in package.json from 1.38.0 to 1.39.0` with the expected `feat:` and `fix:` entries from commits since `v1.38.0`.
- [ ] After merge, the Deploy workflow's `release` job creates `v1.39.0` (or higher) and pushes the tag.
- [ ] `VITE_APP_VERSION` on the deployed PWA reflects the new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)