### PR TITLE
feat(web): replace update dot with "Mettre à jour" button

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -61,11 +61,13 @@ interface LocalGameScreenProps extends SessionScreenProps {
 
 function LocalGameScreen({
   applyUpdateWhenSafe,
+  isApplyingUpdate,
   isUpdatePending,
   onJoinOnlineGame,
   onReplay,
   onStartLocalGame,
   onStartOnlineGame,
+  onUpdateNow,
   updateNotice,
 }: LocalGameScreenProps) {
   const {
@@ -116,12 +118,14 @@ function LocalGameScreen({
         />
       }
       gameBoard={gameBoard}
+      isApplyingUpdate={isApplyingUpdate}
       isGameOver={gameState.gameIsOver}
       isUpdatePending={isUpdatePending}
       onJoinOnlineGame={onJoinOnlineGame}
       onReplay={onReplay}
       onStartLocalGame={onStartLocalGame}
       onStartOnlineGame={onStartOnlineGame}
+      onUpdateNow={onUpdateNow}
       updateNotice={updateNotice}
     />
   );
@@ -257,12 +261,14 @@ function LiveApp() {
         <OnlineGameScreen
           key={`${onlineSession.roomCode}-${onlineSession.seatToken}`}
           applyUpdateWhenSafe={applyUpdateOnceForCurrentTarget}
+          isApplyingUpdate={isApplyingUpdate}
           isUpdatePending={isUpdatePending}
           onJoinOnlineGame={joinGame}
           onLeaveSession={leaveOnlineSession}
           onReplay={replayCurrentGame}
           onStartLocalGame={startLocalGame}
           onStartOnlineGame={startOnlineGame}
+          onUpdateNow={reloadToUpdate}
           session={onlineSession}
           updateNotice={hasUpdateNotice ? updateNotice : undefined}
         />
@@ -271,11 +277,13 @@ function LiveApp() {
       <LocalGameScreen
         key={`local-${localSessionVersion}`}
         applyUpdateWhenSafe={applyUpdateOnceForCurrentTarget}
+        isApplyingUpdate={isApplyingUpdate}
         isUpdatePending={isUpdatePending}
         onJoinOnlineGame={joinGame}
         onReplay={replayCurrentGame}
         onStartLocalGame={startLocalGame}
         onStartOnlineGame={startOnlineGame}
+        onUpdateNow={reloadToUpdate}
         updateNotice={hasUpdateNotice ? updateNotice : undefined}
       />
     );

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -11,12 +11,14 @@ export interface AppShellProps {
   debugStrip?: ReactNode;
   fixtureName?: UiFixtureName;
   gameBoard: ReactNode;
+  isApplyingUpdate?: boolean;
   isGameOver: boolean;
   isUpdatePending?: boolean;
   onJoinOnlineGame: (roomCode: string) => Promise<void>;
   onReplay: () => Promise<void> | void;
   onStartLocalGame: () => void;
   onStartOnlineGame: (stockSize?: number) => Promise<void>;
+  onUpdateNow?: () => void;
   statusStrip?: ReactNode;
   updateNotice?: ReactNode;
 }
@@ -30,12 +32,14 @@ export function AppShell({
   debugStrip,
   fixtureName,
   gameBoard,
+  isApplyingUpdate = false,
   isGameOver,
   isUpdatePending = false,
   onJoinOnlineGame,
   onReplay,
   onStartLocalGame,
   onStartOnlineGame,
+  onUpdateNow,
   statusStrip,
   updateNotice,
 }: AppShellProps) {
@@ -75,18 +79,15 @@ export function AppShell({
         <div className="mt-4 flex items-center gap-3 justify-between">
           {debugStrip}
           <div className="grow"></div>
+          {isUpdatePending && onUpdateNow ? (
+            <Button size="xs" onClick={onUpdateNow} disabled={isApplyingUpdate} data-testid="app-version-update-button">
+              {isApplyingUpdate ? 'Mise à jour…' : 'Mettre à jour'}
+            </Button>
+          ) : null}
           <p
             className="app-version-badge flex items-center gap-1.5 text-xs text-muted-foreground/80 tabular-nums"
             data-testid="app-version"
           >
-            {isUpdatePending ? (
-              <span
-                aria-label="Mise à jour prête, elle sera appliquée à la prochaine partie"
-                className="inline-block size-2 shrink-0 rounded-full bg-primary"
-                data-testid="app-version-update-dot"
-                title="Mise à jour prête, elle sera appliquée à la prochaine partie"
-              />
-            ) : null}
             Version {APP_VERSION}
           </p>
         </div>
@@ -96,10 +97,12 @@ export function AppShell({
 }
 
 export interface SessionScreenProps {
+  isApplyingUpdate?: boolean;
   isUpdatePending?: boolean;
   onJoinOnlineGame: (roomCode: string) => Promise<void>;
   onReplay: () => Promise<void>;
   onStartLocalGame: () => void;
   onStartOnlineGame: (stockSize?: number) => Promise<void>;
+  onUpdateNow?: () => void;
   updateNotice?: ReactNode;
 }

--- a/apps/web/src/components/OnlineGameScreen.tsx
+++ b/apps/web/src/components/OnlineGameScreen.tsx
@@ -26,12 +26,14 @@ export interface OnlineGameScreenProps extends SessionScreenProps {
  */
 function OnlineGameScreen({
   applyUpdateWhenSafe,
+  isApplyingUpdate,
   isUpdatePending,
   onJoinOnlineGame,
   onLeaveSession,
   onReplay,
   onStartLocalGame,
   onStartOnlineGame,
+  onUpdateNow,
   session,
   updateNotice,
 }: OnlineGameScreenProps) {
@@ -136,12 +138,14 @@ function OnlineGameScreen({
           />
         }
         gameBoard={gameBoard}
+        isApplyingUpdate={isApplyingUpdate}
         isGameOver={gameState.gameIsOver}
         isUpdatePending={isUpdatePending}
         onJoinOnlineGame={onJoinOnlineGame}
         onReplay={onReplay}
         onStartLocalGame={onStartLocalGame}
         onStartOnlineGame={onStartOnlineGame}
+        onUpdateNow={onUpdateNow}
         statusStrip={
           <OnlineStatusStrip
             canStartGame={canStartGame}

--- a/apps/web/src/components/__tests__/AppShell.test.tsx
+++ b/apps/web/src/components/__tests__/AppShell.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { AppShell, type AppShellProps } from '@/components/AppShell';
+
+const renderAppShell = (overrides: Partial<AppShellProps> = {}) =>
+  render(
+    <AppShell
+      gameBoard={<div data-testid="board" />}
+      isGameOver={false}
+      onJoinOnlineGame={() => Promise.resolve()}
+      onReplay={() => undefined}
+      onStartLocalGame={() => undefined}
+      onStartOnlineGame={() => Promise.resolve()}
+      {...overrides}
+    />,
+  );
+
+describe('AppShell update button', () => {
+  test('hides the update button when no update is pending', () => {
+    renderAppShell({ isUpdatePending: false, onUpdateNow: vi.fn() });
+
+    expect(screen.queryByTestId('app-version-update-button')).toBeNull();
+  });
+
+  test('hides the update button when no handler is provided even if an update is pending', () => {
+    renderAppShell({ isUpdatePending: true });
+
+    expect(screen.queryByTestId('app-version-update-button')).toBeNull();
+  });
+
+  test('shows the update button and invokes the handler on click', () => {
+    const onUpdateNow = vi.fn();
+    renderAppShell({ isUpdatePending: true, onUpdateNow });
+
+    const button = screen.getByTestId<HTMLButtonElement>('app-version-update-button');
+    expect(button.textContent).toBe('Mettre à jour');
+    expect(button.disabled).toBe(false);
+
+    fireEvent.click(button);
+    expect(onUpdateNow).toHaveBeenCalledTimes(1);
+  });
+
+  test('disables the button and shows progress while the update is applying', () => {
+    renderAppShell({ isUpdatePending: true, isApplyingUpdate: true, onUpdateNow: vi.fn() });
+
+    const button = screen.getByTestId<HTMLButtonElement>('app-version-update-button');
+    expect(button.textContent).toBe('Mise à jour…');
+    expect(button.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Résumé

Quand une mise à jour est disponible, l'app affichait un petit point coloré à côté du numéro de version, avec le message qu'elle s'appliquerait « à la prochaine partie ». En pratique, ce redémarrage automatique se déclenche rarement de lui-même.

Ce point est remplacé par un **bouton « Mettre à jour »** cliquable qui force l'application immédiate de la mise à jour en attente (`reloadToUpdate` → active le service worker en attente puis recharge).

## Changements

- **`AppShell.tsx`** — remplace le `<span>` point par un `<Button size="xs">` qui appelle `onUpdateNow`. Affiche « Mise à jour… » et se désactive pendant l'application (`isApplyingUpdate`). Ajout des props `onUpdateNow` / `isApplyingUpdate` (aussi sur `SessionScreenProps`).
- **`App.tsx`** — câble `reloadToUpdate` comme `onUpdateNow` et `isApplyingUpdate` vers les écrans local et online.
- **`OnlineGameScreen.tsx`** — propage les nouvelles props jusqu'à `AppShell`.

L'auto-application aux moments « sûrs » (`applyUpdateWhenSafe`) reste en place — le bouton est une porte de sortie manuelle qui s'ajoute.

## Tests

- `pnpm lint` ✅ · `pnpm typecheck` ✅
- 253 tests unitaires ✅
- 174 E2E ✅ · 174 visuels ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)