### PR TITLE
fix(web): record online stats from real view, not placeholder

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -43,6 +43,12 @@ applies **optimistic updates** for `PLAY_CARD`/`DISCARD_CARD`, reconciled when t
 next authoritative view arrives. Lobby data comes from `presence` (there is no
 game view during `WAITING`).
 
+**Placeholder gotcha:** `useOnlineSkipBoGame` returns a seat-capacity placeholder
+`gameState` (`createPlaceholderGameState` — 4 seats, no `displayName`, `isAI` by
+index) until the first real `view` is ingested, while `roomStatus` may already be
+`ACTIVE`/`FINISHED` via presence. Any consumer reading `gameState.players` (stats,
+summaries) must gate on the returned `hasGameView` flag, not on `roomStatus` alone.
+
 ## AI
 
 Entry point: `src/ai/computeBestMove.ts`  
@@ -111,3 +117,9 @@ pnpm test:visual:update
 
 Unit tests: `src/**/__tests__/`  
 E2E + visual: `tests/ui/`
+
+## Coverage
+
+`codecov/patch` is a **required** check — new/changed lines need test coverage.
+Component-inline expressions are awkward to render-test; extract non-trivial logic
+into an exported pure helper (e.g. `shouldRecordOnlineStats`) and unit-test that.

