### PR TITLE
fix(neon): seamless background grid loop

### DIFF
--- a/apps/web/src/themes/neon.css
+++ b/apps/web/src/themes/neon.css
@@ -264,7 +264,9 @@
     transform: perspective(400px) rotateX(50deg) translateY(0);
   }
   to {
-    transform: perspective(400px) rotateX(50deg) translateY(-80px);
+    /* Translate by an exact multiple of the grid's 4vh repeat period so the
+       loop point lands on an identical copy of the pattern — no flicker. */
+    transform: perspective(400px) rotateX(50deg) translateY(-8vh);
   }
 }
 


### PR DESCRIPTION
## Problem

On the **Neon** theme, the synthwave perspective grid (`body::before`) flickered each time its scroll animation looped.

The grid is a `repeating-linear-gradient` whose horizontal lines repeat every **4vh**, but `backgroundMoving` translated by a fixed **-80px**. Since `-80px` is not a multiple of the `4vh` period, the pattern snapped from `-80px` back to `0` at the loop boundary instead of landing on an identical copy — producing the visible flicker.

## Fix

Translate by **`-8vh`** (exactly 2× the `4vh` grid period). The 100% frame is now visually identical to the 0% frame, so the loop is imperceptible and the grid appears to scroll infinitely. Perceived speed is essentially unchanged (`-80px` ≈ `8.9vh` on a typical viewport).

## Verification

- Confirmed in the local preview: Neon theme active, keyframe live as `translateY(-8vh)`, grid renders without console errors or regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)