### PR TITLE
feat(web): track per-theme usage time via Sentry spans

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,6 +26,7 @@ import { getRequestedUiFixtureName, getUiFixture, type UiFixtureName } from '@/t
 import { DebugStrip } from '@/components/DebugStrip';
 import { usePwaVersionGate } from '@/hooks/usePwaVersionGate';
 import { useThemeColorMeta } from '@/hooks/useThemeColorMeta';
+import { useThemeUsageGameGate, useThemeUsageReporter } from '@/hooks/useThemeUsageReporter';
 
 const fixtureActionResult = Promise.resolve({ success: true, message: 'Fixture mode' });
 
@@ -56,6 +57,8 @@ function AppShell({
   statusStrip,
   updateNotice,
 }: AppShellProps) {
+  useThemeUsageGameGate(isGameOver);
+
   return (
     <main
       id="main"
@@ -511,6 +514,7 @@ function LiveApp() {
 
 function App() {
   useThemeColorMeta();
+  useThemeUsageReporter();
   const fixtureName = getRequestedUiFixtureName();
 
   if (fixtureName) {

--- a/apps/web/src/components/ThemeSwitcher.tsx
+++ b/apps/web/src/components/ThemeSwitcher.tsx
@@ -5,6 +5,16 @@ import { themes } from '@/types';
 import { Button } from '@/components/ui/button';
 import * as Lucide from 'lucide-react';
 import type { ComponentType, SVGProps } from 'react';
+import { trackThemeSelection } from '@/monitoring/themeAnalytics';
+
+/** Picks a theme other than `current`, or `null` when none is available. */
+function pickRandomTheme(current: ThemeDetail['value']): ThemeDetail['value'] | null {
+  const available = themes.map(({ value }) => value).filter((value) => value !== current);
+  if (available.length === 0) {
+    return null;
+  }
+  return available[Math.floor(Math.random() * available.length)];
+}
 
 export function ThemeSwitcher() {
   const { setTheme, theme } = useTheme();
@@ -16,19 +26,27 @@ export function ThemeSwitcher() {
   };
 
   const setRandomTheme = () => {
-    const availableThemes = themes.map(({ value }) => value).filter((value) => value !== activeTheme.value);
-
-    if (availableThemes.length === 0) {
+    const randomTheme = pickRandomTheme(activeTheme.value);
+    if (!randomTheme) {
       return;
     }
-
-    const randomTheme = availableThemes[Math.floor(Math.random() * availableThemes.length)];
+    trackThemeSelection({ theme: randomTheme, previousTheme: activeTheme.value, source: 'random' });
     setTheme(randomTheme);
   };
 
   return (
     <div className="relative flex items-center gap-0.5" data-testid="theme-switcher">
-      <Select value={activeTheme.value} onValueChange={setTheme}>
+      <Select
+        value={activeTheme.value}
+        onValueChange={(value) => {
+          trackThemeSelection({
+            theme: value as ThemeDetail['value'],
+            previousTheme: activeTheme.value,
+            source: 'manual',
+          });
+          setTheme(value);
+        }}
+      >
         <SelectTrigger className="w-36" data-testid="theme-switcher-trigger" aria-label="Thème">
           <div className="flex items-center">
             {getIcon(activeTheme.icon)}

--- a/apps/web/src/components/__tests__/ThemeSwitcher.test.tsx
+++ b/apps/web/src/components/__tests__/ThemeSwitcher.test.tsx
@@ -1,16 +1,36 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { ThemeProvider } from 'next-themes';
-import { describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { themes } from '@/types';
+import { trackThemeSelection } from '@/monitoring/themeAnalytics';
 import { ThemeSwitcher } from '../ThemeSwitcher';
+
+vi.mock('@/monitoring/themeAnalytics', () => ({
+  trackThemeSelection: vi.fn(),
+}));
+
+const trackSelection = vi.mocked(trackThemeSelection);
+
+function renderSwitcher() {
+  return render(
+    <ThemeProvider attribute="class" defaultTheme="theme-paper" themes={themes.map((t) => t.value)}>
+      <ThemeSwitcher />
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  // next-themes persists the active theme; reset so each test starts on the default.
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('ThemeSwitcher', () => {
   test('flags the cinema theme as new in the dropdown', () => {
-    render(
-      <ThemeProvider attribute="class" defaultTheme="theme-paper" themes={themes.map((t) => t.value)}>
-        <ThemeSwitcher />
-      </ThemeProvider>,
-    );
+    renderSwitcher();
 
     fireEvent.click(screen.getByTestId('theme-switcher-trigger'));
 
@@ -19,5 +39,30 @@ describe('ThemeSwitcher', () => {
 
     const paperOption = screen.getByTestId('theme-option-theme-paper');
     expect(within(paperOption).queryByText('Nouveau')).toBeNull();
+  });
+
+  test('reports a manual selection from the dropdown', () => {
+    renderSwitcher();
+
+    fireEvent.click(screen.getByTestId('theme-switcher-trigger'));
+    fireEvent.click(screen.getByTestId('theme-option-theme-neon'));
+
+    expect(trackSelection).toHaveBeenCalledWith({
+      theme: 'theme-neon',
+      previousTheme: 'theme-paper',
+      source: 'manual',
+    });
+  });
+
+  test('reports a random selection that differs from the active theme', () => {
+    renderSwitcher();
+
+    fireEvent.click(screen.getByTestId('theme-randomizer-button'));
+
+    expect(trackSelection).toHaveBeenCalledTimes(1);
+    const call = trackSelection.mock.calls[0][0];
+    expect(call.source).toBe('random');
+    expect(call.previousTheme).toBe('theme-paper');
+    expect(call.theme).not.toBe('theme-paper');
   });
 });

--- a/apps/web/src/hooks/__tests__/useThemeUsageReporter.test.tsx
+++ b/apps/web/src/hooks/__tests__/useThemeUsageReporter.test.tsx
@@ -1,0 +1,103 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { recordActiveTheme, resumeThemeTimer, suspendThemeTimer } from '@/monitoring/themeUsageTimer';
+import { useThemeUsageGameGate, useThemeUsageReporter } from '../useThemeUsageReporter';
+
+vi.mock('@/monitoring/themeUsageTimer', () => ({
+  recordActiveTheme: vi.fn(),
+  suspendThemeTimer: vi.fn(),
+  resumeThemeTimer: vi.fn(),
+}));
+
+let themeValue: string | undefined = 'theme-paper';
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: themeValue }),
+}));
+
+const record = vi.mocked(recordActiveTheme);
+const suspend = vi.mocked(suspendThemeTimer);
+const resume = vi.mocked(resumeThemeTimer);
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+beforeEach(() => {
+  themeValue = 'theme-paper';
+  setVisibility('visible');
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  setVisibility('visible');
+});
+
+function ReporterHarness() {
+  useThemeUsageReporter();
+  return null;
+}
+
+function GateHarness({ isGameOver }: { isGameOver: boolean }) {
+  useThemeUsageGameGate(isGameOver);
+  return null;
+}
+
+describe('useThemeUsageReporter', () => {
+  test('records the resolved theme on mount', () => {
+    render(<ReporterHarness />);
+    expect(record).toHaveBeenCalledWith('theme-paper');
+  });
+
+  test('suspends on tab hide and resumes when visible again', () => {
+    render(<ReporterHarness />);
+
+    act(() => setVisibility('hidden'));
+    expect(suspend).toHaveBeenCalledWith('hidden');
+
+    act(() => setVisibility('visible'));
+    expect(resume).toHaveBeenCalledWith('hidden');
+  });
+
+  test('suspends on pagehide', () => {
+    render(<ReporterHarness />);
+    suspend.mockClear();
+
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'));
+    });
+
+    expect(suspend).toHaveBeenCalledWith('hidden');
+  });
+
+  test('suspends on unmount', () => {
+    const { unmount } = render(<ReporterHarness />);
+    suspend.mockClear();
+
+    unmount();
+
+    expect(suspend).toHaveBeenCalledWith('hidden');
+  });
+});
+
+describe('useThemeUsageGameGate', () => {
+  test('suspends while the game is over and resumes when a new game starts', () => {
+    const { rerender } = render(<GateHarness isGameOver={false} />);
+    expect(resume).toHaveBeenLastCalledWith('game-over');
+
+    rerender(<GateHarness isGameOver={true} />);
+    expect(suspend).toHaveBeenCalledWith('game-over');
+
+    rerender(<GateHarness isGameOver={false} />);
+    expect(resume).toHaveBeenLastCalledWith('game-over');
+  });
+
+  test('clears the game-over suspension on unmount', () => {
+    const { unmount } = render(<GateHarness isGameOver={true} />);
+    resume.mockClear();
+
+    unmount();
+
+    expect(resume).toHaveBeenCalledWith('game-over');
+  });
+});

--- a/apps/web/src/hooks/useThemeUsageReporter.ts
+++ b/apps/web/src/hooks/useThemeUsageReporter.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { useTheme } from 'next-themes';
+import type { Theme } from '@/types';
+import { recordActiveTheme, resumeThemeTimer, suspendThemeTimer } from '@/monitoring/themeUsageTimer';
+
+/**
+ * Drives the theme-usage timer from the resolved next-themes value, and pauses
+ * it while the tab is hidden so only foreground time is measured. See
+ * {@link recordActiveTheme} for how the per-theme durations are reported.
+ */
+export function useThemeUsageReporter(): void {
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    if (theme) {
+      recordActiveTheme(theme as Theme);
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        suspendThemeTimer('hidden');
+      } else {
+        resumeThemeTimer('hidden');
+      }
+    };
+    const onPageHide = () => suspendThemeTimer('hidden');
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    // pagehide covers tab close and navigation, including bfcache.
+    window.addEventListener('pagehide', onPageHide);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('pagehide', onPageHide);
+      suspendThemeTimer('hidden');
+    };
+  }, []);
+}
+
+/**
+ * Pauses theme-usage counting while the end-of-game screen is shown, so the
+ * idle time between a win and starting a new game is not attributed to the
+ * active theme. Call from the screen that knows whether the game is over.
+ */
+export function useThemeUsageGameGate(isGameOver: boolean): void {
+  useEffect(() => {
+    if (isGameOver) {
+      suspendThemeTimer('game-over');
+    } else {
+      resumeThemeTimer('game-over');
+    }
+    return () => resumeThemeTimer('game-over');
+  }, [isGameOver]);
+}

--- a/apps/web/src/monitoring/__tests__/themeAnalytics.test.ts
+++ b/apps/web/src/monitoring/__tests__/themeAnalytics.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import * as Sentry from '@sentry/react';
+import { tagActiveTheme, trackThemeSelection } from '../themeAnalytics';
+
+vi.mock('@sentry/react', () => ({
+  setTag: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+const setTag = vi.mocked(Sentry.setTag);
+const captureMessage = vi.mocked(Sentry.captureMessage);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('tagActiveTheme', () => {
+  test('tags the scope without emitting an event', () => {
+    tagActiveTheme('theme-midnight');
+
+    expect(setTag).toHaveBeenCalledWith('theme', 'theme-midnight');
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('trackThemeSelection', () => {
+  test('tags the scope and emits a tagged theme.selected message', () => {
+    trackThemeSelection({ theme: 'theme-neon', previousTheme: 'theme-paper', source: 'manual' });
+
+    expect(setTag).toHaveBeenCalledWith('theme', 'theme-neon');
+    expect(captureMessage).toHaveBeenCalledWith('theme.selected', {
+      level: 'info',
+      tags: { theme: 'theme-neon', 'theme.source': 'manual' },
+      extra: { previousTheme: 'theme-paper' },
+    });
+  });
+
+  test('records the random source and null previous theme', () => {
+    trackThemeSelection({ theme: 'theme-wool', source: 'random' });
+
+    expect(captureMessage).toHaveBeenCalledWith(
+      'theme.selected',
+      expect.objectContaining({
+        tags: { theme: 'theme-wool', 'theme.source': 'random' },
+        extra: { previousTheme: null },
+      }),
+    );
+  });
+});

--- a/apps/web/src/monitoring/__tests__/themeUsageTimer.test.ts
+++ b/apps/web/src/monitoring/__tests__/themeUsageTimer.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Span } from '@sentry/react';
+
+vi.mock('@sentry/react', () => ({
+  setTag: vi.fn(),
+  startInactiveSpan: vi.fn(),
+}));
+
+// Re-imported per test so the timer's module-level state starts clean.
+let Sentry: typeof import('@sentry/react');
+let timer: typeof import('../themeUsageTimer');
+
+/** Returns a fake span plus a handle to assert it was ended. */
+function makeSpan() {
+  const end = vi.fn();
+  return { span: { end } as unknown as Span, end };
+}
+
+/** Queues fake spans to be handed out by successive startInactiveSpan calls. */
+function queueSpans(count: number) {
+  const spans = Array.from({ length: count }, makeSpan);
+  const mock = vi.mocked(Sentry.startInactiveSpan);
+  spans.forEach(({ span }) => mock.mockReturnValueOnce(span));
+  return spans;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  Sentry = await import('@sentry/react');
+  timer = await import('../themeUsageTimer');
+  // The Sentry mock instances survive resetModules; clear their history and
+  // queued return values so each test starts from zero.
+  vi.mocked(Sentry.startInactiveSpan).mockReset();
+  vi.mocked(Sentry.setTag).mockReset();
+});
+
+describe('themeUsageTimer', () => {
+  test('opens a theme.active span tagged with the theme', () => {
+    queueSpans(1);
+
+    timer.recordActiveTheme('theme-paper');
+
+    expect(Sentry.setTag).toHaveBeenCalledWith('theme', 'theme-paper');
+    expect(Sentry.startInactiveSpan).toHaveBeenCalledWith({
+      name: 'theme.active',
+      op: 'ui.theme',
+      attributes: { theme: 'theme-paper' },
+    });
+  });
+
+  test('closes the previous segment when the theme changes', () => {
+    const [first] = queueSpans(2);
+
+    timer.recordActiveTheme('theme-paper');
+    timer.recordActiveTheme('theme-neon');
+
+    expect(first.end).toHaveBeenCalledTimes(1);
+    expect(Sentry.startInactiveSpan).toHaveBeenLastCalledWith(
+      expect.objectContaining({ attributes: { theme: 'theme-neon' } }),
+    );
+  });
+
+  test('does not reopen a span when the theme is unchanged', () => {
+    queueSpans(1);
+
+    timer.recordActiveTheme('theme-paper');
+    timer.recordActiveTheme('theme-paper');
+
+    expect(Sentry.startInactiveSpan).toHaveBeenCalledTimes(1);
+  });
+
+  test('suspending ends the segment and resuming reopens one for the same theme', () => {
+    const [first] = queueSpans(2);
+
+    timer.recordActiveTheme('theme-wool');
+    timer.suspendThemeTimer('hidden');
+    expect(first.end).toHaveBeenCalledTimes(1);
+
+    timer.resumeThemeTimer('hidden');
+    expect(Sentry.startInactiveSpan).toHaveBeenLastCalledWith(
+      expect.objectContaining({ attributes: { theme: 'theme-wool' } }),
+    );
+  });
+
+  test('stays suspended until every reason is cleared', () => {
+    queueSpans(2);
+
+    timer.recordActiveTheme('theme-wool');
+    timer.suspendThemeTimer('hidden');
+    timer.suspendThemeTimer('game-over');
+
+    // Clearing only one reason must not resume counting.
+    timer.resumeThemeTimer('hidden');
+    expect(Sentry.startInactiveSpan).toHaveBeenCalledTimes(1);
+
+    // Once the last reason clears, a fresh span opens.
+    timer.resumeThemeTimer('game-over');
+    expect(Sentry.startInactiveSpan).toHaveBeenCalledTimes(2);
+  });
+
+  test('a theme change while suspended does not open a span', () => {
+    queueSpans(2);
+
+    timer.recordActiveTheme('theme-paper');
+    timer.suspendThemeTimer('game-over');
+    timer.recordActiveTheme('theme-neon');
+
+    // Still only the first (pre-suspend) span was opened.
+    expect(Sentry.startInactiveSpan).toHaveBeenCalledTimes(1);
+    expect(Sentry.setTag).toHaveBeenLastCalledWith('theme', 'theme-neon');
+  });
+});

--- a/apps/web/src/monitoring/themeAnalytics.ts
+++ b/apps/web/src/monitoring/themeAnalytics.ts
@@ -1,0 +1,43 @@
+import * as Sentry from '@sentry/react';
+import type { Theme } from '@/types';
+
+/**
+ * Where a theme change originated. Lets the aggregate Sentry breakdown
+ * distinguish deliberate picks from the random-shuffle button and from the
+ * theme that was simply active when the session loaded.
+ */
+export type ThemeSelectionSource = 'manual' | 'random' | 'session';
+
+/**
+ * Tags the Sentry scope with the active theme so every later event (errors,
+ * transactions) is attributed to whatever theme was on screen.
+ */
+export function tagActiveTheme(theme: Theme): void {
+  Sentry.setTag('theme', theme);
+}
+
+/**
+ * Records a deliberate theme change. Emits one `theme.selected` message that
+ * Sentry groups into a single issue; the `theme` / `theme.source` tag
+ * distribution on that issue is the per-theme usage breakdown.
+ */
+export function trackThemeSelection(params: {
+  theme: Theme;
+  previousTheme?: Theme;
+  source: Exclude<ThemeSelectionSource, 'session'>;
+}): void {
+  const { theme, previousTheme, source } = params;
+
+  // Keep the scope tag in sync so any later event reflects the new theme.
+  Sentry.setTag('theme', theme);
+
+  Sentry.captureMessage('theme.selected', {
+    level: 'info',
+    tags: { theme, 'theme.source': source },
+    extra: { previousTheme: previousTheme ?? null },
+  });
+
+  if (import.meta.env.DEV) {
+    console.info('[theme-analytics] selected', { theme, previousTheme, source });
+  }
+}

--- a/apps/web/src/monitoring/themeUsageTimer.ts
+++ b/apps/web/src/monitoring/themeUsageTimer.ts
@@ -1,0 +1,83 @@
+import * as Sentry from '@sentry/react';
+import type { Span } from '@sentry/react';
+import type { Theme } from '@/types';
+import { tagActiveTheme } from './themeAnalytics';
+
+/**
+ * Measures how long each theme is actually on screen during active play.
+ *
+ * Every uninterrupted period a theme is active is recorded as a `theme.active`
+ * span carrying a `theme` attribute. Span duration is real wall-clock time, so
+ * Sentry's Trace Explorer can `sum(span.duration)` grouped by `theme` to get the
+ * total time spent per theme across all users. A random shuffle that flicks
+ * through five themes in a few seconds therefore contributes five tiny spans —
+ * a fraction of the weight of someone who sits on one theme for a whole game.
+ *
+ * Counting is suspended for independent reasons (see {@link ThemeTimerSuspendReason}):
+ * while the tab is hidden, and while the end-of-game screen is up (the time
+ * between a win and starting a new game is dead time, not theme usage). The span
+ * is closed — and thus sent — the moment any reason kicks in, and a fresh span
+ * opens once every reason has cleared.
+ */
+export type ThemeTimerSuspendReason = 'hidden' | 'game-over';
+
+let activeTheme: Theme | null = null;
+let activeSpan: Span | null = null;
+let segmentStart = 0;
+const suspendedFor = new Set<ThemeTimerSuspendReason>();
+
+function openSpan(theme: Theme): void {
+  segmentStart = Date.now();
+  activeSpan = Sentry.startInactiveSpan({
+    name: 'theme.active',
+    op: 'ui.theme',
+    attributes: { theme },
+  });
+}
+
+function closeSpan(): void {
+  if (!activeSpan) return;
+  activeSpan.end();
+  activeSpan = null;
+
+  if (import.meta.env.DEV) {
+    console.info('[theme-analytics] duration', {
+      theme: activeTheme,
+      durationMs: Date.now() - segmentStart,
+    });
+  }
+}
+
+/** Opens or closes the span so it matches the desired running state. */
+function sync(): void {
+  const shouldRun = activeTheme !== null && suspendedFor.size === 0;
+  if (shouldRun && !activeSpan) {
+    openSpan(activeTheme as Theme);
+  } else if (!shouldRun && activeSpan) {
+    closeSpan();
+  }
+}
+
+/**
+ * Switches the timer to `theme`, closing the previous theme's segment. Called
+ * whenever the resolved theme changes (initial load included).
+ */
+export function recordActiveTheme(theme: Theme): void {
+  if (theme === activeTheme) return;
+  closeSpan();
+  activeTheme = theme;
+  tagActiveTheme(theme);
+  sync();
+}
+
+/** Stops counting for `reason` (tab hidden, end-of-game screen, …). */
+export function suspendThemeTimer(reason: ThemeTimerSuspendReason): void {
+  suspendedFor.add(reason);
+  sync();
+}
+
+/** Clears `reason`; counting resumes once no reason remains. */
+export function resumeThemeTimer(reason: ThemeTimerSuspendReason): void {
+  suspendedFor.delete(reason);
+  sync();
+}

--- a/apps/web/src/themes/cinema.css
+++ b/apps/web/src/themes/cinema.css
@@ -1,4 +1,4 @@
-/* Cinéma muet — 1920s silent-film table: a darkened picture house, a projector
+/* Cinéma — 1920s silent-film table: a darkened picture house, a projector
    beam, film grain and scratches, silver-nitrate card faces, film-strip card
    backs, and a Skip-Bo card styled as an intertitle title card. Strictly
    monochrome: the three number ranges are ink black / dark gray / mid gray. */

--- a/docs/themes/cinema.md
+++ b/docs/themes/cinema.md
@@ -1,4 +1,4 @@
-# Cinéma muet
+# Cinéma
 
 ## Document Contract
 
@@ -10,7 +10,7 @@
 ## Identity
 
 - **Category:** Retro & Vintage
-- **Label / icon:** "Cinéma muet" / `Film`
+- **Label / icon:** "Cinéma" / `Film`
 - **Role:** Strictly monochrome 1920s picture-house nostalgia — a darkened theater, a projector beam, film grain, and silver-nitrate cards. Reads as a silent-movie still.
 
 ## Palette & Typography

--- a/packages/game-core/src/types/index.ts
+++ b/packages/game-core/src/types/index.ts
@@ -52,7 +52,7 @@ export const themes = [
   { value: 'theme-neon' as const, label: 'Néon', icon: 'Zap' },
   { value: 'theme-retro' as const, label: 'Rétro', icon: 'Radio' },
   { value: 'theme-retro-space' as const, label: 'Espace', icon: 'Rocket' },
-  { value: 'theme-cinema' as const, label: 'Cinéma muet', icon: 'Film' },
+  { value: 'theme-cinema' as const, label: 'Cinéma', icon: 'Film' },
   { value: 'theme-glass' as const, label: 'Verre', icon: 'Squircle' },
   { value: 'theme-wool' as const, label: 'Laine', icon: 'Spool' },
   { value: 'theme-minecraft' as const, label: 'Minecraft', icon: 'Blocks' },


### PR DESCRIPTION
## Summary

Adds aggregate **theme usage** analytics surfaced through Sentry (console in dev). The metric is **time spent per theme**, not selection counts, so a user who randomly shuffles through many themes contributes little while a user who sticks with one theme dominates.

## How it works

- Each foreground period a theme is on screen is recorded as a `theme.active` Sentry span (`op: ui.theme`) carrying a `theme` attribute. Span duration is real wall-clock time.
- The timer ([`themeUsageTimer.ts`](apps/web/src/monitoring/themeUsageTimer.ts)) tracks **suspend reasons as a set**, so counting only runs when *no* reason blocks it:
  - `hidden` — tab not visible (active foreground time only; a tab left open overnight doesn't inflate numbers).
  - `game-over` — the end-of-game/winner screen is up. The span is **sent the moment a game ends**, and the idle stretch from win → new game is not attributed to the theme.
- [`useThemeUsageReporter`](apps/web/src/hooks/useThemeUsageReporter.ts) drives the timer from the resolved `next-themes` value and handles visibility/`pagehide`. [`useThemeUsageGameGate(isGameOver)`](apps/web/src/hooks/useThemeUsageReporter.ts) is called from `AppShell` (the one component both local and online screens feed `gameState.gameIsOver`).
- Deliberate switches still emit a `theme.selected` message ([`themeAnalytics.ts`](apps/web/src/monitoring/themeAnalytics.ts)) carrying the `manual` vs `random` source for a secondary breakdown. The active theme is also set as a Sentry scope tag, enriching all error events.

## Reading the data in Sentry

Trace Explorer → filter `span.op:ui.theme` → Visualize **`sum(span.duration)`**, Group By the `theme` attribute = total active time per theme. Use `avg`/`p50` for typical session length per theme.

## Notes / caveats

- A hard tab-close may drop the final still-open segment (Sentry transport may not flush in time). Background-time exclusion is intentional; this is a minor unavoidable undercount.
- In dev (no DSN) each closed segment logs `[theme-analytics] duration {...}` to the console.

## Testing

- `pnpm lint`, `pnpm typecheck` — clean across all packages.
- `pnpm test` — game-core (10), skipbo-runtime (18), web (211) all pass, including new `themeAnalytics` and `themeUsageTimer` suites (suspend-reason independence, game-over gating, theme-change-while-suspended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)