### PR TITLE
fix(web): apply pending update at safe game state, not on a timer

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@ import { ResumeGameBanner } from '@/components/ResumeGameBanner';
 import { LocalGameBoard } from '@/components/LocalGameBoard';
 import { useCardAnimation } from '@/contexts/useCardAnimation';
 import { animationServiceBridge } from '@/lib/animationServiceBridge';
+import { isSafeToApplyLocalUpdate } from '@/lib/localUpdateGate';
 import { canPlayCard } from '@/lib/validators';
 import { createOnlineRoom, joinOnlineRoom } from '@/online/api';
 import { getStoredStockSize } from '@/state/initialGameState';
@@ -80,19 +81,11 @@ function LocalGameScreen({
     selectCard,
   } = useLocalSkipBoGame();
 
-  // A local reload always re-deals a fresh game (it isn't persisted), so the
-  // only lossless moment to apply a pending update is before the player has
-  // touched the freshly dealt game. "Untouched" = nothing has been played to a
-  // build pile and nobody has discarded yet; a start-of-turn draw doesn't count.
-  // Unlike the old launch timer this has no deadline, so a service worker that
+  // Apply a pending update without a wall-clock deadline: a service worker that
   // finishes downloading minutes after open is still caught on the next idle
-  // render — while an in-progress game is never reloaded out from under the
-  // player. Online's equivalent safe-moment gate lives in OnlineGameScreen.
-  const isLocalGameUntouched =
-    gameState.buildPiles.every((pile) => pile.length === 0) &&
-    gameState.completedBuildPiles.length === 0 &&
-    gameState.players.every((player) => player.discardPiles.every((pile) => pile.length === 0));
-  const isSafeToApplyUpdate = !gameState.gameIsOver && isLocalGameUntouched;
+  // render, while an in-progress game is never reloaded out from under the
+  // player. See isSafeToApplyLocalUpdate for what counts as a lossless moment.
+  const isSafeToApplyUpdate = isSafeToApplyLocalUpdate(gameState);
 
   useEffect(() => {
     if (isUpdatePending && isSafeToApplyUpdate) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -54,14 +54,19 @@ function FixtureApp({ fixtureName }: { fixtureName: UiFixtureName }) {
   );
 }
 
+interface LocalGameScreenProps extends SessionScreenProps {
+  applyUpdateWhenSafe: () => void;
+}
+
 function LocalGameScreen({
+  applyUpdateWhenSafe,
   isUpdatePending,
   onJoinOnlineGame,
   onReplay,
   onStartLocalGame,
   onStartOnlineGame,
   updateNotice,
-}: SessionScreenProps) {
+}: LocalGameScreenProps) {
   const {
     clearSelection,
     debugFillBuildPile,
@@ -74,6 +79,27 @@ function LocalGameScreen({
     playCard,
     selectCard,
   } = useLocalSkipBoGame();
+
+  // A local reload always re-deals a fresh game (it isn't persisted), so the
+  // only lossless moment to apply a pending update is before the player has
+  // touched the freshly dealt game. "Untouched" = nothing has been played to a
+  // build pile and nobody has discarded yet; a start-of-turn draw doesn't count.
+  // Unlike the old launch timer this has no deadline, so a service worker that
+  // finishes downloading minutes after open is still caught on the next idle
+  // render — while an in-progress game is never reloaded out from under the
+  // player. Online's equivalent safe-moment gate lives in OnlineGameScreen.
+  const isLocalGameUntouched =
+    gameState.buildPiles.every((pile) => pile.length === 0) &&
+    gameState.completedBuildPiles.length === 0 &&
+    gameState.players.every((player) => player.discardPiles.every((pile) => pile.length === 0));
+  const isSafeToApplyUpdate = !gameState.gameIsOver && isLocalGameUntouched;
+
+  useEffect(() => {
+    if (isUpdatePending && isSafeToApplyUpdate) {
+      applyUpdateWhenSafe();
+    }
+  }, [isUpdatePending, isSafeToApplyUpdate, applyUpdateWhenSafe]);
+
   const gameBoard = (
     <LocalGameBoard
       gameState={gameState}
@@ -131,7 +157,7 @@ function LiveApp() {
     latestAppVersion,
     minimumSupportedVersion,
     reloadToUpdate,
-  } = usePwaVersionGate({ deferHardUpdate: isLocalMode, autoApplyPendingOnLaunch: isLocalMode });
+  } = usePwaVersionGate({ deferHardUpdate: isLocalMode });
 
   useEffect(() => {
     animationServiceBridge.waitForAnimations = waitForAnimations;
@@ -251,6 +277,7 @@ function LiveApp() {
     ) : (
       <LocalGameScreen
         key={`local-${localSessionVersion}`}
+        applyUpdateWhenSafe={applyUpdateOnceForCurrentTarget}
         isUpdatePending={isUpdatePending}
         onJoinOnlineGame={joinGame}
         onReplay={replayCurrentGame}

--- a/apps/web/src/config/timing.ts
+++ b/apps/web/src/config/timing.ts
@@ -19,13 +19,3 @@ export const PWA_UPDATE_CHECK_INTERVAL_MS = 10 * 60 * 1000;
 // `registration.update()` + runtime-config fetches. The periodic poll above is
 // unaffected.
 export const PWA_UPDATE_RECHECK_MIN_INTERVAL_MS = 30 * 1000;
-
-// Window after launch during which a pending soft update is applied
-// automatically (local mode only). Players typically open the app and start
-// playing before the new service worker finishes downloading, so the
-// "apply on New Game" path never fires for them. The local game is always
-// freshly dealt on launch, so reloading within this window loses nothing; the
-// margin is generous enough to outlast a slow bundle download. After it
-// elapses we revert to the deferred behavior so an in-progress game is never
-// reloaded out from under the player by a background update.
-export const PWA_LAUNCH_AUTO_UPDATE_WINDOW_MS = 60 * 1000;

--- a/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
@@ -148,7 +148,12 @@ describe('usePwaVersionGate', () => {
   });
 
   it('applies a pending soft update at most once per target version', async () => {
-    applyServiceWorkerUpdateMock.mockResolvedValue(true);
+    // A real apply fires the reload, so it records the per-version guard via the
+    // onReloadCommitted callback the hook passes in.
+    applyServiceWorkerUpdateMock.mockImplementation(async (onReloadCommitted?: () => void) => {
+      onReloadCommitted?.();
+      return true;
+    });
 
     const { result } = renderHook(() => usePwaVersionGate());
 
@@ -166,11 +171,60 @@ describe('usePwaVersionGate', () => {
 
     await act(async () => {
       result.current.applyUpdateOnceForCurrentTarget();
+      await Promise.resolve();
+    });
+
+    expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
+
+    // The version's single attempt is now recorded, so a later call is a no-op.
+    await act(async () => {
       result.current.applyUpdateOnceForCurrentTarget();
       await Promise.resolve();
     });
 
     expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not burn the version attempt when the apply is a no-op (retries later)', async () => {
+    // First apply finds no waiting worker (runtime config raced ahead of the
+    // service worker): no reload fires, onReloadCommitted is never called, so the
+    // guard stays unset.
+    applyServiceWorkerUpdateMock.mockResolvedValueOnce(false);
+
+    const { result } = renderHook(() => usePwaVersionGate());
+
+    await waitFor(() => {
+      expect(fetchRuntimeConfigMock).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      emitPwaSnapshot({ needRefresh: true });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isUpdatePending).toBe(true);
+    });
+
+    await act(async () => {
+      result.current.applyUpdateOnceForCurrentTarget();
+      await Promise.resolve();
+    });
+
+    expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
+
+    // The worker has now caught up; the next attempt for the same version retries
+    // instead of being blocked by a burned guard.
+    applyServiceWorkerUpdateMock.mockImplementation(async (onReloadCommitted?: () => void) => {
+      onReloadCommitted?.();
+      return true;
+    });
+
+    await act(async () => {
+      result.current.applyUpdateOnceForCurrentTarget();
+      await Promise.resolve();
+    });
+
+    expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(2);
   });
 
   it('never auto-applies a pending soft update on its own (callers drive it at a safe moment)', async () => {

--- a/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
@@ -43,7 +43,7 @@ vi.mock('@/lib/pwaUpdates', () => ({
   },
 }));
 
-import { PWA_LAUNCH_AUTO_UPDATE_WINDOW_MS, PWA_UPDATE_RECHECK_MIN_INTERVAL_MS } from '@/config/timing';
+import { PWA_UPDATE_RECHECK_MIN_INTERVAL_MS } from '@/config/timing';
 
 import { AUTO_RELOAD_SESSION_STORAGE_KEY, usePwaVersionGate } from '../usePwaVersionGate';
 
@@ -173,29 +173,7 @@ describe('usePwaVersionGate', () => {
     expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
   });
 
-  it('auto-applies a pending soft update that lands within the launch window', async () => {
-    applyServiceWorkerUpdateMock.mockResolvedValue(true);
-
-    const { result } = renderHook(() => usePwaVersionGate({ autoApplyPendingOnLaunch: true }));
-
-    await waitFor(() => {
-      expect(fetchRuntimeConfigMock).toHaveBeenCalledTimes(1);
-    });
-
-    // The service worker reaches `waiting` a few seconds after mount, still
-    // inside the launch window.
-    currentTime += 5_000;
-    act(() => {
-      emitPwaSnapshot({ needRefresh: true });
-    });
-
-    await waitFor(() => {
-      expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
-    });
-    expect(result.current.isUpdatePending).toBe(true);
-  });
-
-  it('does not auto-apply on launch when the option is off (the default)', async () => {
+  it('never auto-applies a pending soft update on its own (callers drive it at a safe moment)', async () => {
     applyServiceWorkerUpdateMock.mockResolvedValue(true);
 
     const { result } = renderHook(() => usePwaVersionGate());
@@ -213,28 +191,8 @@ describe('usePwaVersionGate', () => {
     });
     await Promise.resolve();
 
-    expect(applyServiceWorkerUpdateMock).not.toHaveBeenCalled();
-  });
-
-  it('does not auto-apply a soft update that lands after the launch window elapses', async () => {
-    applyServiceWorkerUpdateMock.mockResolvedValue(true);
-
-    const { result } = renderHook(() => usePwaVersionGate({ autoApplyPendingOnLaunch: true }));
-
-    await waitFor(() => {
-      expect(fetchRuntimeConfigMock).toHaveBeenCalledTimes(1);
-    });
-
-    currentTime += PWA_LAUNCH_AUTO_UPDATE_WINDOW_MS;
-    act(() => {
-      emitPwaSnapshot({ needRefresh: true });
-    });
-
-    await waitFor(() => {
-      expect(result.current.isUpdatePending).toBe(true);
-    });
-    await Promise.resolve();
-
+    // The hook surfaces the pending update but leaves the reload to the caller's
+    // safe-moment gate (a fresh local game / a safe point online).
     expect(applyServiceWorkerUpdateMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/hooks/usePwaVersionGate.ts
+++ b/apps/web/src/hooks/usePwaVersionGate.ts
@@ -128,7 +128,7 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
     });
   });
 
-  const runReloadToUpdate = useCallback(async () => {
+  const runReloadToUpdate = useCallback(async (onReloadCommitted?: () => void) => {
     if (isApplyingUpdateRef.current) {
       return;
     }
@@ -140,7 +140,7 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
       // No `location.reload()` fallback: reloading without a freshly installed
       // worker re-serves the same precached bundle, which on iOS standalone
       // PWAs loops splash → blank → reload whenever a hard update is required.
-      await applyServiceWorkerUpdate().catch(() => false);
+      await applyServiceWorkerUpdate(onReloadCommitted).catch(() => false);
     } finally {
       isApplyingUpdateRef.current = false;
       setIsApplyingUpdate(false);
@@ -222,9 +222,15 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
   // Apply a pending soft update at most once per target version. Callers invoke
   // this at a lossless moment (a fresh/untouched local game, or a safe point in
   // an online game) so a background update lands without a wall-clock deadline —
-  // a slow service-worker download is still caught whenever it finishes. The
-  // sessionStorage guard survives `location.reload()`, so a deploy that
-  // advertises a version it isn't actually serving yet can't reload-loop.
+  // a slow service-worker download is still caught whenever it finishes.
+  //
+  // The per-version guard is written from `onReloadCommitted`, i.e. only once a
+  // reload is actually firing. A no-op apply — the `runtime:` channel advertising
+  // a version the service worker hasn't staged yet, so there's no waiting worker
+  // — leaves the guard unset, so a later safe render retries instead of burning
+  // this version's single attempt. The write still lands before navigation, so
+  // the sessionStorage guard survives `location.reload()` and a deploy that
+  // reloads without advancing the version can't reload-loop.
   const applyUpdateOnceForCurrentTarget = useCallback(() => {
     if (!isUpdatePending || !updateKey) {
       return;
@@ -234,8 +240,7 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
       return;
     }
 
-    writeSoftAutoReloadKey(updateKey);
-    void runReloadToUpdate();
+    void runReloadToUpdate(() => writeSoftAutoReloadKey(updateKey));
   }, [isUpdatePending, updateKey, runReloadToUpdate]);
 
   const dismissJustUpdated = useCallback(() => {

--- a/apps/web/src/hooks/usePwaVersionGate.ts
+++ b/apps/web/src/hooks/usePwaVersionGate.ts
@@ -9,11 +9,7 @@ import {
 } from '@/lib/pwaUpdates';
 import { fetchRuntimeConfig } from '@/lib/runtimeConfig';
 import { compareAppVersions, normalizeVersionTag } from '@/lib/versionUtils';
-import {
-  PWA_LAUNCH_AUTO_UPDATE_WINDOW_MS,
-  PWA_UPDATE_CHECK_INTERVAL_MS,
-  PWA_UPDATE_RECHECK_MIN_INTERVAL_MS,
-} from '@/config/timing';
+import { PWA_UPDATE_CHECK_INTERVAL_MS, PWA_UPDATE_RECHECK_MIN_INTERVAL_MS } from '@/config/timing';
 export const AUTO_RELOAD_SESSION_STORAGE_KEY = 'skipbo:pwa-auto-reload-version';
 export const SOFT_AUTO_RELOAD_SESSION_STORAGE_KEY = 'skipbo:pwa-soft-auto-reload-key';
 export const LAST_SEEN_VERSION_STORAGE_KEY = 'skipbo:last-seen-version';
@@ -96,21 +92,9 @@ export interface UsePwaVersionGateOptions {
   // for multiplayer, so the caller defers the hard update until a lossless moment
   // (new game / replay / going online) and applies it imperatively there.
   deferHardUpdate?: boolean;
-  // While true, a pending soft update is applied automatically if it becomes
-  // available within PWA_LAUNCH_AUTO_UPDATE_WINDOW_MS of mount. Players usually
-  // open the app and start playing before the new service worker finishes
-  // downloading, so the deferred "apply on New Game" path never fires for them.
-  // The local game is freshly dealt on launch, so reloading within the window
-  // loses nothing; once it elapses we fall back to deferring so an in-progress
-  // game is never reloaded away by a background update.
-  autoApplyPendingOnLaunch?: boolean;
 }
 
-export const usePwaVersionGate = ({
-  deferHardUpdate = false,
-  autoApplyPendingOnLaunch = false,
-}: UsePwaVersionGateOptions = {}): PwaVersionGateState => {
-  const mountedAtRef = useRef(0);
+export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGateOptions = {}): PwaVersionGateState => {
   const [dismissedUpdateKey, setDismissedUpdateKey] = useState<string | null>(null);
   const [isApplyingUpdate, setIsApplyingUpdate] = useState(false);
   const [justUpdatedFromVersion, setJustUpdatedFromVersion] = useState<string | null>(() => {
@@ -168,7 +152,6 @@ export const usePwaVersionGate = ({
   });
 
   useEffect(() => {
-    mountedAtRef.current = Date.now();
     void checkForUpdates();
 
     const intervalId = globalThis.setInterval(() => {
@@ -236,7 +219,10 @@ export const usePwaVersionGate = ({
     writeLastSeenVersion(APP_VERSION);
   }, []);
 
-  // Apply a pending soft update at most once per target version. The
+  // Apply a pending soft update at most once per target version. Callers invoke
+  // this at a lossless moment (a fresh/untouched local game, or a safe point in
+  // an online game) so a background update lands without a wall-clock deadline —
+  // a slow service-worker download is still caught whenever it finishes. The
   // sessionStorage guard survives `location.reload()`, so a deploy that
   // advertises a version it isn't actually serving yet can't reload-loop.
   const applyUpdateOnceForCurrentTarget = useCallback(() => {
@@ -251,22 +237,6 @@ export const usePwaVersionGate = ({
     writeSoftAutoReloadKey(updateKey);
     void runReloadToUpdate();
   }, [isUpdatePending, updateKey, runReloadToUpdate]);
-
-  // Apply a pending soft update automatically when it lands within the launch
-  // window. This re-runs when `isUpdatePending` flips true (the service worker
-  // typically reaches `waiting` a few seconds after mount), so a slow download
-  // is still caught as long as it finishes inside the window.
-  useEffect(() => {
-    if (!autoApplyPendingOnLaunch || !isUpdatePending) {
-      return;
-    }
-
-    if (Date.now() - mountedAtRef.current >= PWA_LAUNCH_AUTO_UPDATE_WINDOW_MS) {
-      return;
-    }
-
-    applyUpdateOnceForCurrentTarget();
-  }, [autoApplyPendingOnLaunch, isUpdatePending, applyUpdateOnceForCurrentTarget]);
 
   const dismissJustUpdated = useCallback(() => {
     setJustUpdatedFromVersion(null);

--- a/apps/web/src/lib/__tests__/localUpdateGate.test.ts
+++ b/apps/web/src/lib/__tests__/localUpdateGate.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSafeToApplyLocalUpdate } from '@/lib/localUpdateGate';
+import { initialGameState } from '@/state/initialGameState';
+import type { Card } from '@/types';
+
+const card: Card = { value: 5, isSkipBo: false };
+
+describe('isSafeToApplyLocalUpdate', () => {
+  it('is safe on a freshly dealt, untouched game', () => {
+    expect(isSafeToApplyLocalUpdate(initialGameState())).toBe(true);
+  });
+
+  it('is not safe once the game is over', () => {
+    expect(isSafeToApplyLocalUpdate({ ...initialGameState(), gameIsOver: true })).toBe(false);
+  });
+
+  it('is not safe once a card has been played to a build pile', () => {
+    const gameState = initialGameState();
+    gameState.buildPiles[0] = [card];
+    expect(isSafeToApplyLocalUpdate(gameState)).toBe(false);
+  });
+
+  it('is not safe once a build pile has been completed', () => {
+    const gameState = initialGameState();
+    gameState.completedBuildPiles = [card];
+    expect(isSafeToApplyLocalUpdate(gameState)).toBe(false);
+  });
+
+  it('is not safe once a player has discarded', () => {
+    const gameState = initialGameState();
+    gameState.players[0].discardPiles[0] = [card];
+    expect(isSafeToApplyLocalUpdate(gameState)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/pwaUpdates.test.ts
+++ b/apps/web/src/lib/__tests__/pwaUpdates.test.ts
@@ -168,6 +168,30 @@ describe('pwaUpdates', () => {
     expect(applied).toBe(true);
   });
 
+  it('invokes onReloadCommitted only when a reload actually fires', async () => {
+    const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
+    initializePwaUpdates();
+
+    const onReloadCommitted = vi.fn();
+
+    // No waiting worker → no reload → callback must not fire (so the caller's
+    // per-version guard isn't burned on a no-op apply).
+    const noWorker = buildFakeRegistration();
+    registerOptions.onRegisteredSW?.('/sw.js', noWorker as unknown as ServiceWorkerRegistration);
+    expect(await applyServiceWorkerUpdate(onReloadCommitted)).toBe(false);
+    expect(onReloadCommitted).not.toHaveBeenCalled();
+
+    // Waiting worker present → reload fires → callback runs once, before the
+    // activate + reload.
+    const withWorker = buildFakeRegistration();
+    withWorker.waiting = new FakeServiceWorker();
+    withWorker.waiting.state = 'installed';
+    registerOptions.onRegisteredSW?.('/sw.js', withWorker as unknown as ServiceWorkerRegistration);
+    expect(await applyServiceWorkerUpdate(onReloadCommitted)).toBe(true);
+    expect(onReloadCommitted).toHaveBeenCalledTimes(1);
+    expect(updateServiceWorkerMock).toHaveBeenCalledWith(true);
+  });
+
   it('times out the install wait so the promise never hangs forever', async () => {
     vi.useFakeTimers();
 

--- a/apps/web/src/lib/localUpdateGate.ts
+++ b/apps/web/src/lib/localUpdateGate.ts
@@ -1,0 +1,15 @@
+import type { GameState } from '@/types';
+
+/**
+ * Whether a pending PWA update can be applied to a local game without losing
+ * anything. A local reload always re-deals a fresh game (it isn't persisted), so
+ * the only lossless moment is before the player has touched the freshly dealt
+ * game: nothing played to a build pile, no build pile completed, and nobody has
+ * discarded yet. A start-of-turn draw doesn't count. Online's equivalent
+ * safe-moment gate lives in OnlineGameScreen.
+ */
+export const isSafeToApplyLocalUpdate = (gameState: GameState): boolean =>
+  !gameState.gameIsOver &&
+  gameState.buildPiles.every((pile) => pile.length === 0) &&
+  gameState.completedBuildPiles.length === 0 &&
+  gameState.players.every((player) => player.discardPiles.every((pile) => pile.length === 0));

--- a/apps/web/src/lib/pwaUpdates.ts
+++ b/apps/web/src/lib/pwaUpdates.ts
@@ -109,7 +109,12 @@ const waitForInstallingWorker = (worker: ServiceWorker, timeoutMs: number): Prom
     worker.addEventListener('statechange', handleStateChange);
   });
 
-export const applyServiceWorkerUpdate = async (): Promise<boolean> => {
+// `onReloadCommitted` runs at the single instant the update is about to be
+// applied — after a waiting worker is confirmed, just before the activate +
+// reload. Callers use it to record a per-version guard that must survive the
+// reload yet must not be written on the no-op path (no waiting worker), so a
+// transient miss doesn't burn that version's one attempt.
+export const applyServiceWorkerUpdate = async (onReloadCommitted?: () => void): Promise<boolean> => {
   const registration = snapshot.registration;
   if (!registration || !updateServiceWorker) {
     return false;
@@ -132,6 +137,7 @@ export const applyServiceWorkerUpdate = async (): Promise<boolean> => {
   }
 
   if (snapshot.needRefresh || registration.waiting) {
+    onReloadCommitted?.();
     await updateServiceWorker(true);
     return true;
   }


### PR DESCRIPTION
## Problem

When opening Skip-Bo, the launch auto-upgrade never fired — you had to start a New Game or kill/restart the app to pick up a new version.

Root cause: local-mode auto-update was gated by a **60s wall-clock window from app mount** (`PWA_LAUNCH_AUTO_UPDATE_WINDOW_MS`). The runtime-config check detects a new version in ~1s, but the service worker — the only thing that can actually reload — frequently doesn't reach `waiting` until after that window closes, especially on iOS standalone PWAs. So the launch auto-apply consistently missed the SW becoming ready.

## Fix

Replace the timer with the same **safe-moment gate online mode already uses** (`isSafeToApplyUpdate` in `OnlineGameScreen`), with no deadline:

- `LocalGameScreen` applies a pending update whenever the local game is **untouched** (nothing played to a build pile, no completed piles, no discards — a start-of-turn draw doesn't count) and not over.
- A service worker that finishes downloading minutes after open is now caught on the next idle render, while an in-progress game is never reloaded out from under the player.
- Removed the now-unused `autoApplyPendingOnLaunch` option, the wall-clock effect, `mountedAtRef`, and the `PWA_LAUNCH_AUTO_UPDATE_WINDOW_MS` constant.

## Tests

- Replaced the three launch-window hook tests with one asserting the hook never auto-applies on its own (callers drive it at a safe moment).
- `pnpm --filter @skipbo/web test`, `lint`, and `typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)