### PR TITLE
ci: enable automatic Claude code review on PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Disabled: re-enable by removing this `if: false`.
-    if: false
+    # Skip draft PRs and Dependabot's automated bumps.
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary

Re-enables the `claude-code-review` workflow so every PR gets an automatic Claude review — no `@claude review` comment needed.

The workflow already existed and was fully configured (OAuth token, `/code-review` plugin, triggers on `opened`/`synchronize`/`ready_for_review`/`reopened`) but had been disabled in `8e59600` with `if: false`, so every run was skipped.

## Changes

- Replace `if: false` with a guard that runs the review on every PR **except** drafts and Dependabot bumps.

## Notes

- `pull_request` workflows are read from the **base branch**, so this takes effect once merged to `main`.
- The `@claude` mention bot (`claude.yml`) is untouched and still works for on-demand asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)