### PR TITLE
fix(game-core): consolidate refill/validation logic, fix README drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@
 - Source of truth: package scripts, workspace package manifests, and the docs linked from this file.
 - When to update: when setup steps, top-level workflows, or contributor-facing entrypoints change.
 
-Skip-Bo is a `pnpm` monorepo with three main concerns:
+Skip-Bo is a `pnpm` monorepo with two main concerns:
 
 - a React web app for local play and online play
 - shared gameplay and multiplayer packages
-- an AWS/OpenTofu stack for the realtime backend
 
 The default experience is local play against the built-in AI. The same web app can also create or join private online rooms for two to four human players, backed by the realtime API.
 
@@ -29,7 +28,6 @@ The default experience is local play against the built-in AI. The same web app c
 
 - Node.js `>=22.12.0`
 - `pnpm`
-- OpenTofu if you need to work on the AWS stack
 
 ### Install
 

--- a/apps/web/src/state/__tests__/gameReducer.test.ts
+++ b/apps/web/src/state/__tests__/gameReducer.test.ts
@@ -563,6 +563,48 @@ describe('gameReducer', () => {
         // Deck should have remaining cards after reshuffle (1 card left)
         expect(result.deck.length).toBeGreaterThan(0);
       });
+
+      it('should refill from a build pile completed by the same play', () => {
+        // 11 cards already on the build pile; the played card is the 12th and
+        // also empties the hand. The deck and completedBuildPiles both start
+        // empty, so the only cards available to refill the hand are the 12
+        // that this play just completed.
+        const buildPileWith11Cards = Array.from({ length: 11 }, (_, i) => ({
+          value: i + 1,
+          isSkipBo: false,
+        }));
+
+        const stateWithEmptyDeck = {
+          ...initialState,
+          deck: [],
+          completedBuildPiles: [],
+          buildPiles: [buildPileWith11Cards, [], [], []],
+          players: [
+            {
+              ...initialState.players[0],
+              hand: [{ value: 12, isSkipBo: false }, null, null, null, null], // Only 1 card in hand
+            },
+            initialState.players[1],
+          ],
+        };
+
+        const stateWithSelection = gameReducer(stateWithEmptyDeck, {
+          type: 'SELECT_CARD',
+          source: 'hand',
+          index: 0,
+        });
+
+        const result = gameReducer(stateWithSelection, {
+          type: 'PLAY_CARD',
+          buildPile: 0,
+        });
+
+        // The completed pile's 12 cards should have been reshuffled into the
+        // deck and used to refill the hand.
+        expect(result.players[0].hand.filter((c) => !!c)).toHaveLength(5);
+        expect(result.completedBuildPiles).toHaveLength(0);
+        expect(result.deck.length).toBe(7);
+      });
     });
 
     describe('END_TURN with deck exhaustion', () => {

--- a/packages/game-core/src/lib/handRefill.ts
+++ b/packages/game-core/src/lib/handRefill.ts
@@ -1,4 +1,4 @@
-import type { Card } from '../types/index.js';
+import type { Card, GameState, Player } from '../types/index.js';
 import { shuffleInPlace } from './shuffle.js';
 
 export interface HandRefillAnimationPlan {
@@ -51,4 +51,39 @@ export const planHandRefill = (
   }
 
   return { cards, handIndices };
+};
+
+/**
+ * Fill `player.hand`'s `null` slots from `draft.deck`, reshuffling
+ * `draft.completedBuildPiles` back into the deck if more cards are needed.
+ * Mutates the Immer draft in place. `requestedCount` defaults to filling all
+ * empty slots (bounded by what's available).
+ */
+export const refillHand = (draft: GameState, player: Player, requestedCount?: number): void => {
+  const emptySlots = player.hand.filter((card) => card === null).length;
+  let remainingToDraw = requestedCount ?? Math.min(emptySlots, draft.deck.length + draft.completedBuildPiles.length);
+
+  if (remainingToDraw === 0) {
+    return;
+  }
+
+  for (let i = 0; i < player.hand.length && remainingToDraw > 0; i++) {
+    if (player.hand[i] === null && draft.deck.length > 0) {
+      player.hand[i] = draft.deck.shift()!;
+      remainingToDraw--;
+    }
+  }
+
+  if (remainingToDraw > 0 && draft.completedBuildPiles.length > 0) {
+    draft.deck.push(...draft.completedBuildPiles);
+    draft.completedBuildPiles = [];
+    shuffleInPlace(draft.deck);
+
+    for (let i = 0; i < player.hand.length && remainingToDraw > 0 && draft.deck.length > 0; i++) {
+      if (player.hand[i] === null) {
+        player.hand[i] = draft.deck.shift()!;
+        remainingToDraw--;
+      }
+    }
+  }
 };

--- a/packages/game-core/src/lib/validators.ts
+++ b/packages/game-core/src/lib/validators.ts
@@ -1,4 +1,4 @@
-import type { Card, GameState } from '../types/index.js';
+import type { Card, GameState, Player, SelectedCard } from '../types/index.js';
 
 export const canPlayCard = (card: Card, buildPileIndex: number, gameState: GameState): boolean => {
   const buildPile = gameState.buildPiles[buildPileIndex];
@@ -15,7 +15,37 @@ export const canPlayCard = (card: Card, buildPileIndex: number, gameState: GameS
   // This handles Skip-Bo cards correctly since they maintain their identity but represent the pile position
   const expectedValue = buildPile.length + 1;
 
-  if (expectedValue > 12) return false;
+  if (expectedValue > gameState.config.CARD_VALUES_MAX) return false;
 
   return card.isSkipBo || card.value === expectedValue;
+};
+
+export const cardsMatch = (candidate: Card | null | undefined, selectedCard: Card): boolean =>
+  !!candidate && candidate.value === selectedCard.value && candidate.isSkipBo === selectedCard.isSkipBo;
+
+export const hasValidDiscardPileIndex = (player: Player, discardPileIndex: number): boolean =>
+  discardPileIndex >= 0 && discardPileIndex < player.discardPiles.length;
+
+export const hasValidSelectedSource = (player: Player, selectedCard: SelectedCard): boolean => {
+  switch (selectedCard.source) {
+    case 'hand':
+      return (
+        selectedCard.index >= 0 &&
+        selectedCard.index < player.hand.length &&
+        cardsMatch(player.hand[selectedCard.index], selectedCard.card)
+      );
+    case 'stock':
+      return cardsMatch(player.stockPile[player.stockPile.length - 1], selectedCard.card);
+    case 'discard':
+      return (
+        selectedCard.discardPileIndex !== undefined &&
+        hasValidDiscardPileIndex(player, selectedCard.discardPileIndex) &&
+        cardsMatch(
+          player.discardPiles[selectedCard.discardPileIndex][
+            player.discardPiles[selectedCard.discardPileIndex].length - 1
+          ],
+          selectedCard.card,
+        )
+      );
+  }
 };

--- a/packages/game-core/src/state/gameReducer.ts
+++ b/packages/game-core/src/state/gameReducer.ts
@@ -1,13 +1,10 @@
 import { produce } from 'immer';
-import type { Card, GameState, Player, SelectedCard } from '../types/index.js';
+import type { Card, GameState } from '../types/index.js';
 import type { GameAction } from './gameActions.js';
 import { initialGameState } from './initialGameState.js';
 import { MESSAGES } from '../lib/config.js';
-import { shuffleInPlace } from '../lib/shuffle.js';
-import { canPlayCard } from '../lib/validators.js';
-
-const cardsMatch = (candidate: Card | null | undefined, selectedCard: Card): boolean =>
-  !!candidate && candidate.value === selectedCard.value && candidate.isSkipBo === selectedCard.isSkipBo;
+import { refillHand } from '../lib/handRefill.js';
+import { canPlayCard, hasValidDiscardPileIndex, hasValidSelectedSource } from '../lib/validators.js';
 
 const getNextPlayerIndex = (currentPlayerIndex: number, playerCount: number): number => {
   if (playerCount <= 0) {
@@ -15,33 +12,6 @@ const getNextPlayerIndex = (currentPlayerIndex: number, playerCount: number): nu
   }
 
   return (currentPlayerIndex + 1) % playerCount;
-};
-
-const hasValidDiscardPileIndex = (player: Player, discardPileIndex: number): boolean =>
-  discardPileIndex >= 0 && discardPileIndex < player.discardPiles.length;
-
-const hasValidSelectedSource = (player: Player, selectedCard: SelectedCard): boolean => {
-  switch (selectedCard.source) {
-    case 'hand':
-      return (
-        selectedCard.index >= 0 &&
-        selectedCard.index < player.hand.length &&
-        cardsMatch(player.hand[selectedCard.index], selectedCard.card)
-      );
-    case 'stock':
-      return cardsMatch(player.stockPile[player.stockPile.length - 1], selectedCard.card);
-    case 'discard':
-      return (
-        selectedCard.discardPileIndex !== undefined &&
-        hasValidDiscardPileIndex(player, selectedCard.discardPileIndex) &&
-        cardsMatch(
-          player.discardPiles[selectedCard.discardPileIndex][
-            player.discardPiles[selectedCard.discardPileIndex].length - 1
-          ],
-          selectedCard.card,
-        )
-      );
-  }
 };
 
 export const gameReducer = produce((draft: GameState, action: GameAction) => {
@@ -52,51 +22,7 @@ export const gameReducer = produce((draft: GameState, action: GameAction) => {
 
     case 'DRAW': {
       const player = draft.players[draft.currentPlayerIndex];
-
-      // Count empty slots in hand (null values)
-      const emptySlots = player.hand.filter((card) => card === null).length;
-
-      let remainingToDraw = action.count ?? Math.min(emptySlots, draft.deck.length + draft.completedBuildPiles.length);
-
-      // If no empty slots and no count specified, return early
-      if (remainingToDraw === 0) {
-        return;
-      }
-
-      // First, draw from existing deck
-      const fromDeck = Math.min(remainingToDraw, draft.deck.length);
-      if (fromDeck > 0) {
-        // Fill empty slots first
-        for (let i = 0; i < player.hand.length && remainingToDraw > 0; i++) {
-          if (player.hand[i] === null && draft.deck.length > 0) {
-            player.hand[i] = draft.deck.shift()!;
-            remainingToDraw--;
-          }
-        }
-      } else {
-        // Variable-length system: add cards to end
-        while (remainingToDraw > 0 && draft.deck.length > 0) {
-          player.hand.push(draft.deck.shift()!);
-          remainingToDraw--;
-        }
-      }
-
-      // If we still need more cards and have completed build piles, reshuffle and continue
-      if (remainingToDraw > 0 && draft.completedBuildPiles.length > 0) {
-        // Move completed build piles to deck and shuffle
-        draft.deck.push(...draft.completedBuildPiles);
-        draft.completedBuildPiles = [];
-
-        shuffleInPlace(draft.deck);
-
-        // Draw remaining cards to fill empty slots
-        for (let i = 0; i < player.hand.length && remainingToDraw > 0 && draft.deck.length > 0; i++) {
-          if (player.hand[i] === null) {
-            player.hand[i] = draft.deck.shift()!;
-            remainingToDraw--;
-          }
-        }
-      }
+      refillHand(draft, player, action.count);
       break;
     }
 
@@ -114,9 +40,8 @@ export const gameReducer = produce((draft: GameState, action: GameAction) => {
     case 'DEBUG_SET_AI_HAND': {
       const player = draft.players[draft.currentPlayerIndex];
       const targetSize = draft.config.HAND_SIZE;
-      const newHand = action.hand.slice(0, targetSize);
+      const newHand: (Card | null)[] = action.hand.slice(0, targetSize);
       while (newHand.length < targetSize) {
-        // @ts-expect-error will never happen
         newHand.push(null);
       }
       player.hand = newHand;
@@ -267,49 +192,18 @@ export const gameReducer = produce((draft: GameState, action: GameAction) => {
         player.discardPiles[selectedCard.discardPileIndex].pop();
       }
 
-      // Draw cards only if the player's hand is empty (all slots are null)
-      const allSlotsEmpty = player.hand.every((card) => card === null);
-      if (allSlotsEmpty) {
-        // Count empty slots in hand (null values)
-        const emptySlots = player.hand.filter((card) => card === null).length;
-
-        let remainingToDraw = Math.min(emptySlots, draft.deck.length + draft.completedBuildPiles.length);
-
-        // First, draw from existing deck
-        const fromDeck = Math.min(remainingToDraw, draft.deck.length);
-        if (fromDeck > 0) {
-          // Fill empty slots first
-          for (let i = 0; i < player.hand.length && remainingToDraw > 0; i++) {
-            if (player.hand[i] === null && draft.deck.length > 0) {
-              player.hand[i] = draft.deck.shift()!;
-              remainingToDraw--;
-            }
-          }
-        }
-
-        // If we still need more cards and have completed build piles, reshuffle and continue
-        if (remainingToDraw > 0 && draft.completedBuildPiles.length > 0) {
-          // Move completed build piles to deck and shuffle
-          draft.deck.push(...draft.completedBuildPiles);
-          draft.completedBuildPiles = [];
-
-          shuffleInPlace(draft.deck);
-
-          // Draw remaining cards to fill empty slots
-          for (let i = 0; i < player.hand.length && remainingToDraw > 0 && draft.deck.length > 0; i++) {
-            if (player.hand[i] === null) {
-              player.hand[i] = draft.deck.shift()!;
-              remainingToDraw--;
-            }
-          }
-        }
-      }
-
-      // Check if build pile is complete (12 cards)
-      if (draft.buildPiles[buildPileIndex].length === 12) {
+      // Check if build pile is complete, before refilling the hand so a
+      // pile completed by this very play is available to reshuffle from.
+      if (draft.buildPiles[buildPileIndex].length === draft.config.CARD_VALUES_MAX) {
         // Completed build pile: move cards to completed pile storage
         draft.completedBuildPiles.push(...draft.buildPiles[buildPileIndex]);
         draft.buildPiles[buildPileIndex] = [];
+      }
+
+      // Draw cards only if the player's hand is empty (all slots are null)
+      const allSlotsEmpty = player.hand.every((card) => card === null);
+      if (allSlotsEmpty) {
+        refillHand(draft, player);
       }
 
       // Check win condition

--- a/packages/skipbo-runtime/src/gameLogic.ts
+++ b/packages/skipbo-runtime/src/gameLogic.ts
@@ -1,44 +1,13 @@
 import {
   canPlayCard,
   gameReducer,
+  hasValidDiscardPileIndex,
+  hasValidSelectedSource,
   initialGameState,
-  type Card,
   type GameAction,
   type GameState,
-  type Player,
-  type SelectedCard,
 } from '@skipbo/game-core';
 import { resolvePlayerName } from '@klbsjpolp/realtime-core';
-
-const cardsMatch = (candidate: Card | null | undefined, selectedCard: Card): boolean =>
-  !!candidate && candidate.value === selectedCard.value && candidate.isSkipBo === selectedCard.isSkipBo;
-
-const hasValidDiscardPileIndex = (player: Player, discardPileIndex: number): boolean =>
-  discardPileIndex >= 0 && discardPileIndex < player.discardPiles.length;
-
-const hasValidSelectedSource = (player: Player, selectedCard: SelectedCard): boolean => {
-  switch (selectedCard.source) {
-    case 'hand':
-      return (
-        selectedCard.index >= 0 &&
-        selectedCard.index < player.hand.length &&
-        cardsMatch(player.hand[selectedCard.index], selectedCard.card)
-      );
-    case 'stock':
-      return cardsMatch(player.stockPile[player.stockPile.length - 1], selectedCard.card);
-    case 'discard':
-      return (
-        selectedCard.discardPileIndex !== undefined &&
-        hasValidDiscardPileIndex(player, selectedCard.discardPileIndex) &&
-        cardsMatch(
-          player.discardPiles[selectedCard.discardPileIndex][
-            player.discardPiles[selectedCard.discardPileIndex].length - 1
-          ],
-          selectedCard.card,
-        )
-      );
-  }
-};
 
 const isCardSelectable = (gameState: GameState, action: Extract<GameAction, { type: 'SELECT_CARD' }>): boolean => {
   const player = gameState.players[gameState.currentPlayerIndex];


### PR DESCRIPTION
## Summary
- Dedupe `cardsMatch`/`hasValidSelectedSource`/`hasValidDiscardPileIndex` into `@skipbo/game-core` validators, used by both `gameReducer` and `skipbo-runtime`.
- Extract a shared `refillHand` helper for the hand-refill logic duplicated across `DRAW` and `PLAY_CARD`.
- Replace hardcoded build-pile size `12` with `config.CARD_VALUES_MAX` in the reducer and validators.
- Reorder `PLAY_CARD` so build-pile completion is checked before the empty-hand refill, so a pile completed by the same play can be reshuffled into the draw.
- Remove a dead branch in `DRAW` and a stale `@ts-expect-error` in `DEBUG_SET_AI_HAND`.
- Fix README references to an AWS/OpenTofu stack that now lives in realtime-infra.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (201/201 passing, includes new regression test for the refill-ordering edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)