### PR TITLE
feat: add clear stock pile debug buttons

### DIFF
--- a/apps/realtime-api/src/services/gameState.ts
+++ b/apps/realtime-api/src/services/gameState.ts
@@ -67,6 +67,8 @@ export const isDebugAction = (action: GameAction): boolean =>
   action.type === 'DEBUG_SET_AI_HAND' ||
   action.type === 'DEBUG_FILL_BUILD_PILE' ||
   action.type === 'DEBUG_FILL_HAND_SKIPBO' ||
+  action.type === 'DEBUG_CLEAR_STOCK_PILE' ||
+  action.type === 'DEBUG_CLEAR_AI_STOCK_PILE' ||
   action.type === 'DEBUG_WIN';
 
 const isSupportedOnlineAction = (action: GameAction): boolean => {
@@ -193,6 +195,8 @@ export const validateOnlineAction = (gameState: GameState, action: GameAction): 
     case 'DEBUG_SET_AI_HAND':
     case 'DEBUG_FILL_BUILD_PILE':
     case 'DEBUG_FILL_HAND_SKIPBO':
+    case 'DEBUG_CLEAR_STOCK_PILE':
+    case 'DEBUG_CLEAR_AI_STOCK_PILE':
     case 'DEBUG_WIN':
       return null;
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -142,6 +142,8 @@ function LocalGameScreen({
     clearSelection,
     debugFillBuildPile,
     debugFillHandSkipBo,
+    debugClearStockPile,
+    debugClearAiStockPile,
     debugWin,
     discardCard,
     gameState,
@@ -165,6 +167,8 @@ function LocalGameScreen({
         <DebugStrip
           debugFillBuildPile={() => debugFillBuildPile(0)}
           debugFillHandSkipBo={debugFillHandSkipBo}
+          debugClearStockPile={debugClearStockPile}
+          debugClearAiStockPile={debugClearAiStockPile}
           debugWin={debugWin}
         />
       }
@@ -200,6 +204,8 @@ function OnlineGameScreen({
     connectionStatus,
     debugFillBuildPile,
     debugFillHandSkipBo,
+    debugClearStockPile,
+    debugClearAiStockPile,
     debugWin,
     discardCard,
     disconnectedSeats,
@@ -272,6 +278,8 @@ function OnlineGameScreen({
           <DebugStrip
             debugFillBuildPile={() => debugFillBuildPile(0)}
             debugFillHandSkipBo={debugFillHandSkipBo}
+            debugClearStockPile={debugClearStockPile}
+            debugClearAiStockPile={debugClearAiStockPile}
             debugWin={debugWin}
           />
         }

--- a/apps/web/src/components/DebugStrip.tsx
+++ b/apps/web/src/components/DebugStrip.tsx
@@ -3,6 +3,8 @@ import { Button } from '@/components/ui/button.tsx';
 interface DebugStripProps {
   debugFillBuildPile: () => void;
   debugFillHandSkipBo: () => void;
+  debugClearStockPile: () => void;
+  debugClearAiStockPile: () => void;
   debugWin: () => void;
 }
 
@@ -27,6 +29,26 @@ export function DebugStrip(props: DebugStripProps) {
           data-testid="debug-fill-hand-skipbo-button"
         >
           Fill hand Skip-Bo
+        </Button>
+      ) : null}
+      {props.debugClearStockPile ? (
+        <Button
+          variant="destructive"
+          size="xs"
+          onClick={props.debugClearStockPile}
+          data-testid="debug-clear-stock-pile-button"
+        >
+          Clear stock pile
+        </Button>
+      ) : null}
+      {props.debugClearAiStockPile ? (
+        <Button
+          variant="destructive"
+          size="xs"
+          onClick={props.debugClearAiStockPile}
+          data-testid="debug-clear-ai-stock-pile-button"
+        >
+          Clear AI stock pile
         </Button>
       ) : null}
       {props.debugWin ? (

--- a/apps/web/src/components/player-area/StockPile.tsx
+++ b/apps/web/src/components/player-area/StockPile.tsx
@@ -52,7 +52,7 @@ export function StockPile({
     <div className="flex items-center relative gap-2" style={{ '--card-rotate': '0deg' } as CSSProperties}>
       <h2 className="vertical-text">Talon ({player.stockPile.length})</h2>
       {player.stockPile.length > 0 ? (
-        <div className="relative w-(--card-width) stock-pile">
+        <div className="relative h-card w-(--card-width) stock-pile">
           {/* Placeholder slot behind the stock top card so the slot stays
             visible while the top card is animating to a build / discard
             pile. The label is hidden because there's a real card on top in

--- a/apps/web/src/components/player-area/StockPile.tsx
+++ b/apps/web/src/components/player-area/StockPile.tsx
@@ -52,7 +52,7 @@ export function StockPile({
     <div className="flex items-center relative gap-2" style={{ '--card-rotate': '0deg' } as CSSProperties}>
       <h2 className="vertical-text">Talon ({player.stockPile.length})</h2>
       {player.stockPile.length > 0 ? (
-        <div className="relative h-card w-(--card-width) stock-pile">
+        <div className="relative h-card w-card stock-pile">
           {/* Placeholder slot behind the stock top card so the slot stays
             visible while the top card is animating to a build / discard
             pile. The label is hidden because there's a real card on top in

--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -494,6 +494,14 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     sendAction({ type: 'DEBUG_FILL_HAND_SKIPBO' });
   }, [sendAction]);
 
+  const debugClearStockPile = useCallback((): void => {
+    sendAction({ type: 'DEBUG_CLEAR_STOCK_PILE' });
+  }, [sendAction]);
+
+  const debugClearAiStockPile = useCallback((): void => {
+    sendAction({ type: 'DEBUG_CLEAR_AI_STOCK_PILE' });
+  }, [sendAction]);
+
   const debugWin = useCallback((): void => {
     sendAction({ type: 'DEBUG_WIN' });
   }, [sendAction]);
@@ -869,6 +877,8 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     connectionStatus,
     debugFillBuildPile,
     debugFillHandSkipBo,
+    debugClearStockPile,
+    debugClearAiStockPile,
     debugWin,
     disconnectedSeats,
     gameState,

--- a/apps/web/src/hooks/useSkipBoGame.ts
+++ b/apps/web/src/hooks/useSkipBoGame.ts
@@ -74,6 +74,14 @@ export function useSkipBoGame() {
     dispatch({ type: 'DEBUG_FILL_HAND_SKIPBO' });
   }, [dispatch]);
 
+  const debugClearStockPile = useCallback(() => {
+    dispatch({ type: 'DEBUG_CLEAR_STOCK_PILE' });
+  }, [dispatch]);
+
+  const debugClearAiStockPile = useCallback(() => {
+    dispatch({ type: 'DEBUG_CLEAR_AI_STOCK_PILE' });
+  }, [dispatch]);
+
   const debugWin = useCallback(() => {
     dispatch({ type: 'DEBUG_WIN' });
   }, [dispatch]);
@@ -391,6 +399,8 @@ export function useSkipBoGame() {
     initializeGame,
     debugFillBuildPile,
     debugFillHandSkipBo,
+    debugClearStockPile,
+    debugClearAiStockPile,
     debugWin,
     selectCard,
     playCard,

--- a/apps/web/src/state/gameMachine.ts
+++ b/apps/web/src/state/gameMachine.ts
@@ -114,6 +114,16 @@ export const gameMachine = createMachine(
                 actions: 'apply',
                 guard: 'isHumanAction',
               },
+              DEBUG_CLEAR_STOCK_PILE: {
+                actions: 'apply',
+                guard: 'isHumanAction',
+              },
+              DEBUG_CLEAR_AI_STOCK_PILE: {
+                // Reducer empties the AI stock to a single Skip-Bo and hands the
+                // turn to the AI; route into botTurn so it plays that card and wins.
+                actions: 'apply',
+                target: '#skipbo.botTurn',
+              },
               RESET: {
                 actions: 'apply',
                 target: '#skipbo.setup',

--- a/packages/game-core/src/state/gameActions.ts
+++ b/packages/game-core/src/state/gameActions.ts
@@ -20,4 +20,6 @@ export type GameAction =
   | { type: 'DEBUG_SET_AI_HAND'; hand: Card[] }
   | { type: 'DEBUG_FILL_BUILD_PILE'; buildPile: number }
   | { type: 'DEBUG_FILL_HAND_SKIPBO' }
+  | { type: 'DEBUG_CLEAR_STOCK_PILE' }
+  | { type: 'DEBUG_CLEAR_AI_STOCK_PILE' }
   | { type: 'DEBUG_WIN' };

--- a/packages/game-core/src/state/gameReducer.ts
+++ b/packages/game-core/src/state/gameReducer.ts
@@ -161,6 +161,29 @@ export const gameReducer = produce((draft: GameState, action: GameAction) => {
       return;
     }
 
+    case 'DEBUG_CLEAR_STOCK_PILE': {
+      const player = draft.players[0];
+      player.stockPile = [{ value: 0, isSkipBo: true }];
+      draft.selectedCard = null;
+      draft.message = 'Pile de réserve vidée (debug)';
+      return;
+    }
+
+    case 'DEBUG_CLEAR_AI_STOCK_PILE': {
+      const aiIndex = draft.players.findIndex((p) => p.isAI);
+      if (aiIndex === -1) {
+        draft.message = MESSAGES.INVALID_MOVE;
+        return;
+      }
+
+      draft.players[aiIndex].stockPile = [{ value: 0, isSkipBo: true }];
+      // Hand the turn to the AI so it plays its last stock card and wins.
+      draft.currentPlayerIndex = aiIndex;
+      draft.selectedCard = null;
+      draft.message = 'Pile de réserve IA vidée (debug)';
+      return;
+    }
+
     case 'DEBUG_WIN': {
       const winnerIndex = draft.currentPlayerIndex;
       const winner = draft.players[winnerIndex];

--- a/packages/multiplayer-protocol/src/schemas/websocket.ts
+++ b/packages/multiplayer-protocol/src/schemas/websocket.ts
@@ -44,6 +44,8 @@ export const gameActionSchema = z.discriminatedUnion('type', [
     buildPile: z.number().int().min(0),
   }),
   z.object({ type: z.literal('DEBUG_FILL_HAND_SKIPBO') }),
+  z.object({ type: z.literal('DEBUG_CLEAR_STOCK_PILE') }),
+  z.object({ type: z.literal('DEBUG_CLEAR_AI_STOCK_PILE') }),
   z.object({ type: z.literal('DEBUG_WIN') }),
 ]);
 


### PR DESCRIPTION
## Summary

Adds two debug buttons to the `DebugStrip` (DEV-only, local + online screens) and fixes a stock-pile animation layout bug.

- **Clear stock pile** (`DEBUG_CLEAR_STOCK_PILE`) — reduces the human stock to a single Skip-Bo card.
- **Clear AI stock pile** (`DEBUG_CLEAR_AI_STOCK_PILE`) — reduces the AI stock to a single Skip-Bo and hands the turn to the AI so it plays that last card and wins. The `gameMachine` routes into `botTurn` after applying the action.

Both actions are wired through every tier: `game-core` (`gameActions` + reducer), `multiplayer-protocol` (`gameActionSchema`), `realtime-api` (`isDebugAction` + `validateOnlineAction`), and the web hooks/UI. In online multiplayer there's no AI player, so `DEBUG_CLEAR_AI_STOCK_PILE` no-ops gracefully.

## Bug fix

While the AI played its **last** stock card, the stock-pile slot collapsed to height 0 (the animating branch renders no in-flow child when length is 1), so the `absolute inset-0` placeholder `EmptyCard` dropped to the flex row's vertical center — appearing to slide down ~a card height. The container now keeps a fixed `h-card` height.

Verified live: the placeholder holds steady (`top: 78, height: 100`) across every animation frame, and the AI still plays its card and wins.

## Validation

- `pnpm typecheck`, `pnpm lint` clean
- Unit tests pass: game-core (10), protocol (11), realtime-api (18), web (192)
- Visual regression: 150 tests pass (desktop + mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)