### PR TITLE
fix(web): reset neon stock glow by remounting card on value change

### DIFF
--- a/apps/web/src/components/player-area/StockPile.tsx
+++ b/apps/web/src/components/player-area/StockPile.tsx
@@ -26,8 +26,7 @@ const isHiddenMultiplayerCard = (card: CardType | null | undefined): card is Car
 // renders, so a value-bound key forces React to remount when the revealed card
 // changes — restarting per-value CSS animations (e.g. neon's `neonTextPulse`,
 // whose glow uses `currentColor`). Without the remount, WebKit keeps the
-// previous card's glow color (a magenta 5–8 glow lingering on a blue 9–12), so
-// the freshly revealed card shows the wrong-colored halo.
+// previous card's glow color: a magenta 5–8 glow lingering on a blue 9–12.
 const stockCardIdentityKey = (card: CardType | null | undefined): string =>
   card ? (card.isSkipBo ? 'skipbo' : `v${card.value}`) : 'empty';
 

--- a/apps/web/src/components/player-area/StockPile.tsx
+++ b/apps/web/src/components/player-area/StockPile.tsx
@@ -22,6 +22,15 @@ export interface StockPileProps {
 const isHiddenMultiplayerCard = (card: CardType | null | undefined): card is CardType =>
   card !== null && card !== undefined && card.value === 0 && !card.isSkipBo;
 
+// Identity key for the stock-top Card. The slot reuses a single DOM node across
+// renders, so a value-bound key forces React to remount when the revealed card
+// changes — restarting per-value CSS animations (e.g. neon's `neonTextPulse`,
+// whose glow uses `currentColor`). Without the remount, WebKit keeps the
+// previous card's glow color (a magenta 5–8 glow lingering on a blue 9–12), so
+// the freshly revealed card shows the wrong-colored halo.
+const stockCardIdentityKey = (card: CardType | null | undefined): string =>
+  card ? (card.isSkipBo ? 'skipbo' : `v${card.value}`) : 'empty';
+
 export function StockPile({
   player,
   playerIndex,
@@ -62,6 +71,7 @@ export function StockPile({
           {isCardBeingAnimated(playerIndex, 'stock', player.stockPile.length - 1) ? (
             player.stockPile.length > 1 ? (
               <Card
+                key={stockCardIdentityKey(player.stockPile[player.stockPile.length - 2])}
                 hint={player.stockPile.length === 2 ? 'Second card in stock' : 'Second card in stock (hidden)'}
                 card={player.stockPile[player.stockPile.length - 2]}
                 isRevealed={!isHiddenMultiplayerCard(player.stockPile[player.stockPile.length - 2])}
@@ -70,6 +80,7 @@ export function StockPile({
             ) : null
           ) : isHuman && isCurrentPlayer && player.stockPile[player.stockPile.length - 1] ? (
             <DraggableStockTop
+              key={stockCardIdentityKey(player.stockPile[player.stockPile.length - 1])}
               card={player.stockPile[player.stockPile.length - 1]}
               stockTopIndex={player.stockPile.length - 1}
               playerIndex={playerIndex}
@@ -81,6 +92,7 @@ export function StockPile({
             />
           ) : (
             <Card
+              key={stockCardIdentityKey(player.stockPile[player.stockPile.length - 1])}
               hint={player.stockPile.length === 1 ? 'Top card in stock' : 'Top card in stock (hidden)'}
               card={player.stockPile[player.stockPile.length - 1]}
               isRevealed={true}


### PR DESCRIPTION
## Problem

On the Neon theme, a freshly revealed stock-top (talon) card could show the **wrong-colored glow** — e.g. a blue `11` surrounded by a **red/magenta halo** carried over from the previous 5–8 card. Reported on iOS Safari (PWA).

## Root cause

- The stock-top slot renders a single `Card` whose value changes as cards are played, and React **reuses the same DOM node** (no identity `key`), so the `neonTextPulse` CSS animation never restarts.
- The neon glow uses `text-shadow: … currentColor`. On **WebKit/Safari**, `currentColor` inside a *running* `@keyframes` is not re-resolved when the element's `color` changes. The digit fill turns blue, but the glow keeps the previous card's magenta color.
- Chrome re-resolves `currentColor` live, which is why it only reproduces on Safari.

## Fix

Key each stock-top `Card` (all three render branches) by a value-bound identity (`stockCardIdentityKey`) so React **remounts** the node when the revealed value changes. The animation restarts and the glow recomputes against the new color.

Discard piles are unaffected: they are keyed by position index and a card never changes value in place (stack grows/shrinks from the top → natural remount).

## Validation

- `pnpm --filter @skipbo/web typecheck` ✅
- `pnpm --filter @skipbo/web lint` ✅
- `pnpm --filter @skipbo/web test` ✅ 200/200

Couldn't validate on real iOS Safari from the dev environment (preview runs Chrome); recommend a quick check on the deployed PWA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)