### PR TITLE
fix(web): harden PWA auto-update for local games and victory screens

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -373,12 +373,19 @@ function LiveApp() {
   }, [waitForAnimations]);
 
   const startLocalGame = () => {
-    // Starting a fresh local game is a lossless moment to apply a pending update:
-    // the reload boots straight into a new local game, so the intent is honoured.
-    // Hard updates were deferred while in local mode — apply them here too.
-    if (isUpdatePending || isHardUpdateRequired) {
+    // A required hard update was deferred while in local mode — apply it now and
+    // abort the start (the reload boots into a fresh local game).
+    if (isHardUpdateRequired) {
       reloadToUpdate();
       return;
+    }
+
+    // Starting a fresh local game is a lossless moment to apply a pending soft
+    // update — but the `runtime:` channel can report a version before the service
+    // worker has staged it, in which case `reloadToUpdate()` is a no-op. Fire it
+    // and still start the game so a lagging SW can't leave "New Game" stuck.
+    if (isUpdatePending) {
+      reloadToUpdate();
     }
 
     setCurrentGameType('local-ai');

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -250,8 +250,10 @@ function OnlineGameScreen({
   // Online state is rebuilt from the server snapshot after a reload, so applying
   // a pending update is lossless. Only do it at a "safe" moment — never while it
   // is the local player's active turn (index 0 in the recentred view), to avoid
-  // cutting off an in-progress action.
-  const isSafeToApplyUpdate = roomStatus === 'WAITING' || gameState.gameIsOver || gameState.currentPlayerIndex !== 0;
+  // cutting off an in-progress action, and never on a finished game so the
+  // victory/defeat screen is preserved. The update then lands during an
+  // opponent's turn, in the next lobby, or on the user's next deliberate action.
+  const isSafeToApplyUpdate = !gameState.gameIsOver && (roomStatus === 'WAITING' || gameState.currentPlayerIndex !== 0);
 
   useEffect(() => {
     if (isUpdatePending && isSafeToApplyUpdate) {
@@ -349,6 +351,10 @@ function LiveApp() {
   const [pendingResumeSession, setPendingResumeSession] = useState<CreateRoomResponse | null>(() =>
     loadOnlineSession(),
   );
+  // A local single-player game can't be rebuilt after a reload, so we hold off the
+  // blocking minimum-version auto-reload while in local mode and apply it on the
+  // next deliberate action instead (see the game-start handlers below).
+  const isLocalMode = currentGameType === 'local-ai';
   const {
     applyUpdateOnceForCurrentTarget,
     currentAppVersion,
@@ -360,7 +366,7 @@ function LiveApp() {
     latestAppVersion,
     minimumSupportedVersion,
     reloadToUpdate,
-  } = usePwaVersionGate();
+  } = usePwaVersionGate({ deferHardUpdate: isLocalMode });
 
   useEffect(() => {
     animationServiceBridge.waitForAnimations = waitForAnimations;
@@ -369,7 +375,8 @@ function LiveApp() {
   const startLocalGame = () => {
     // Starting a fresh local game is a lossless moment to apply a pending update:
     // the reload boots straight into a new local game, so the intent is honoured.
-    if (isUpdatePending) {
+    // Hard updates were deferred while in local mode — apply them here too.
+    if (isUpdatePending || isHardUpdateRequired) {
       reloadToUpdate();
       return;
     }
@@ -379,6 +386,13 @@ function LiveApp() {
   };
 
   const startOnlineGame = async (stockSize = getStoredStockSize()) => {
+    // Never contact the server on a build below the protocol floor — apply the
+    // deferred hard update first (the reload aborts this start).
+    if (isHardUpdateRequired) {
+      reloadToUpdate();
+      return;
+    }
+
     const session = await createOnlineRoom(stockSize);
     saveOnlineSession(session);
     setPendingResumeSession(null);
@@ -387,6 +401,11 @@ function LiveApp() {
   };
 
   const joinGame = async (roomCode: string) => {
+    if (isHardUpdateRequired) {
+      reloadToUpdate();
+      return;
+    }
+
     const session = await joinOnlineRoom(roomCode);
     saveOnlineSession(session);
     setPendingResumeSession(null);
@@ -470,7 +489,7 @@ function LiveApp() {
   return (
     <>
       {screen}
-      {isHardUpdateRequired && minimumSupportedVersion ? (
+      {isHardUpdateRequired && !isLocalMode && minimumSupportedVersion ? (
         <ForcedUpdateOverlay
           currentVersion={currentAppVersion}
           isReloading={isApplyingUpdate}

--- a/apps/web/src/config/timing.ts
+++ b/apps/web/src/config/timing.ts
@@ -13,3 +13,9 @@ export const DISCONNECT_GRACE_MS = 5 * 60 * 1000;
 // How often usePwaVersionGate polls runtime-config + the service worker to
 // detect that a new web release has been deployed.
 export const PWA_UPDATE_CHECK_INTERVAL_MS = 10 * 60 * 1000;
+
+// Minimum gap between event-driven update rechecks (visibility/pageshow/online).
+// Mobile app-switching fires these in bursts; this throttle collapses redundant
+// `registration.update()` + runtime-config fetches. The periodic poll above is
+// unaffected.
+export const PWA_UPDATE_RECHECK_MIN_INTERVAL_MS = 30 * 1000;

--- a/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
@@ -43,13 +43,21 @@ vi.mock('@/lib/pwaUpdates', () => ({
   },
 }));
 
+import { PWA_UPDATE_RECHECK_MIN_INTERVAL_MS } from '@/config/timing';
+
 import { AUTO_RELOAD_SESSION_STORAGE_KEY, usePwaVersionGate } from '../usePwaVersionGate';
+
+// Throttling keys off Date.now; freeze it so tests advance the clock explicitly.
+let currentTime = 0;
 
 describe('usePwaVersionGate', () => {
   beforeEach(() => {
     fetchRuntimeConfigMock.mockReset();
     applyServiceWorkerUpdateMock.mockReset();
     refreshServiceWorkerRegistrationMock.mockReset();
+
+    currentTime = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
 
     pwaSnapshot = {
       needRefresh: false,
@@ -73,6 +81,7 @@ describe('usePwaVersionGate', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -125,6 +134,7 @@ describe('usePwaVersionGate', () => {
 
     fetchRuntimeConfigMock.mockResolvedValue({ appVersion: 'v1.2.0', minimumSupportedVersion: 'v1.1.0' });
 
+    currentTime += PWA_UPDATE_RECHECK_MIN_INTERVAL_MS;
     act(() => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
@@ -258,6 +268,7 @@ describe('usePwaVersionGate', () => {
       expect(fetchRuntimeConfigMock).toHaveBeenCalledTimes(1);
     });
 
+    currentTime += PWA_UPDATE_RECHECK_MIN_INTERVAL_MS;
     act(() => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
@@ -268,6 +279,77 @@ describe('usePwaVersionGate', () => {
 
     await waitFor(() => {
       expect(result.current.latestAppVersion).toBe('v1.1.0');
+    });
+  });
+
+  it('throttles event-driven rechecks within the minimum interval', async () => {
+    const { result } = renderHook(() => usePwaVersionGate());
+
+    await waitFor(() => {
+      expect(fetchRuntimeConfigMock).toHaveBeenCalledTimes(1);
+    });
+
+    // A focus event inside the throttle window is collapsed — no extra fetch.
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    await Promise.resolve();
+    expect(fetchRuntimeConfigMock).toHaveBeenCalledTimes(1);
+
+    // Past the window, the next event re-checks.
+    fetchRuntimeConfigMock.mockResolvedValue({ appVersion: 'v1.1.0' });
+    currentTime += PWA_UPDATE_RECHECK_MIN_INTERVAL_MS;
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => {
+      expect(fetchRuntimeConfigMock).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(result.current.latestAppVersion).toBe('v1.1.0');
+    });
+  });
+
+  it('does not auto-reload a required hard update while it is deferred', async () => {
+    fetchRuntimeConfigMock.mockResolvedValue({
+      appVersion: 'v1.2.0',
+      minimumSupportedVersion: 'v1.1.0',
+    });
+
+    const { result } = renderHook(() => usePwaVersionGate({ deferHardUpdate: true }));
+
+    await waitFor(() => {
+      expect(result.current.isHardUpdateRequired).toBe(true);
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(applyServiceWorkerUpdateMock).not.toHaveBeenCalled();
+    expect(globalThis.sessionStorage?.getItem(AUTO_RELOAD_SESSION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('applies the deferred hard update once it is no longer deferred', async () => {
+    fetchRuntimeConfigMock.mockResolvedValue({
+      appVersion: 'v1.2.0',
+      minimumSupportedVersion: 'v1.1.0',
+    });
+    applyServiceWorkerUpdateMock.mockResolvedValue(true);
+
+    const { result, rerender } = renderHook(({ deferHardUpdate }) => usePwaVersionGate({ deferHardUpdate }), {
+      initialProps: { deferHardUpdate: true },
+    });
+
+    await waitFor(() => {
+      expect(result.current.isHardUpdateRequired).toBe(true);
+    });
+    expect(applyServiceWorkerUpdateMock).not.toHaveBeenCalled();
+
+    rerender({ deferHardUpdate: false });
+
+    await waitFor(() => {
+      expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/web/src/hooks/usePwaVersionGate.ts
+++ b/apps/web/src/hooks/usePwaVersionGate.ts
@@ -9,7 +9,7 @@ import {
 } from '@/lib/pwaUpdates';
 import { fetchRuntimeConfig } from '@/lib/runtimeConfig';
 import { compareAppVersions, normalizeVersionTag } from '@/lib/versionUtils';
-import { PWA_UPDATE_CHECK_INTERVAL_MS } from '@/config/timing';
+import { PWA_UPDATE_CHECK_INTERVAL_MS, PWA_UPDATE_RECHECK_MIN_INTERVAL_MS } from '@/config/timing';
 export const AUTO_RELOAD_SESSION_STORAGE_KEY = 'skipbo:pwa-auto-reload-version';
 export const SOFT_AUTO_RELOAD_SESSION_STORAGE_KEY = 'skipbo:pwa-soft-auto-reload-key';
 export const LAST_SEEN_VERSION_STORAGE_KEY = 'skipbo:last-seen-version';
@@ -85,7 +85,16 @@ export interface PwaVersionGateState {
   shouldShowSoftUpdate: boolean;
 }
 
-export const usePwaVersionGate = (): PwaVersionGateState => {
+export interface UsePwaVersionGateOptions {
+  // While true, the blocking minimum-version auto-reload is held off. Local
+  // single-player games aren't reconstructable after a reload (unlike online,
+  // which rebuilds from the server snapshot) and the protocol floor only matters
+  // for multiplayer, so the caller defers the hard update until a lossless moment
+  // (new game / replay / going online) and applies it imperatively there.
+  deferHardUpdate?: boolean;
+}
+
+export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGateOptions = {}): PwaVersionGateState => {
   const [dismissedUpdateKey, setDismissedUpdateKey] = useState<string | null>(null);
   const [isApplyingUpdate, setIsApplyingUpdate] = useState(false);
   const [justUpdatedFromVersion, setJustUpdatedFromVersion] = useState<string | null>(() => {
@@ -98,9 +107,14 @@ export const usePwaVersionGate = (): PwaVersionGateState => {
     lastCheckAt: null,
   });
   const isApplyingUpdateRef = useRef(false);
+  const lastCheckAtRef = useRef(0);
   const pwaUpdateSnapshot = useSyncExternalStore(subscribeToPwaUpdates, getPwaUpdateSnapshot, getPwaUpdateSnapshot);
 
   const checkForUpdates = useEffectEvent(async () => {
+    // Stamp before the awaits so a burst of focus events throttles against this
+    // in-flight check rather than only against the previous completed one.
+    lastCheckAtRef.current = Date.now();
+
     await refreshServiceWorkerRegistration().catch(() => undefined);
 
     const runtimeConfig = await fetchRuntimeConfig({ force: true });
@@ -154,6 +168,12 @@ export const usePwaVersionGate = (): PwaVersionGateState => {
       return;
     }
 
+    // Collapse bursts of visibility/pageshow/online events (common on mobile
+    // app-switching) into one network round-trip per throttle window.
+    if (Date.now() - lastCheckAtRef.current < PWA_UPDATE_RECHECK_MIN_INTERVAL_MS) {
+      return;
+    }
+
     void checkForUpdates();
   });
 
@@ -175,6 +195,12 @@ export const usePwaVersionGate = (): PwaVersionGateState => {
   const isHardUpdateRequired = runtimeVersionSnapshot.minimumSupportedVersion
     ? compareAppVersions(APP_VERSION, runtimeVersionSnapshot.minimumSupportedVersion) < 0
     : false;
+  // The `runtime:` key can be pending before the service worker has fetched the
+  // new build: `applyServiceWorkerUpdate` then finds no waiting worker and
+  // returns false (no reload), logging `pwa.apply-update.no-waiting-worker`. This
+  // self-heals — once the worker catches up, `needRefresh` flips the key to
+  // `service-worker:` and apply succeeds — and the per-key soft guard below keeps
+  // it from reload-looping in the meantime.
   const updateKey = isHardUpdateRequired
     ? `minimum:${runtimeVersionSnapshot.minimumSupportedVersion}`
     : pwaUpdateSnapshot.needRefresh
@@ -218,6 +244,13 @@ export const usePwaVersionGate = (): PwaVersionGateState => {
       return;
     }
 
+    // The caller is in a state where an automatic reload would be destructive
+    // (e.g. an in-progress local game). Hold off — it will apply the update at a
+    // lossless moment. Lifting the defer re-runs this effect via the dep below.
+    if (deferHardUpdate) {
+      return;
+    }
+
     // sessionStorage survives `location.reload()`, so this guard keeps a single
     // tab from re-auto-triggering the flow for the same minimum version after
     // a reload — required retries must come from `ForcedUpdateOverlay`.
@@ -227,7 +260,7 @@ export const usePwaVersionGate = (): PwaVersionGateState => {
 
     writeAutoReloadVersion(runtimeVersionSnapshot.minimumSupportedVersion);
     void reloadToUpdate();
-  }, [isHardUpdateRequired, runtimeVersionSnapshot.minimumSupportedVersion]);
+  }, [deferHardUpdate, isHardUpdateRequired, runtimeVersionSnapshot.minimumSupportedVersion]);
 
   return {
     currentAppVersion: APP_VERSION,

--- a/apps/web/src/lib/__tests__/pwaUpdates.test.ts
+++ b/apps/web/src/lib/__tests__/pwaUpdates.test.ts
@@ -17,6 +17,16 @@ vi.mock('virtual:pwa-register', () => ({
   },
 }));
 
+const sentryAddBreadcrumb = vi.fn();
+const sentryCaptureException = vi.fn();
+const sentryCaptureMessage = vi.fn();
+
+vi.mock('@sentry/react', () => ({
+  addBreadcrumb: (...args: unknown[]) => sentryAddBreadcrumb(...args),
+  captureException: (...args: unknown[]) => sentryCaptureException(...args),
+  captureMessage: (...args: unknown[]) => sentryCaptureMessage(...args),
+}));
+
 class FakeServiceWorker extends EventTarget implements Partial<ServiceWorker> {
   state: ServiceWorkerState = 'installing';
 
@@ -51,6 +61,9 @@ describe('pwaUpdates', () => {
   beforeEach(() => {
     updateServiceWorkerMock.mockReset();
     updateServiceWorkerMock.mockResolvedValue(undefined);
+    sentryAddBreadcrumb.mockClear();
+    sentryCaptureException.mockClear();
+    sentryCaptureMessage.mockClear();
   });
 
   afterEach(() => {
@@ -69,6 +82,27 @@ describe('pwaUpdates', () => {
     expect(registration.update).toHaveBeenCalledTimes(1);
     expect(updateServiceWorkerMock).not.toHaveBeenCalled();
     expect(applied).toBe(false);
+    expect(sentryCaptureMessage).toHaveBeenCalledWith('pwa.apply-update.no-waiting-worker', 'warning');
+  });
+
+  it('reports a captured exception when the registration update rejects', async () => {
+    const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
+    initializePwaUpdates();
+
+    const registration = buildFakeRegistration();
+    const updateError = new Error('network down');
+    registration.update.mockRejectedValue(updateError);
+    registration.waiting = new FakeServiceWorker();
+    registration.waiting.state = 'installed';
+
+    registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
+
+    const applied = await applyServiceWorkerUpdate();
+
+    expect(sentryCaptureException).toHaveBeenCalledWith(updateError);
+    // A waiting worker is still present, so the update is applied despite the
+    // failed `registration.update()` refresh.
+    expect(applied).toBe(true);
   });
 
   it('waits for an installing worker to finish before applying the update', async () => {
@@ -153,5 +187,6 @@ describe('pwaUpdates', () => {
 
     expect(updateServiceWorkerMock).not.toHaveBeenCalled();
     expect(applied).toBe(false);
+    expect(sentryCaptureMessage).toHaveBeenCalledWith('pwa.apply-update.install-timeout', 'warning');
   });
 });

--- a/apps/web/src/lib/pwaUpdates.ts
+++ b/apps/web/src/lib/pwaUpdates.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import { registerSW } from 'virtual:pwa-register';
 
 type Listener = () => void;
@@ -57,6 +58,7 @@ export const initializePwaUpdates = () => {
       });
     },
     onRegisterError(error) {
+      Sentry.captureException(toRegistrationError(error));
       updateSnapshot({ registrationError: toRegistrationError(error) });
     },
   });
@@ -77,17 +79,19 @@ export const refreshServiceWorkerRegistration = async (): Promise<void> => {
 
 const SERVICE_WORKER_INSTALL_TIMEOUT_MS = 8000;
 
-const waitForInstallingWorker = (worker: ServiceWorker, timeoutMs: number): Promise<void> =>
-  new Promise<void>((resolve) => {
+type InstallWaitResult = 'settled' | 'timeout';
+
+const waitForInstallingWorker = (worker: ServiceWorker, timeoutMs: number): Promise<InstallWaitResult> =>
+  new Promise<InstallWaitResult>((resolve) => {
     if (worker.state !== 'installing') {
-      resolve();
+      resolve('settled');
       return;
     }
 
     const handleStateChange = () => {
       if (worker.state !== 'installing') {
         cleanup();
-        resolve();
+        resolve('settled');
       }
     };
 
@@ -98,7 +102,7 @@ const waitForInstallingWorker = (worker: ServiceWorker, timeoutMs: number): Prom
 
     const timeoutId = globalThis.setTimeout(() => {
       cleanup();
-      resolve();
+      resolve('timeout');
     }, timeoutMs);
 
     worker.addEventListener('statechange', handleStateChange);
@@ -110,13 +114,20 @@ export const applyServiceWorkerUpdate = async (): Promise<boolean> => {
     return false;
   }
 
-  await registration.update().catch(() => undefined);
+  Sentry.addBreadcrumb({ category: 'pwa', message: 'apply-update:start', level: 'info' });
+
+  await registration.update().catch((error: unknown) => {
+    Sentry.captureException(error);
+  });
 
   // `registration.update()` resolves before a freshly fetched worker leaves
   // `installing`. Wait it out so the `waiting`/`needRefresh` check below
   // doesn't false-negative and skip an available update.
   if (registration.installing) {
-    await waitForInstallingWorker(registration.installing, SERVICE_WORKER_INSTALL_TIMEOUT_MS);
+    const installResult = await waitForInstallingWorker(registration.installing, SERVICE_WORKER_INSTALL_TIMEOUT_MS);
+    if (installResult === 'timeout') {
+      Sentry.captureMessage('pwa.apply-update.install-timeout', 'warning');
+    }
   }
 
   if (snapshot.needRefresh || registration.waiting) {
@@ -124,5 +135,10 @@ export const applyServiceWorkerUpdate = async (): Promise<boolean> => {
     return true;
   }
 
+  // No worker is staged yet: this is the runtime-config channel advertising a
+  // version the service worker hasn't fetched (see usePwaVersionGate's updateKey
+  // self-heal note). The caller's per-key guard prevents a reload loop; surface
+  // it so a genuinely stuck client is visible in telemetry rather than silent.
+  Sentry.captureMessage('pwa.apply-update.no-waiting-worker', 'warning');
   return false;
 };

--- a/apps/web/src/lib/pwaUpdates.ts
+++ b/apps/web/src/lib/pwaUpdates.ts
@@ -58,8 +58,9 @@ export const initializePwaUpdates = () => {
       });
     },
     onRegisterError(error) {
-      Sentry.captureException(toRegistrationError(error));
-      updateSnapshot({ registrationError: toRegistrationError(error) });
+      const registrationError = toRegistrationError(error);
+      Sentry.captureException(registrationError);
+      updateSnapshot({ registrationError });
     },
   });
 };


### PR DESCRIPTION
## Summary

Closes five gaps in the PWA auto-update pipeline ([`pwaUpdates.ts`](apps/web/src/lib/pwaUpdates.ts), [`usePwaVersionGate.ts`](apps/web/src/hooks/usePwaVersionGate.ts), [`App.tsx`](apps/web/src/App.tsx)):

1. **Forced updates no longer wipe an in-progress local game.** `usePwaVersionGate` accepts `{ deferHardUpdate }`; App defers while `isLocalMode`, gates the `ForcedUpdateOverlay`, and applies the update at lossless moments (new game / replay, and before any online room create/join).
2. **Throttled event-driven rechecks** — new `PWA_UPDATE_RECHECK_MIN_INTERVAL_MS` (30s) collapses bursts of visibility/pageshow/online events; the 10-min poll is unaffected.
3. **Online victory screen preserved** — `isSafeToApplyUpdate` no longer fires on `gameIsOver`, so a finished match never reloads on the victory/defeat screen.
4. **Sentry telemetry** — breadcrumb on apply start; `captureException` on update/registration errors; `captureMessage` warnings for `install-timeout` and `no-waiting-worker`.
5. **Documented self-heal** — the `runtime:` → `service-worker:` updateKey transition is now commented and observable via the `no-waiting-worker` warning.

## Test plan

- `pnpm --filter @skipbo/web test` — 200 pass, incl. new cases (defer suppress/lift, recheck throttle, Sentry no-waiting-worker / install-timeout / captureException).
- `pnpm --filter @skipbo/web typecheck` & `lint` — clean.
- Manual (prod build + `runtime-config.json` tweaks): a hard update during a local game shows no overlay and no reload until the user starts a new game / goes online; a pending update at the end of an online match leaves the victory screen intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)