### PR TITLE
fix(web): record theme usage as real-duration standalone spans

### DIFF
--- a/apps/web/src/monitoring/__tests__/themeUsageTimer.test.ts
+++ b/apps/web/src/monitoring/__tests__/themeUsageTimer.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { Span } from '@sentry/react';
 
 vi.mock('@sentry/react', () => ({
@@ -10,103 +10,107 @@ vi.mock('@sentry/react', () => ({
 let Sentry: typeof import('@sentry/react');
 let timer: typeof import('../themeUsageTimer');
 
-/** Returns a fake span plus a handle to assert it was ended. */
-function makeSpan() {
-  const end = vi.fn();
-  return { span: { end } as unknown as Span, end };
-}
-
-/** Queues fake spans to be handed out by successive startInactiveSpan calls. */
-function queueSpans(count: number) {
-  const spans = Array.from({ length: count }, makeSpan);
-  const mock = vi.mocked(Sentry.startInactiveSpan);
-  spans.forEach(({ span }) => mock.mockReturnValueOnce(span));
-  return spans;
-}
+// Every span handed out by startInactiveSpan, in creation order.
+let spans: { end: ReturnType<typeof vi.fn> }[] = [];
 
 beforeEach(async () => {
   vi.resetModules();
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+
   Sentry = await import('@sentry/react');
   timer = await import('../themeUsageTimer');
-  // The Sentry mock instances survive resetModules; clear their history and
-  // queued return values so each test starts from zero.
-  vi.mocked(Sentry.startInactiveSpan).mockReset();
+
+  spans = [];
+  vi.mocked(Sentry.startInactiveSpan)
+    .mockReset()
+    .mockImplementation(() => {
+      const span = { end: vi.fn() };
+      spans.push(span);
+      return span as unknown as Span;
+    });
   vi.mocked(Sentry.setTag).mockReset();
 });
 
-describe('themeUsageTimer', () => {
-  test('opens a theme.active span tagged with the theme', () => {
-    queueSpans(1);
+afterEach(() => {
+  vi.useRealTimers();
+});
 
+const startInactiveSpan = () => vi.mocked(Sentry.startInactiveSpan);
+
+describe('themeUsageTimer', () => {
+  test('records nothing until a segment ends', () => {
     timer.recordActiveTheme('theme-paper');
 
     expect(Sentry.setTag).toHaveBeenCalledWith('theme', 'theme-paper');
-    expect(Sentry.startInactiveSpan).toHaveBeenCalledWith({
+    expect(startInactiveSpan()).not.toHaveBeenCalled();
+  });
+
+  test('emits a standalone theme.active span with the real duration when the segment ends', () => {
+    timer.recordActiveTheme('theme-paper');
+    vi.advanceTimersByTime(90_000); // 90s on screen
+    timer.suspendThemeTimer('hidden');
+
+    expect(startInactiveSpan()).toHaveBeenCalledWith({
       name: 'theme.active',
       op: 'ui.theme',
-      attributes: { theme: 'theme-paper' },
+      forceTransaction: true,
+      startTime: new Date(0),
+      attributes: { theme: 'theme-paper', 'theme.duration_ms': 90_000 },
     });
+    expect(spans[0].end).toHaveBeenCalledWith(new Date(90_000));
   });
 
-  test('closes the previous segment when the theme changes', () => {
-    const [first] = queueSpans(2);
-
+  test('records the previous theme when the theme changes, then keeps timing the new one', () => {
     timer.recordActiveTheme('theme-paper');
+    vi.advanceTimersByTime(5_000);
     timer.recordActiveTheme('theme-neon');
 
-    expect(first.end).toHaveBeenCalledTimes(1);
-    expect(Sentry.startInactiveSpan).toHaveBeenLastCalledWith(
-      expect.objectContaining({ attributes: { theme: 'theme-neon' } }),
+    expect(startInactiveSpan()).toHaveBeenCalledTimes(1);
+    expect(startInactiveSpan()).toHaveBeenCalledWith(
+      expect.objectContaining({ attributes: { theme: 'theme-paper', 'theme.duration_ms': 5_000 } }),
     );
   });
 
-  test('does not reopen a span when the theme is unchanged', () => {
-    queueSpans(1);
-
+  test('does not record a zero-length segment when the theme is unchanged', () => {
     timer.recordActiveTheme('theme-paper');
     timer.recordActiveTheme('theme-paper');
 
-    expect(Sentry.startInactiveSpan).toHaveBeenCalledTimes(1);
-  });
-
-  test('suspending ends the segment and resuming reopens one for the same theme', () => {
-    const [first] = queueSpans(2);
-
-    timer.recordActiveTheme('theme-wool');
-    timer.suspendThemeTimer('hidden');
-    expect(first.end).toHaveBeenCalledTimes(1);
-
-    timer.resumeThemeTimer('hidden');
-    expect(Sentry.startInactiveSpan).toHaveBeenLastCalledWith(
-      expect.objectContaining({ attributes: { theme: 'theme-wool' } }),
-    );
+    expect(startInactiveSpan()).not.toHaveBeenCalled();
   });
 
   test('stays suspended until every reason is cleared', () => {
-    queueSpans(2);
-
     timer.recordActiveTheme('theme-wool');
+    vi.advanceTimersByTime(1_000);
     timer.suspendThemeTimer('hidden');
+    expect(startInactiveSpan()).toHaveBeenCalledTimes(1);
+
     timer.suspendThemeTimer('game-over');
-
-    // Clearing only one reason must not resume counting.
+    // Clearing only one reason must not resume counting (still game-over).
     timer.resumeThemeTimer('hidden');
-    expect(Sentry.startInactiveSpan).toHaveBeenCalledTimes(1);
+    expect(startInactiveSpan()).toHaveBeenCalledTimes(1);
 
-    // Once the last reason clears, a fresh span opens.
+    // Once the last reason clears, a fresh segment runs and is recorded.
     timer.resumeThemeTimer('game-over');
-    expect(Sentry.startInactiveSpan).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(2_000);
+    timer.suspendThemeTimer('hidden');
+    expect(startInactiveSpan()).toHaveBeenCalledTimes(2);
+    expect(startInactiveSpan()).toHaveBeenLastCalledWith(
+      expect.objectContaining({ attributes: { theme: 'theme-wool', 'theme.duration_ms': 2_000 } }),
+    );
   });
 
-  test('a theme change while suspended does not open a span', () => {
-    queueSpans(2);
-
+  test('a theme change while suspended records the old theme but does not start a new segment', () => {
     timer.recordActiveTheme('theme-paper');
+    vi.advanceTimersByTime(3_000);
     timer.suspendThemeTimer('game-over');
-    timer.recordActiveTheme('theme-neon');
+    expect(startInactiveSpan()).toHaveBeenCalledTimes(1);
 
-    // Still only the first (pre-suspend) span was opened.
-    expect(Sentry.startInactiveSpan).toHaveBeenCalledTimes(1);
+    timer.recordActiveTheme('theme-neon');
+    vi.advanceTimersByTime(3_000);
+
+    // No new segment opened while suspended.
+    expect(startInactiveSpan()).toHaveBeenCalledTimes(1);
     expect(Sentry.setTag).toHaveBeenLastCalledWith('theme', 'theme-neon');
   });
 });

--- a/apps/web/src/monitoring/__tests__/themeUsageTimer.test.ts
+++ b/apps/web/src/monitoring/__tests__/themeUsageTimer.test.ts
@@ -79,6 +79,14 @@ describe('themeUsageTimer', () => {
     expect(startInactiveSpan()).not.toHaveBeenCalled();
   });
 
+  test('does not emit a span for a segment that ends on the same tick it started', () => {
+    timer.recordActiveTheme('theme-paper');
+    // Suspend with no time elapsed: the segment has zero duration.
+    timer.suspendThemeTimer('hidden');
+
+    expect(startInactiveSpan()).not.toHaveBeenCalled();
+  });
+
   test('stays suspended until every reason is cleared', () => {
     timer.recordActiveTheme('theme-wool');
     vi.advanceTimersByTime(1_000);

--- a/apps/web/src/monitoring/themeUsageTimer.ts
+++ b/apps/web/src/monitoring/themeUsageTimer.ts
@@ -1,70 +1,79 @@
 import * as Sentry from '@sentry/react';
-import type { Span } from '@sentry/react';
 import type { Theme } from '@/types';
 import { tagActiveTheme } from './themeAnalytics';
 
 /**
  * Measures how long each theme is actually on screen during active play.
  *
- * Every uninterrupted period a theme is active is recorded as a `theme.active`
- * span carrying a `theme` attribute. Span duration is real wall-clock time, so
- * Sentry's Trace Explorer can `sum(span.duration)` grouped by `theme` to get the
- * total time spent per theme across all users. A random shuffle that flicks
- * through five themes in a few seconds therefore contributes five tiny spans —
- * a fraction of the weight of someone who sits on one theme for a whole game.
+ * Each uninterrupted period a theme is active is recorded — when it ends — as a
+ * standalone `theme.active` span carrying a `theme` attribute and the real
+ * wall-clock duration. Sentry's Trace Explorer can then `sum(span.duration)`
+ * grouped by `theme` for total time spent per theme across all users. A random
+ * shuffle that flicks through five themes in a few seconds contributes five tiny
+ * spans — a fraction of the weight of someone who sits on one theme for a game.
+ *
+ * The span is emitted with `forceTransaction: true` and explicit start/end
+ * timestamps. A span held open across the whole game would instead become a
+ * child of the browser-tracing pageload transaction and get truncated to that
+ * transaction's lifetime (a few seconds), so a multi-minute game was being
+ * recorded as a few milliseconds.
  *
  * Counting is suspended for independent reasons (see {@link ThemeTimerSuspendReason}):
  * while the tab is hidden, and while the end-of-game screen is up (the time
- * between a win and starting a new game is dead time, not theme usage). The span
- * is closed — and thus sent — the moment any reason kicks in, and a fresh span
- * opens once every reason has cleared.
+ * between a win and starting a new game is dead time, not theme usage). Each
+ * segment is recorded the moment any reason kicks in, and a fresh one starts
+ * once every reason has cleared.
  */
 export type ThemeTimerSuspendReason = 'hidden' | 'game-over';
 
 let activeTheme: Theme | null = null;
-let activeSpan: Span | null = null;
-let segmentStart = 0;
+// Epoch ms when the current segment started, or null when not counting.
+let segmentStart: number | null = null;
 const suspendedFor = new Set<ThemeTimerSuspendReason>();
 
-function openSpan(theme: Theme): void {
-  segmentStart = Date.now();
-  activeSpan = Sentry.startInactiveSpan({
+function emitSegment(theme: Theme, startMs: number, endMs: number): void {
+  const durationMs = endMs - startMs;
+  if (durationMs <= 0) return;
+
+  const span = Sentry.startInactiveSpan({
     name: 'theme.active',
     op: 'ui.theme',
-    attributes: { theme },
+    forceTransaction: true,
+    startTime: new Date(startMs),
+    attributes: { theme, 'theme.duration_ms': durationMs },
   });
-}
-
-function closeSpan(): void {
-  if (!activeSpan) return;
-  activeSpan.end();
-  activeSpan = null;
+  span.end(new Date(endMs));
 
   if (import.meta.env.DEV) {
-    console.info('[theme-analytics] duration', {
-      theme: activeTheme,
-      durationMs: Date.now() - segmentStart,
-    });
+    console.info('[theme-analytics] duration', { theme, durationMs });
   }
 }
 
-/** Opens or closes the span so it matches the desired running state. */
+/** Closes the running segment, if any, recording its duration. */
+function stopSegment(): void {
+  if (activeTheme !== null && segmentStart !== null) {
+    emitSegment(activeTheme, segmentStart, Date.now());
+  }
+  segmentStart = null;
+}
+
+/** Starts or stops the current segment to match the desired running state. */
 function sync(): void {
   const shouldRun = activeTheme !== null && suspendedFor.size === 0;
-  if (shouldRun && !activeSpan) {
-    openSpan(activeTheme as Theme);
-  } else if (!shouldRun && activeSpan) {
-    closeSpan();
+  if (shouldRun && segmentStart === null) {
+    segmentStart = Date.now();
+  } else if (!shouldRun && segmentStart !== null) {
+    stopSegment();
   }
 }
 
 /**
- * Switches the timer to `theme`, closing the previous theme's segment. Called
+ * Switches the timer to `theme`, recording the previous theme's segment. Called
  * whenever the resolved theme changes (initial load included).
  */
 export function recordActiveTheme(theme: Theme): void {
   if (theme === activeTheme) return;
-  closeSpan();
+  stopSegment();
   activeTheme = theme;
   tagActiveTheme(theme);
   sync();


### PR DESCRIPTION
## Problem

Follow-up to #159. In Sentry, `sum(span.duration)` grouped by `theme` showed a full multi-minute game as only **~69ms**.

**Cause:** the `theme.active` span was opened at app load and held open for the whole game. `startInactiveSpan` creates the span as a **child of the currently-active span** — at load that's the browser-tracing *pageload transaction*, which finishes a few seconds later. When a parent transaction ends, its still-open child spans are truncated to the parent's lifetime, so the whole game collapsed to a few milliseconds.

## Fix

Record each segment **when it ends** instead of holding a span open:

- Emitted with `forceTransaction: true`, so it's a standalone root span with no parent to truncate it.
- Explicit `startTime` / `end()` timestamps capture the true wall-clock duration regardless of any active trace.
- Also exposes the duration as a `theme.duration_ms` span attribute (handy if you'd rather `sum(theme.duration_ms)`).

Suspend/resume semantics (tab-hidden, end-of-game screen) are unchanged — a segment is recorded the moment any reason kicks in, and a fresh one starts once every reason clears.

## Reading the data

Trace Explorer → filter `span.op:ui.theme` → Visualize `sum(span.duration)` (or `sum(theme.duration_ms)`), Group By `theme`. Durations now reflect real time on each theme.

## Testing

- `themeUsageTimer` tests rewritten for emit-at-close, using fake timers to assert real durations (e.g. a 90s segment emits a span with `theme.duration_ms: 90000`, `forceTransaction: true`, and matching start/end `Date`s).
- `pnpm --filter @skipbo/web typecheck` and the web test suite (222 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)