### PR TITLE
fix(web): recover from stale code-split chunk load failures

### DIFF
--- a/apps/web/src/lib/__tests__/chunkLoadRecovery.test.ts
+++ b/apps/web/src/lib/__tests__/chunkLoadRecovery.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sentryAddBreadcrumb = vi.fn();
+const sentryCaptureException = vi.fn();
+
+vi.mock('@sentry/react', () => ({
+  addBreadcrumb: (...args: unknown[]) => sentryAddBreadcrumb(...args),
+  captureException: (...args: unknown[]) => sentryCaptureException(...args),
+}));
+
+const reloadMock = vi.fn();
+
+const loadModule = async () => {
+  vi.resetModules();
+  return import('../chunkLoadRecovery');
+};
+
+const dispatchPreloadError = (payload: unknown) => {
+  const event = new Event('vite:preloadError', { cancelable: true });
+  (event as Event & { payload: unknown }).payload = payload;
+  window.dispatchEvent(event);
+  return event;
+};
+
+const originalLocation = window.location;
+
+describe('chunkLoadRecovery', () => {
+  beforeEach(() => {
+    sentryAddBreadcrumb.mockClear();
+    sentryCaptureException.mockClear();
+    reloadMock.mockClear();
+    window.sessionStorage.clear();
+    // jsdom's location.reload is non-configurable, so swap the whole object.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadMock },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+    vi.restoreAllMocks();
+  });
+
+  it('reloads once on the first preload error and records a breadcrumb', async () => {
+    const { installChunkLoadRecovery } = await loadModule();
+    installChunkLoadRecovery();
+
+    const event = dispatchPreloadError(new Error('Importing a module script failed.'));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(sentryAddBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'pwa', message: 'chunk-load-recovery:reload' }),
+    );
+    expect(sentryCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('does not reload again within the loop-guard window and surfaces the error', async () => {
+    const { handleChunkLoadFailure, CHUNK_RELOAD_TIMESTAMP_KEY } = await loadModule();
+
+    window.sessionStorage.setItem(CHUNK_RELOAD_TIMESTAMP_KEY, String(Date.now()));
+
+    const error = new Error('Importing a module script failed.');
+    handleChunkLoadFailure(error);
+
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(sentryCaptureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({ tags: { chunkLoadRecovery: 'loop-guard-tripped' } }),
+    );
+  });
+
+  it('reloads again once the loop-guard window has elapsed', async () => {
+    const { handleChunkLoadFailure, CHUNK_RELOAD_TIMESTAMP_KEY, CHUNK_RELOAD_LOOP_GUARD_MS } = await loadModule();
+
+    window.sessionStorage.setItem(CHUNK_RELOAD_TIMESTAMP_KEY, String(Date.now() - CHUNK_RELOAD_LOOP_GUARD_MS - 1));
+
+    handleChunkLoadFailure(new Error('Importing a module script failed.'));
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers the window listener only once', async () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+    const { installChunkLoadRecovery } = await loadModule();
+
+    installChunkLoadRecovery();
+    installChunkLoadRecovery();
+
+    const preloadRegistrations = addEventListenerSpy.mock.calls.filter(([type]) => type === 'vite:preloadError');
+    expect(preloadRegistrations).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/__tests__/chunkLoadRecovery.test.ts
+++ b/apps/web/src/lib/__tests__/chunkLoadRecovery.test.ts
@@ -81,6 +81,21 @@ describe('chunkLoadRecovery', () => {
     expect(reloadMock).toHaveBeenCalledTimes(1);
   });
 
+  it('still reloads when sessionStorage is unavailable (private mode)', async () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+
+    const { handleChunkLoadFailure } = await loadModule();
+    handleChunkLoadFailure(new Error('Importing a module script failed.'));
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(sentryCaptureException).not.toHaveBeenCalled();
+  });
+
   it('registers the window listener only once', async () => {
     const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
     const { installChunkLoadRecovery } = await loadModule();

--- a/apps/web/src/lib/chunkLoadRecovery.ts
+++ b/apps/web/src/lib/chunkLoadRecovery.ts
@@ -1,0 +1,66 @@
+import * as Sentry from '@sentry/react';
+
+// A code-split chunk can fail to load — surfacing on iOS Safari as
+// `TypeError: Importing a module script failed.` — when a client running a stale
+// precached build dynamically imports a hashed chunk that a newer deploy has
+// already replaced on the origin (the classic GitHub Pages / PWA stale-deploy
+// race). Reloading re-serves an internally consistent build (the precache, or a
+// freshly staged one) and recovers; the timestamp guard below keeps a genuinely
+// broken deploy from looping splash → blank → reload forever.
+export const CHUNK_RELOAD_TIMESTAMP_KEY = 'skipbo:chunk-reload-at';
+
+// If a chunk failure recurs within this window of our own recovery reload, the
+// reload didn't fix it — stop reloading and surface the error instead.
+export const CHUNK_RELOAD_LOOP_GUARD_MS = 10_000;
+
+const readLastReloadAt = (): number => {
+  try {
+    const raw = globalThis.sessionStorage?.getItem(CHUNK_RELOAD_TIMESTAMP_KEY);
+    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+    return Number.isFinite(parsed) ? parsed : 0;
+  } catch {
+    return 0;
+  }
+};
+
+const writeLastReloadAt = (at: number) => {
+  try {
+    globalThis.sessionStorage?.setItem(CHUNK_RELOAD_TIMESTAMP_KEY, String(at));
+  } catch {
+    // private mode / disabled storage — silently no-op
+  }
+};
+
+let installed = false;
+
+export const handleChunkLoadFailure = (error: unknown): void => {
+  const at = Date.now();
+
+  // Loop guard: a second failure right after our recovery reload means the
+  // reload didn't help (the chunk is genuinely gone or the service worker is
+  // wedged). Capture it so it's visible in telemetry rather than reload-looping.
+  if (at - readLastReloadAt() < CHUNK_RELOAD_LOOP_GUARD_MS) {
+    Sentry.captureException(error, { tags: { chunkLoadRecovery: 'loop-guard-tripped' } });
+    return;
+  }
+
+  Sentry.addBreadcrumb({ category: 'pwa', message: 'chunk-load-recovery:reload', level: 'warning' });
+  writeLastReloadAt(at);
+  globalThis.location.reload();
+};
+
+export const installChunkLoadRecovery = (): void => {
+  if (installed || typeof window === 'undefined') {
+    return;
+  }
+  installed = true;
+
+  // Vite dispatches `vite:preloadError` on window when a dynamically imported
+  // module (here: the lazily loaded OnlineGameScreen chunk) fails to load.
+  // preventDefault() stops Vite from rethrowing so we own the recovery instead
+  // of the error propagating past Suspense and crashing the app.
+  window.addEventListener('vite:preloadError', (event) => {
+    event.preventDefault();
+    handleChunkLoadFailure(event.payload);
+  });
+};

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,7 +4,9 @@ import './index.css';
 import Root from '@/Root.tsx';
 import { reactErrorHandler } from '@sentry/react';
 import { initializePwaUpdates } from '@/lib/pwaUpdates';
+import { installChunkLoadRecovery } from '@/lib/chunkLoadRecovery';
 
+installChunkLoadRecovery();
 initializePwaUpdates();
 
 ReactDOM.createRoot(document.getElementById('root')!, {


### PR DESCRIPTION
## Problem

Sentry [SKIP-BO-FRONTEND-4](https://pierre-luc.sentry.io/issues/SKIP-BO-FRONTEND-4): `TypeError: Importing a module script failed.` on Mobile Safari (iOS), release v2.9.0.

A client running a **stale precached build** dynamically imports the hashed `OnlineGameScreen` chunk ([App.tsx:28](apps/web/src/App.tsx#L28)). After a redeploy on GitHub Pages that hash is gone, the import rejects, propagates past the `<Suspense fallback={null}>` (which has **no error boundary**, [App.tsx:256](apps/web/src/App.tsx#L256)), and crashes the app. Nothing listened for Vite's `vite:preloadError`, so there was no recovery path.

## Fix

- New [`chunkLoadRecovery.ts`](apps/web/src/lib/chunkLoadRecovery.ts): listens for `vite:preloadError`, `preventDefault()`s it, and fires a **one-shot `location.reload()`** that re-serves an internally consistent build (recovering the chunk from precache).
- A **10s `sessionStorage` loop-guard** stops a genuinely broken deploy from looping splash→blank→reload; instead it captures to Sentry so the stuck client stays visible.
- Wired `installChunkLoadRecovery()` into [`main.tsx`](apps/web/src/main.tsx) before render.

### Why guarded `location.reload()` (not the SW-update path)
The existing `applyServiceWorkerUpdate` flow only reloads when a *new* version is staged. Chunk recovery needs the *current* build's missing asset, which a plain reload pulls from precache; the loop-guard handles the pathological "chunk permanently gone" case.

## Tests

[`chunkLoadRecovery.test.ts`](apps/web/src/lib/__tests__/chunkLoadRecovery.test.ts) — reload + breadcrumb on first error, loop-guard suppression + Sentry capture, retry after the window elapses, single listener registration. Web suite: 252 passed. Typecheck + lint clean.

## Follow-ups (not in this PR)
- An error boundary around the `OnlineGameScreen` Suspense for a graceful in-app fallback if recovery can't reload.
- Optionally prefer applying a *waiting* service worker (new consistent build) before falling back to `location.reload()`.

Fixes SKIP-BO-FRONTEND-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)