### PR TITLE
Fix empty-card flash on discard-into-empty-pile animation

### DIFF
--- a/apps/web/src/components/player-area/DiscardPiles.tsx
+++ b/apps/web/src/components/player-area/DiscardPiles.tsx
@@ -1,6 +1,5 @@
 import type { Card as CardType, GameState, MoveResult, Player } from '@/types';
 import type { CSSProperties } from 'react';
-import { Fragment } from 'react';
 
 import { Card } from '@/components/Card';
 import { EmptyCard } from '@/components/EmptyCard.tsx';
@@ -101,6 +100,12 @@ function DiscardPile({
     return { card, cardIdx, isAnimated, key: `discard-${pileIndex}-card-${cardIdx}` };
   });
 
+  // True while the pile's only card is still masked behind the flying
+  // animated replica — visually the pile still reads as empty, so the
+  // "Vide" placeholder should stay shown rather than flip to hidden and
+  // back, which would otherwise mount a second empty-card on top of it.
+  const soleCardMasked = computedPiles.length === 1 && computedPiles[0].isAnimated;
+
   const canInteract = isHuman && isCurrentPlayer;
 
   const handleDiscardPilePress = () => {
@@ -159,26 +164,18 @@ function DiscardPile({
     >
       <EmptyCard
         canDropCard={computedPiles.length === 0}
-        hideLabel={computedPiles.length > 0}
+        hideLabel={computedPiles.length > 0 && !soleCardMasked}
         className="absolute inset-0"
       />
       {computedPiles.map(({ card, cardIdx, isAnimated, key }) => {
         if (isAnimated) {
-          const fakeCard = (
+          return (
             <div
               key={key}
               className="card opacity-0 pointer-events-none"
               style={{ top: `${cardIdx * 20}px`, zIndex: cardIdx }}
             />
           );
-          if (cardIdx === 0)
-            return (
-              <Fragment key={key}>
-                <EmptyCard />
-                {fakeCard}
-              </Fragment>
-            );
-          else return fakeCard;
         }
         const isTop = cardIdx === pile.length - 1;
         if (isTop && isHuman && isCurrentPlayer) {


### PR DESCRIPTION
## Summary

- Discarding a card onto an empty discard pile briefly rendered **two overlapping `EmptyCard` elements** while the real card was masked behind the flying animated replica — the always-present background `EmptyCard` (`DiscardPiles.tsx:165`) plus a duplicate one mounted specifically for this case.
- Both carry the same `.empty-card` box-shadow, and in the wool theme (which uses a bright neumorphic inset highlight) the two overlapping semi-transparent shadows visually reinforced each other, making the "Vide" placeholder appear to "light up" for the duration of the animation. Measured average tile brightness jumped from `188/192/195` (resting) to `201/203/205` (mid-animation) before the fix.
- Fixed by keeping a single background `EmptyCard` and just suppressing its `hideLabel` while the pile's sole card is masked, instead of mounting a second element on top of it.

## Test plan

- [x] `pnpm --filter @skipbo/web typecheck`
- [x] `pnpm --filter @skipbo/web lint`
- [x] `pnpm --filter @skipbo/web test` (293 tests passed)
- [x] Manually reproduced with Playwright against a live wool-themed game: discarded onto an empty pile, captured frame-by-frame screenshots, and confirmed the brightness spike is gone after the fix (matches resting-state brightness exactly).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KG57oLhoTfBQCX3Rv2PFm4)_