--- a/apps/web/src/components/OnlineGameScreen.tsx
+++ b/apps/web/src/components/OnlineGameScreen.tsx
@@ -51,6 +51,7 @@ function OnlineGameScreen({
     discardCard,
     disconnectedSeats,
     gameState,
+    hasGameView,
     isLocalHost,
     kickSeat,
     leaveLobby,
@@ -72,7 +73,11 @@ function OnlineGameScreen({
   // Record stats only once the game is actually being played (not during the
   // lobby). Every seat keeps its own local history; only the host emits the
   // centralized report so a finished game is counted once globally.
-  const isLiveGame = roomStatus === 'ACTIVE' || roomStatus === 'FINISHED';
+  // Gate on `hasGameView`: while a real server view has not been ingested,
+  // `gameState` is the seat-capacity placeholder (4 seats, no display names).
+  // Recording it would freeze the wrong player count and generic "IA" names for
+  // the whole game (the tracker snapshots names when it opens the recording).
+  const isLiveGame = (roomStatus === 'ACTIVE' || roomStatus === 'FINISHED') && hasGameView;
   const statsSnapshot = useMemo(
     () => (isLiveGame ? buildGameStatsSnapshot(gameState, 'online') : null),
     [isLiveGame, gameState],

--- a/apps/web/src/components/OnlineGameScreen.tsx
+++ b/apps/web/src/components/OnlineGameScreen.tsx
@@ -10,7 +10,7 @@ import { OnlineGameBoard } from '@/components/OnlineGameBoard';
 import { OnlineStatusStrip } from '@/components/OnlineStatusStrip';
 import { useLocalSkipBoGame } from '@/hooks/useLocalSkipBoGame';
 import { useOnlineSkipBoGame } from '@/hooks/useOnlineSkipBoGame';
-import { buildGameStatsSnapshot, useGameStatsRecorder } from '@/hooks/useGameStatsRecorder';
+import { buildGameStatsSnapshot, shouldRecordOnlineStats, useGameStatsRecorder } from '@/hooks/useGameStatsRecorder';
 import { canPlayCard } from '@/lib/validators';
 
 export interface OnlineGameScreenProps extends SessionScreenProps {
@@ -77,7 +77,7 @@ function OnlineGameScreen({
   // `gameState` is the seat-capacity placeholder (4 seats, no display names).
   // Recording it would freeze the wrong player count and generic "IA" names for
   // the whole game (the tracker snapshots names when it opens the recording).
-  const isLiveGame = (roomStatus === 'ACTIVE' || roomStatus === 'FINISHED') && hasGameView;
+  const isLiveGame = shouldRecordOnlineStats(roomStatus, hasGameView);
   const statsSnapshot = useMemo(
     () => (isLiveGame ? buildGameStatsSnapshot(gameState, 'online') : null),
     [isLiveGame, gameState],

--- a/apps/web/src/components/__tests__/OnlineGameScreen.test.tsx
+++ b/apps/web/src/components/__tests__/OnlineGameScreen.test.tsx
@@ -1,0 +1,122 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { GameConfig, GameState } from '@/types';
+import type { GameStatsSnapshot } from '@/monitoring/gameStats';
+
+// Capture the snapshot the screen feeds the recorder each render, so we can
+// assert the online recording gate (placeholder window vs. real view).
+const recorderCalls: (GameStatsSnapshot | null)[] = [];
+vi.mock('@/hooks/useGameStatsRecorder', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useGameStatsRecorder')>('@/hooks/useGameStatsRecorder');
+  return {
+    ...actual,
+    useGameStatsRecorder: (snapshot: GameStatsSnapshot | null) => {
+      recorderCalls.push(snapshot);
+      return { lastRecord: null };
+    },
+  };
+});
+
+// Stub the online hook so we can drive room status / view availability.
+const onlineHook = vi.fn();
+vi.mock('@/hooks/useOnlineSkipBoGame', () => ({ useOnlineSkipBoGame: () => onlineHook() }));
+vi.mock('@/hooks/useLocalSkipBoGame', () => ({
+  useLocalSkipBoGame: () => ({ gameState: makeGameState() }),
+}));
+
+// Heavy children are irrelevant to the recording gate — render nothing.
+vi.mock('@/components/AppShell', () => ({ AppShell: () => null }));
+vi.mock('@/components/DebugStrip', () => ({ DebugStrip: () => null }));
+vi.mock('@/components/LobbyDialog', () => ({ LobbyDialog: () => null, LobbyRemovedDialog: () => null }));
+vi.mock('@/components/OnlineGameBoard', () => ({ OnlineGameBoard: () => null }));
+vi.mock('@/components/LocalGameBoard', () => ({ LocalGameBoard: () => null }));
+vi.mock('@/components/OnlineStatusStrip', () => ({ OnlineStatusStrip: () => null }));
+
+import OnlineGameScreen from '@/components/OnlineGameScreen';
+
+function makeGameState(playerCount = 3): GameState {
+  return {
+    deck: [],
+    buildPiles: [[], [], [], []],
+    completedBuildPiles: [],
+    players: Array.from({ length: playerCount }, (_, index) => ({
+      isAI: index !== 0,
+      stockPile: [],
+      hand: [null, null, null, null, null],
+      discardPiles: [[], [], [], []],
+    })),
+    currentPlayerIndex: 0,
+    gameIsOver: false,
+    winnerIndex: null,
+    selectedCard: null,
+    message: '',
+    config: { STOCK_SIZE: 30 } as GameConfig,
+  } as GameState;
+}
+
+const baseHookReturn = () => ({
+  canStartGame: false,
+  clearSelection: vi.fn(),
+  connectedSeats: [],
+  connectionStatus: 'connected',
+  debugFillBuildPile: vi.fn(),
+  debugFillHandSkipBo: vi.fn(),
+  debugClearStockPile: vi.fn(),
+  debugClearAiStockPile: vi.fn(),
+  debugWin: vi.fn(),
+  discardCard: vi.fn(),
+  disconnectedSeats: [],
+  gameState: makeGameState(),
+  hasGameView: false,
+  isLocalHost: true,
+  kickSeat: vi.fn(),
+  leaveLobby: vi.fn(),
+  lobbySeats: [],
+  myReadyState: 'never-ready',
+  playCard: vi.fn(),
+  playersBySeatIndex: {},
+  roomCode: 'ABCD',
+  roomStatus: 'ACTIVE',
+  seatCapacity: 4,
+  selectCard: vi.fn(),
+  sendSetReady: vi.fn(),
+  sendSetUnready: vi.fn(),
+  startGame: vi.fn(),
+  lobbyRemovalReason: null,
+});
+
+const screenProps = {
+  applyUpdateWhenSafe: vi.fn(),
+  isApplyingUpdate: false,
+  isUpdatePending: false,
+  onJoinOnlineGame: vi.fn(),
+  onLeaveSession: vi.fn(),
+  onReplay: vi.fn(),
+  onStartLocalGame: vi.fn(),
+  onStartOnlineGame: vi.fn(),
+  onUpdateNow: vi.fn(),
+  session: { seatIndex: 0, roomCode: 'ABCD', seatCapacity: 4, hostSeatIndex: 0 },
+  updateNotice: null,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+afterEach(() => {
+  recorderCalls.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('OnlineGameScreen stats gate', () => {
+  it('feeds no snapshot while the game is on the placeholder (no view yet)', () => {
+    onlineHook.mockReturnValue({ ...baseHookReturn(), roomStatus: 'ACTIVE', hasGameView: false });
+    render(<OnlineGameScreen {...screenProps} />);
+    expect(recorderCalls.at(-1)).toBeNull();
+  });
+
+  it('feeds a real snapshot once the game view has been ingested', () => {
+    onlineHook.mockReturnValue({ ...baseHookReturn(), roomStatus: 'ACTIVE', hasGameView: true });
+    render(<OnlineGameScreen {...screenProps} />);
+    expect(recorderCalls.at(-1)).toMatchObject({ players: expect.any(Array) });
+    expect(recorderCalls.at(-1)?.players).toHaveLength(3);
+  });
+});

--- a/apps/web/src/hooks/__tests__/useGameStatsRecorder.test.tsx
+++ b/apps/web/src/hooks/__tests__/useGameStatsRecorder.test.tsx
@@ -150,4 +150,44 @@ describe('useGameStatsRecorder', () => {
     expect(report).not.toHaveBeenCalled();
     expect(captured).toBeNull();
   });
+
+  // Regression: online games briefly render a seat-capacity placeholder (4 seats,
+  // generic "IA" names) before the first real view arrives. OnlineGameScreen keeps
+  // the snapshot null during that window, so the recorder must open on the first
+  // real snapshot and record the true player count/names — not the placeholder's.
+  it('records the real players when a placeholder window precedes the first view', () => {
+    captured = null;
+    const realActive: GameStatsSnapshot = {
+      gameIsOver: false,
+      currentPlayerIndex: 0,
+      winnerIndex: null,
+      stockSize: 30,
+      players: [
+        { name: 'Joueur', isAI: false, leftoverStock: 30 },
+        { name: 'Bob', isAI: false, leftoverStock: 30 },
+        { name: 'Carol', isAI: false, leftoverStock: 30 },
+      ],
+    };
+    const realOver: GameStatsSnapshot = {
+      ...realActive,
+      gameIsOver: true,
+      winnerIndex: 1,
+      players: [
+        { name: 'Joueur', isAI: false, leftoverStock: 17 },
+        { name: 'Bob', isAI: false, leftoverStock: 0 },
+        { name: 'Carol', isAI: false, leftoverStock: 15 },
+      ],
+    };
+
+    // Placeholder window: OnlineGameScreen passes null, then the real view arrives.
+    const { rerender } = render(<Harness snapshot={null} isCentralReporter />);
+    rerender(<Harness snapshot={realActive} isCentralReporter />);
+    rerender(<Harness snapshot={realOver} isCentralReporter />);
+
+    expect(append).toHaveBeenCalledTimes(1);
+    const recorded = append.mock.calls[0][0];
+    expect(recorded.playerCount).toBe(3);
+    expect(recorded.players.map((player) => player.name)).toEqual(['Joueur', 'Bob', 'Carol']);
+    expect(recorded.winnerName).toBe('Bob');
+  });
 });

--- a/apps/web/src/hooks/__tests__/useGameStatsRecorder.test.tsx
+++ b/apps/web/src/hooks/__tests__/useGameStatsRecorder.test.tsx
@@ -5,7 +5,7 @@ import type { Card, GameConfig, GameState, Player } from '@/types';
 import type { GameStatsRecord, GameStatsSnapshot } from '@/monitoring/gameStats';
 import { appendGameStatsRecord } from '@/state/gameStatsHistory';
 import { reportGameCompleted } from '@/monitoring/gameAnalytics';
-import { buildGameStatsSnapshot, useGameStatsRecorder } from '../useGameStatsRecorder';
+import { buildGameStatsSnapshot, shouldRecordOnlineStats, useGameStatsRecorder } from '../useGameStatsRecorder';
 
 vi.mock('@/lib/appVersion', () => ({ APP_VERSION: 'vTEST' }));
 vi.mock('@/state/gameStatsHistory', () => ({ appendGameStatsRecord: vi.fn() }));
@@ -86,6 +86,22 @@ describe('buildGameStatsSnapshot', () => {
     const snapshot = buildGameStatsSnapshot(gameState, 'online');
     expect(snapshot.players[1]).toEqual({ name: 'Bob', isAI: false, leftoverStock: 5 });
     expect(snapshot.players.every((player) => !player.isAI)).toBe(true);
+  });
+});
+
+describe('shouldRecordOnlineStats', () => {
+  it('records only an active/finished game whose real view has been ingested', () => {
+    expect(shouldRecordOnlineStats('ACTIVE', true)).toBe(true);
+    expect(shouldRecordOnlineStats('FINISHED', true)).toBe(true);
+  });
+
+  it('does not record before the first real view (placeholder window)', () => {
+    expect(shouldRecordOnlineStats('ACTIVE', false)).toBe(false);
+    expect(shouldRecordOnlineStats('FINISHED', false)).toBe(false);
+  });
+
+  it('does not record the lobby even once a view exists', () => {
+    expect(shouldRecordOnlineStats('WAITING', true)).toBe(false);
   });
 });
 

--- a/apps/web/src/hooks/useGameStatsRecorder.ts
+++ b/apps/web/src/hooks/useGameStatsRecorder.ts
@@ -36,6 +36,16 @@ const resolvePlayerName = (player: Player, index: number, aiCount: number): stri
 };
 
 /**
+ * Whether an online game should be recorded this tick. The game must be in a
+ * playable/finished room state *and* a real server view must have been ingested
+ * — until then `gameState` is the seat-capacity placeholder (wrong player count,
+ * generic "IA" names), which the tracker would otherwise freeze for the whole
+ * game since it snapshots names when it opens the recording.
+ */
+export const shouldRecordOnlineStats = (roomStatus: string, hasGameView: boolean): boolean =>
+  (roomStatus === 'ACTIVE' || roomStatus === 'FINISHED') && hasGameView;
+
+/**
  * Projects a `GameState` (local) or cloned `ClientGameView` (online) onto the
  * minimal snapshot the tracker consumes. Online games are always human-vs-human
  * — the view marks opponents `isAI: true` only as a rendering role — so `isAI`

--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -584,6 +584,9 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     debugWin,
     disconnectedSeats,
     gameState,
+    // True once a real server view has been ingested. Until then `gameState`
+    // is the seat-capacity placeholder, which must not be recorded as a game.
+    hasGameView: view !== null,
     hostSeatIndex,
     isLocalHost,
     kickSeat,


### PR DESCRIPTION
## Problem

In the online **Statistiques de la partie** dialog, a 3-player game was recorded as **4 players** with generic names (`Joueur`, `IA 1`, `IA 2`, `IA 3`) — including a phantom `IA 3` with all-zero stats — instead of the real roster.

## Root cause

When an online game starts (or after a reload), `roomStatus` flips to `ACTIVE`/`FINISHED` via presence **before** the first authoritative game `view` arrives. During that window, `gameState` falls back to `createPlaceholderGameState(roomCode, seatCapacity = 4)` — 4 seats, no display names, `isAI` derived from index.

The stats tracker snapshots player names and count **when it opens the recording** (`beginRecording`), so it froze the placeholder's 4 seats and generic names for the whole game. Turn/stock numbers came from the real views afterward, which is why counts looked real but the roster didn't.

## Fix

- Expose `hasGameView` (`view !== null`) from `useOnlineSkipBoGame`.
- Gate `isLiveGame` in `OnlineGameScreen` on `hasGameView`, so no snapshot is recorded until a real server view exists. The tracker then opens on the true roster (correct player count and real `displayName`s carried by the view).
- Also fixes the same corruption for a mid-game reload that lands on a presence update before the first view.

## Tests

- Added a regression test in `useGameStatsRecorder.test.tsx` covering the placeholder→real-view sequence.
- `pnpm --filter @skipbo/web typecheck`, `lint`, and unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)