### PR TITLE
fix(game-core): scale deck size to avoid early draw-pile depletion

### DIFF
--- a/apps/web/src/components/__tests__/CenterArea.test.tsx
+++ b/apps/web/src/components/__tests__/CenterArea.test.tsx
@@ -8,6 +8,7 @@ import type { Card, GameConfig, GameState, Player } from '@/types';
 const FIXTURE_CONFIG: GameConfig = {
   DECK_SIZE: 162,
   SKIP_BO_CARDS: 18,
+  CARD_COPIES_PER_RANK: 12,
   HAND_SIZE: 5,
   STOCK_SIZE: 30,
   BUILD_PILES_COUNT: 4,

--- a/apps/web/src/components/__tests__/DragSelection.test.tsx
+++ b/apps/web/src/components/__tests__/DragSelection.test.tsx
@@ -28,6 +28,7 @@ const createHandlers = (): MockHandlers => ({
 const FIXTURE_CONFIG: GameConfig = {
   DECK_SIZE: 162,
   SKIP_BO_CARDS: 18,
+  CARD_COPIES_PER_RANK: 12,
   HAND_SIZE: 5,
   STOCK_SIZE: 30,
   BUILD_PILES_COUNT: 4,

--- a/apps/web/src/components/__tests__/OnlineAnimationMasking.test.tsx
+++ b/apps/web/src/components/__tests__/OnlineAnimationMasking.test.tsx
@@ -10,6 +10,7 @@ import type { Card, GameConfig, GameState, Player } from '@/types';
 const FIXTURE_CONFIG: GameConfig = {
   DECK_SIZE: 162,
   SKIP_BO_CARDS: 18,
+  CARD_COPIES_PER_RANK: 12,
   HAND_SIZE: 5,
   STOCK_SIZE: 30,
   BUILD_PILES_COUNT: 4,

--- a/apps/web/src/services/__tests__/completedBuildPileAnimationService.test.ts
+++ b/apps/web/src/services/__tests__/completedBuildPileAnimationService.test.ts
@@ -60,6 +60,7 @@ const createGameState = (): GameState => ({
     DISCARD_PILES_COUNT: 4,
     HAND_SIZE: 5,
     SKIP_BO_CARDS: 18,
+    CARD_COPIES_PER_RANK: 12,
     STOCK_SIZE: 30,
   },
 });

--- a/apps/web/src/testing/uiFixtures.ts
+++ b/apps/web/src/testing/uiFixtures.ts
@@ -15,6 +15,7 @@ export type UiFixtureName = (typeof uiFixtureNames)[number];
 const FIXTURE_CONFIG: GameConfig = {
   DECK_SIZE: 162,
   SKIP_BO_CARDS: 18,
+  CARD_COPIES_PER_RANK: 12,
   HAND_SIZE: 5,
   STOCK_SIZE: 30,
   BUILD_PILES_COUNT: 4,

--- a/packages/game-core/src/state/deck.ts
+++ b/packages/game-core/src/state/deck.ts
@@ -12,9 +12,9 @@ export const createDeck = (config: GameConfig): Card[] => {
   // Skip-Bo
   for (let i = 0; i < config.SKIP_BO_CARDS; i++) deck.push(createCard(config.CARD_VALUES_SKIP_BO, true));
 
-  // 12 × (1-12)
+  // CARD_COPIES_PER_RANK × (CARD_VALUES_MIN-CARD_VALUES_MAX)
   for (let v = config.CARD_VALUES_MIN; v <= config.CARD_VALUES_MAX; v++)
-    for (let i = 0; i < 12; i++) deck.push(createCard(v, false));
+    for (let i = 0; i < config.CARD_COPIES_PER_RANK; i++) deck.push(createCard(v, false));
 
   return shuffle(deck);
 };

--- a/packages/game-core/src/state/initialGameState.ts
+++ b/packages/game-core/src/state/initialGameState.ts
@@ -65,16 +65,46 @@ export function getStoredStockSize(): number {
   return DEFAULT_STOCK_SIZE;
 }
 
+// Standard Skip-Bo deck: 12 copies each of ranks 1-12 (144 cards) + 18 Skip-Bo cards (162 total).
+const BASE_CARD_COPIES_PER_RANK = 12;
+const BASE_SKIP_BO_CARDS = 18;
+
+// When dealing leaves fewer than this many cards in the draw pile, grow the deck by adding
+// extra "decks worth" of cards (2 copies of each rank + 3 Skip-Bo cards = 27 cards per step)
+// until the remaining draw pile is large enough again.
+const MIN_REMAINING_DECK_CARDS = 60;
+const CARD_COPIES_PER_RANK_STEP = 2;
+const SKIP_BO_CARDS_STEP = 3;
+
 function getGameConfig(options: InitialGameStateOptions = {}): GameConfig {
+  const stockSize = parseStockSize(options.stockSize) ?? getStoredStockSize();
+  const playerCount = parsePlayerCount(options.playerCount) ?? 2;
+  const handSize = 5;
+  const cardValuesMin = 1;
+  const cardValuesMax = 12;
+  const rankCount = cardValuesMax - cardValuesMin + 1;
+  const dealtCards = playerCount * (stockSize + handSize);
+
+  let cardCopiesPerRank = BASE_CARD_COPIES_PER_RANK;
+  let skipBoCards = BASE_SKIP_BO_CARDS;
+  let deckSize = cardCopiesPerRank * rankCount + skipBoCards;
+
+  while (deckSize - dealtCards < MIN_REMAINING_DECK_CARDS) {
+    cardCopiesPerRank += CARD_COPIES_PER_RANK_STEP;
+    skipBoCards += SKIP_BO_CARDS_STEP;
+    deckSize = cardCopiesPerRank * rankCount + skipBoCards;
+  }
+
   return {
-    DECK_SIZE: 162,
-    SKIP_BO_CARDS: 18,
-    HAND_SIZE: 5,
-    STOCK_SIZE: parseStockSize(options.stockSize) ?? getStoredStockSize(),
+    DECK_SIZE: deckSize,
+    SKIP_BO_CARDS: skipBoCards,
+    CARD_COPIES_PER_RANK: cardCopiesPerRank,
+    HAND_SIZE: handSize,
+    STOCK_SIZE: stockSize,
     BUILD_PILES_COUNT: 4,
     DISCARD_PILES_COUNT: 4,
-    CARD_VALUES_MIN: 1,
-    CARD_VALUES_MAX: 12,
+    CARD_VALUES_MIN: cardValuesMin,
+    CARD_VALUES_MAX: cardValuesMax,
     CARD_VALUES_SKIP_BO: 0,
   };
 }

--- a/packages/game-core/src/types/index.ts
+++ b/packages/game-core/src/types/index.ts
@@ -71,6 +71,7 @@ export type Theme = ThemeDetail['value'];
 export interface GameConfig {
   DECK_SIZE: number;
   SKIP_BO_CARDS: number;
+  CARD_COPIES_PER_RANK: number;
   HAND_SIZE: number;
   STOCK_SIZE: number;
   BUILD_PILES_COUNT: number;


### PR DESCRIPTION
## Summary
- With 4 players and the default 30-card stock pile, dealing (4×30 stock + 4×5 hand = 140 cards) left only 22 of the 162-card deck in the draw pile, exhausting it almost immediately.
- The deck now grows in 27-card steps (2 extra copies of each rank 1–12 + 3 extra Skip-Bo cards) whenever dealing would leave fewer than 60 cards in the draw pile, for any player count / stock size combination.
- Added `CARD_COPIES_PER_RANK` to `GameConfig` so `createDeck` no longer hardcodes 12 copies per rank.

## Test plan
- [x] `pnpm typecheck` passes across all packages
- [x] `pnpm lint` passes (format + eslint, 0 warnings)
- [x] `pnpm --filter @skipbo/game-core test` — 10/10 passing
- [x] `pnpm --filter @skipbo/web test` — 248/248 passing
- [x] Manually verified scaling math: 2p/30 stock → 162-card deck (92 remaining); 4p/30 stock → 216-card deck (76 remaining); 4p/20 stock (official rule) → 162-card deck (62 remaining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)