### PR TITLE
fix(web): make online endgame stats host-authoritative

### DIFF
--- a/apps/web/src/components/OnlineGameScreen.tsx
+++ b/apps/web/src/components/OnlineGameScreen.tsx
@@ -12,6 +12,7 @@ import { useLocalSkipBoGame } from '@/hooks/useLocalSkipBoGame';
 import { useOnlineSkipBoGame } from '@/hooks/useOnlineSkipBoGame';
 import { buildGameStatsSnapshot, shouldRecordOnlineStats, useGameStatsRecorder } from '@/hooks/useGameStatsRecorder';
 import { canPlayCard } from '@/lib/validators';
+import { appendGameStatsRecord } from '@/state/gameStatsHistory';
 
 export interface OnlineGameScreenProps extends SessionScreenProps {
   applyUpdateWhenSafe: () => void;
@@ -39,6 +40,7 @@ function OnlineGameScreen({
   updateNotice,
 }: OnlineGameScreenProps) {
   const {
+    broadcastGameStats,
     canStartGame,
     clearSelection,
     connectedSeats,
@@ -59,6 +61,7 @@ function OnlineGameScreen({
     myReadyState,
     playCard,
     playersBySeatIndex,
+    receivedGameStats,
     roomCode,
     roomStatus,
     seatCapacity,
@@ -70,22 +73,44 @@ function OnlineGameScreen({
   } = useOnlineSkipBoGame(session);
   const { gameState: localGameState } = useLocalSkipBoGame();
 
-  // Record stats only once the game is actually being played (not during the
-  // lobby). Every seat keeps its own local history; only the host emits the
-  // centralized report so a finished game is counted once globally.
-  // Gate on `hasGameView`: while a real server view has not been ingested,
-  // `gameState` is the seat-capacity placeholder (4 seats, no display names).
-  // Recording it would freeze the wrong player count and generic "IA" names for
-  // the whole game (the tracker snapshots names when it opens the recording).
-  const isLiveGame = shouldRecordOnlineStats(roomStatus, hasGameView);
+  // Only the host tracks stats: its own view is produced synchronously from
+  // its own state with no network delay, so it is the only client that can
+  // reconstruct an accurate turn count / duration. Guests would otherwise
+  // reconstruct their own approximation from asynchronously-delivered views,
+  // producing different numbers per seat for the same finished game (see the
+  // broadcast below). Gate on `hasGameView`: while a real server view has not
+  // been ingested, `gameState` is the seat-capacity placeholder (4 seats, no
+  // display names). Recording it would freeze the wrong player count and
+  // generic "IA" names for the whole game (the tracker snapshots names when it
+  // opens the recording).
+  const isLiveGame = isLocalHost && shouldRecordOnlineStats(roomStatus, hasGameView);
   const statsSnapshot = useMemo(
     () => (isLiveGame ? buildGameStatsSnapshot(gameState, 'online') : null),
     [isLiveGame, gameState],
   );
-  const { lastRecord: statsRecord } = useGameStatsRecorder(statsSnapshot, {
+  const { lastRecord: hostStatsRecord } = useGameStatsRecorder(statsSnapshot, {
     mode: 'online',
     isCentralReporter: isLocalHost,
   });
+
+  // Broadcast the host's finalized record to every guest so all seats display
+  // the same numbers for the game that just ended.
+  useEffect(() => {
+    if (isLocalHost && hostStatsRecord) {
+      broadcastGameStats(hostStatsRecord);
+    }
+  }, [isLocalHost, hostStatsRecord, broadcastGameStats]);
+
+  // Guests persist the host's authoritative record (rather than a self-tracked
+  // approximation) so the local history stays consistent with what every
+  // other seat saw.
+  useEffect(() => {
+    if (!isLocalHost && receivedGameStats) {
+      appendGameStatsRecord(receivedGameStats);
+    }
+  }, [isLocalHost, receivedGameStats]);
+
+  const statsRecord = isLocalHost ? hostStatsRecord : receivedGameStats;
 
   // Online state is rebuilt from the server snapshot after a reload, so applying
   // a pending update is lossless. Only do it at a "safe" moment — never while it

--- a/apps/web/src/components/__tests__/OnlineGameScreen.test.tsx
+++ b/apps/web/src/components/__tests__/OnlineGameScreen.test.tsx
@@ -2,18 +2,21 @@ import { render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { GameConfig, GameState } from '@/types';
-import type { GameStatsSnapshot } from '@/monitoring/gameStats';
+import type { GameStatsRecord, GameStatsSnapshot } from '@/monitoring/gameStats';
 
 // Capture the snapshot the screen feeds the recorder each render, so we can
-// assert the online recording gate (placeholder window vs. real view).
+// assert the online recording gate (placeholder window vs. real view). The
+// record it returns is controllable so tests can simulate the host's tracker
+// finalizing a game.
 const recorderCalls: (GameStatsSnapshot | null)[] = [];
+let recorderLastRecord: GameStatsRecord | null = null;
 vi.mock('@/hooks/useGameStatsRecorder', async () => {
   const actual = await vi.importActual<typeof import('@/hooks/useGameStatsRecorder')>('@/hooks/useGameStatsRecorder');
   return {
     ...actual,
     useGameStatsRecorder: (snapshot: GameStatsSnapshot | null) => {
       recorderCalls.push(snapshot);
-      return { lastRecord: null };
+      return { lastRecord: recorderLastRecord };
     },
   };
 });
@@ -25,8 +28,17 @@ vi.mock('@/hooks/useLocalSkipBoGame', () => ({
   useLocalSkipBoGame: () => ({ gameState: makeGameState() }),
 }));
 
-// Heavy children are irrelevant to the recording gate — render nothing.
-vi.mock('@/components/AppShell', () => ({ AppShell: () => null }));
+vi.mock('@/state/gameStatsHistory', () => ({ appendGameStatsRecord: vi.fn() }));
+
+// Heavy children are irrelevant to the recording gate — render nothing, but
+// capture the props each render so the stats-related ones can be asserted.
+const appShellCalls: Array<{ statsRecord?: GameStatsRecord | null }> = [];
+vi.mock('@/components/AppShell', () => ({
+  AppShell: (props: { statsRecord?: GameStatsRecord | null }) => {
+    appShellCalls.push(props);
+    return null;
+  },
+}));
 vi.mock('@/components/DebugStrip', () => ({ DebugStrip: () => null }));
 vi.mock('@/components/LobbyDialog', () => ({ LobbyDialog: () => null, LobbyRemovedDialog: () => null }));
 vi.mock('@/components/OnlineGameBoard', () => ({ OnlineGameBoard: () => null }));
@@ -56,6 +68,7 @@ function makeGameState(playerCount = 3): GameState {
 }
 
 const baseHookReturn = () => ({
+  broadcastGameStats: vi.fn(),
   canStartGame: false,
   clearSelection: vi.fn(),
   connectedSeats: [],
@@ -76,6 +89,7 @@ const baseHookReturn = () => ({
   myReadyState: 'never-ready',
   playCard: vi.fn(),
   playersBySeatIndex: {},
+  receivedGameStats: null,
   roomCode: 'ABCD',
   roomStatus: 'ACTIVE',
   seatCapacity: 4,
@@ -103,6 +117,8 @@ const screenProps = {
 
 afterEach(() => {
   recorderCalls.length = 0;
+  recorderLastRecord = null;
+  appShellCalls.length = 0;
   vi.clearAllMocks();
 });
 
@@ -118,5 +134,73 @@ describe('OnlineGameScreen stats gate', () => {
     render(<OnlineGameScreen {...screenProps} />);
     expect(recorderCalls.at(-1)).toMatchObject({ players: expect.any(Array) });
     expect(recorderCalls.at(-1)?.players).toHaveLength(3);
+  });
+
+  it('feeds no snapshot for a guest, even once the game view has been ingested', () => {
+    // Only the host's tracker is trustworthy (no network delay); a guest must
+    // rely solely on the host-broadcast record, never self-track.
+    onlineHook.mockReturnValue({
+      ...baseHookReturn(),
+      isLocalHost: false,
+      roomStatus: 'ACTIVE',
+      hasGameView: true,
+    });
+    render(<OnlineGameScreen {...screenProps} />);
+    expect(recorderCalls.at(-1)).toBeNull();
+  });
+});
+
+describe('OnlineGameScreen stats broadcast/receive', () => {
+  const statsRecord: GameStatsRecord = {
+    id: 'game-1',
+    schemaVersion: 1,
+    appVersion: 'vTEST',
+    mode: 'online',
+    startedAt: '2026-04-05T12:00:00.000Z',
+    endedAt: '2026-04-05T12:10:00.000Z',
+    durationMs: 600_000,
+    totalTurns: 12,
+    playerCount: 2,
+    stockSize: 10,
+    winnerIndex: 0,
+    winnerName: 'Alice',
+    winnerIsAI: false,
+    players: [],
+  };
+
+  it('broadcasts the host tracker record once it finalizes and displays it', async () => {
+    recorderLastRecord = statsRecord;
+    const broadcastGameStats = vi.fn();
+    onlineHook.mockReturnValue({
+      ...baseHookReturn(),
+      broadcastGameStats,
+      isLocalHost: true,
+      roomStatus: 'FINISHED',
+      hasGameView: true,
+    });
+
+    render(<OnlineGameScreen {...screenProps} />);
+
+    expect(broadcastGameStats).toHaveBeenCalledWith(statsRecord);
+    expect(appShellCalls.at(-1)?.statsRecord).toBe(statsRecord);
+  });
+
+  it('displays and persists the host-broadcast record for a guest, without broadcasting', async () => {
+    const { appendGameStatsRecord } = await import('@/state/gameStatsHistory');
+    const broadcastGameStats = vi.fn();
+    onlineHook.mockReturnValue({
+      ...baseHookReturn(),
+      broadcastGameStats,
+      isLocalHost: false,
+      receivedGameStats: statsRecord,
+      roomStatus: 'FINISHED',
+      hasGameView: true,
+    });
+
+    render(<OnlineGameScreen {...screenProps} />);
+
+    expect(broadcastGameStats).not.toHaveBeenCalled();
+    expect(appendGameStatsRecord).toHaveBeenCalledWith(statsRecord);
+    expect(appShellCalls.at(-1)?.statsRecord).toBe(statsRecord);
   });
 });

--- a/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
+++ b/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
@@ -1415,6 +1415,50 @@ describe('useOnlineSkipBoGame', () => {
       expect(result.current.receivedGameStats).toEqual(statsRecord);
     });
 
+    it('ignores a relayed move kind (guests never act on it, only on view/event)', async () => {
+      const session = createSession();
+      const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+
+      const socket = MockWebSocket.instances[0];
+      await act(async () => {
+        socket.open();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        socket.emitMessage({ type: 'relayed', fromSeat: 0, kind: 'move', payload: { type: 'DRAW' } });
+        await Promise.resolve();
+      });
+
+      expect(result.current.receivedGameStats).toBeNull();
+    });
+
+    it('ignores a relayed event with no gameStats payload (guest)', async () => {
+      const session = createSession();
+      const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+
+      const socket = MockWebSocket.instances[0];
+      await act(async () => {
+        socket.open();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        socket.emitMessage({ type: 'relayed', fromSeat: 0, kind: 'event', payload: { resync: true } });
+        await Promise.resolve();
+      });
+
+      expect(result.current.receivedGameStats).toBeNull();
+    });
+
     it('resets the received record when a new game starts', async () => {
       const session = createSession();
       const { result } = renderHook(() => useOnlineSkipBoGame(session));

--- a/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
+++ b/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
@@ -7,6 +7,7 @@ import { serializeClientGameView, type ClientGameView } from '@skipbo/skipbo-run
 
 import { inferOpponentTransition, useOnlineSkipBoGame } from '@/hooks/useOnlineSkipBoGame';
 import { WEBSOCKET_PING_INTERVAL_MS } from '@/config/timing';
+import type { GameStatsRecord } from '@/monitoring/gameStats';
 
 const {
   activeAnimationsState,
@@ -1320,6 +1321,129 @@ describe('useOnlineSkipBoGame', () => {
 
     expect(result.current.lobbyRemovalReason).toBeNull();
     expect(result.current.lastError).toBe('Invalid move');
+  });
+
+  describe('game stats broadcast', () => {
+    const statsRecord: GameStatsRecord = {
+      id: 'game-1',
+      schemaVersion: 1,
+      appVersion: 'vTEST',
+      mode: 'online',
+      startedAt: '2026-04-05T12:00:00.000Z',
+      endedAt: '2026-04-05T12:10:00.000Z',
+      durationMs: 600_000,
+      totalTurns: 12,
+      playerCount: 2,
+      stockSize: 10,
+      winnerIndex: 0,
+      winnerName: 'Alice',
+      winnerIsAI: false,
+      players: [
+        {
+          index: 0,
+          name: 'Alice',
+          isAI: false,
+          startStock: 10,
+          leftoverStock: 0,
+          cardsCleared: 10,
+          turns: 6,
+          playTimeMs: 300_000,
+          isWinner: true,
+        },
+        {
+          index: 1,
+          name: 'Bob',
+          isAI: false,
+          startStock: 10,
+          leftoverStock: 4,
+          cardsCleared: 6,
+          turns: 6,
+          playTimeMs: 300_000,
+          isWinner: false,
+        },
+      ],
+    };
+
+    it('broadcasts the host authoritative record as a relay event to every seat', async () => {
+      const session = createHostSession();
+      const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+
+      const socket = MockWebSocket.instances[0];
+      await act(async () => {
+        socket.open();
+        await Promise.resolve();
+      });
+
+      act(() => {
+        result.current.broadcastGameStats(statsRecord);
+      });
+
+      const sent = parseSent(socket);
+      expect(sent).toContainEqual({
+        type: 'relay',
+        kind: 'event',
+        payload: { gameStats: statsRecord },
+        toSeats: undefined,
+      });
+    });
+
+    it('stores the host authoritative record received as a relayed event (guest)', async () => {
+      const session = createSession();
+      const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+
+      const socket = MockWebSocket.instances[0];
+      await act(async () => {
+        socket.open();
+        await Promise.resolve();
+      });
+
+      expect(result.current.receivedGameStats).toBeNull();
+
+      await act(async () => {
+        socket.emitMessage({ type: 'relayed', fromSeat: 0, kind: 'event', payload: { gameStats: statsRecord } });
+        await Promise.resolve();
+      });
+
+      expect(result.current.receivedGameStats).toEqual(statsRecord);
+    });
+
+    it('resets the received record when a new game starts', async () => {
+      const session = createSession();
+      const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+
+      const socket = MockWebSocket.instances[0];
+      await act(async () => {
+        socket.open();
+        socket.emitMessage({ type: 'relayed', fromSeat: 0, kind: 'event', payload: { gameStats: statsRecord } });
+        await Promise.resolve();
+      });
+
+      expect(result.current.receivedGameStats).toEqual(statsRecord);
+
+      await act(async () => {
+        socket.emitMessage({
+          type: 'gameStarted',
+          activeSeatIndices: [0, 1],
+          currentSeatIndex: 0,
+          gameConfig: { stockSize: 10 },
+        });
+        await Promise.resolve();
+      });
+
+      expect(result.current.receivedGameStats).toBeNull();
+    });
   });
 
   describe('opponent build pile completion (12)', () => {

--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { canPlayCard, type Card, getCompletedBuildPileCards, type MoveResult } from '@skipbo/game-core';
 
 import type { GameAction } from '@/state/gameActions';
+import type { GameStatsRecord } from '@/monitoring/gameStats';
 import {
   type CreateRoomResponse,
   type DisconnectedSeatInfo,
@@ -49,6 +50,9 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
   const [lastError, setLastError] = useState<string | null>(null);
   const [turnPresentationOverride, setTurnPresentationOverride] = useState<TurnPresentationOverride | null>(null);
   const [lobbyRemovalReason, setLobbyRemovalReason] = useState<'host-left' | 'kicked' | null>(null);
+  // The host-computed, authoritative end-of-game stats record, relayed to every
+  // guest so all seats display identical numbers (see `broadcastGameStats`).
+  const [receivedGameStats, setReceivedGameStats] = useState<GameStatsRecord | null>(null);
   const authoritativeViewRef = useRef<ClientGameView | null>(null);
   const interactionLockRef = useRef(false);
   const intentionalLeaveRef = useRef(false);
@@ -105,6 +109,18 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
       sendRaw({ type: 'relay', kind, payload, toSeats });
     },
     [sendRaw],
+  );
+
+  // The host computes end-of-game stats from its own state — no network delay,
+  // no risk of missing an intermediate view — so it is the only trustworthy
+  // source. Broadcast the finalized record to every other seat (defaults to
+  // all other seats) so guests display and persist the same numbers instead of
+  // reconstructing an approximation from asynchronously-delivered views.
+  const broadcastGameStats = useCallback(
+    (record: GameStatsRecord): void => {
+      sendRelay('event', { gameStats: record });
+    },
+    [sendRelay],
   );
 
   // ---------------------------------------------------------------------------
@@ -338,6 +354,7 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     setLastError,
     setRoomSummary,
     setLobbyRemovalReason,
+    setReceivedGameStats,
   });
 
   const gameState = useMemo(() => {
@@ -573,6 +590,7 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
   );
 
   return {
+    broadcastGameStats,
     canStartGame,
     clearSelection,
     connectedSeats,
@@ -584,6 +602,7 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     debugWin,
     disconnectedSeats,
     gameState,
+    receivedGameStats,
     // True once a real server view has been ingested. Until then `gameState`
     // is the seat-capacity placeholder, which must not be recorded as a game.
     hasGameView: view !== null,

--- a/apps/web/src/hooks/useOnlineSkipBoGame/useOnlineConnection.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame/useOnlineConnection.ts
@@ -9,6 +9,7 @@ import {
 import { SkipboHost, type ClientGameView, type HostRoomMeta } from '@skipbo/skipbo-runtime';
 
 import type { GameAction } from '@/state/gameActions';
+import type { GameStatsRecord } from '@/monitoring/gameStats';
 import { RECONNECT_DELAYS_MS, WEBSOCKET_PING_INTERVAL_MS } from '@/config/timing';
 import { clearOnlineSession } from '@/state/sessionPersistence';
 
@@ -44,6 +45,7 @@ export interface UseOnlineConnectionParams {
   setLastError: (error: string | null) => void;
   setRoomSummary: Dispatch<SetStateAction<RoomSummary | null>>;
   setLobbyRemovalReason: (reason: 'host-left' | 'kicked' | null) => void;
+  setReceivedGameStats: Dispatch<SetStateAction<GameStatsRecord | null>>;
 }
 
 /**
@@ -90,6 +92,7 @@ export function useOnlineConnection(params: UseOnlineConnectionParams): void {
       setLastError,
       setRoomSummary,
       setLobbyRemovalReason,
+      setReceivedGameStats,
     } = paramsRef.current;
 
     const clearPingInterval = () => {
@@ -119,6 +122,7 @@ export function useOnlineConnection(params: UseOnlineConnectionParams): void {
       roomMetaRef.current = null;
       activeSeatIndicesRef.current = [];
       lastBroadcastTurnRef.current = null;
+      setReceivedGameStats(null);
       return;
     }
 
@@ -208,6 +212,7 @@ export function useOnlineConnection(params: UseOnlineConnectionParams): void {
               setInteractionLocked(false);
               setConnectionStatus('connected');
               setLastError(null);
+              setReceivedGameStats(null);
               activeSeatIndicesRef.current = message.activeSeatIndices;
               lastBroadcastTurnRef.current = message.currentSeatIndex;
 
@@ -292,6 +297,11 @@ export function useOnlineConnection(params: UseOnlineConnectionParams): void {
                 // Host ignores relayed 'view'.
               } else if (message.kind === 'view') {
                 ingestView(message.payload as ClientGameView);
+              } else if (message.kind === 'event') {
+                const payload = message.payload as { gameStats?: GameStatsRecord } | null;
+                if (payload?.gameStats) {
+                  setReceivedGameStats(payload.gameStats);
+                }
               }
               break;
             }

--- a/docs/protocols/realtime-events.md
+++ b/docs/protocols/realtime-events.md
@@ -81,6 +81,13 @@ Gating: a `move` is accepted only from `room.currentSeatIndex`; `view` only from
 the host. Debug actions are sent as `relay { kind: 'event', payload: { move } }`
 to bypass the turn gate — the host applies them behind its own DEV flag.
 
+The host also broadcasts its finalized end-of-game stats as
+`relay { kind: 'event', payload: { gameStats } }` once the game ends. Only the
+host's own `GameStatsRecord` (computed from its own state, with no network
+delay) is trustworthy; guests display and persist that record instead of
+reconstructing their own from asynchronously-delivered `view`s, which would
+otherwise show a different duration/turn count per seat.
+
 ### Server → client
 
 | Type              | Shape                                                 | Notes                                                            |


### PR DESCRIPTION
## Summary

- Fixes a bug where the end-of-game stats dialog (duration, turn count, per-player play time) showed **different values on every seat** in an online game.
- Root cause: `GameStatsRecord` was never part of the host-authoritative sync protocol. Each client (host and every guest) independently ran its own `GameStatsTracker`, fed by its own wall clock (`Date.now()`) and its own asynchronously-delivered `view` messages. Network delivery timing differs per seat, so `startedAt`/`durationMs` diverged, and a client that missed an intermediate `view` (reconnect, dropped message) could undercount turns.
- Fix: only the **host** now tracks stats (its own view is generated synchronously from its own state — no network delay, no risk of missing an intermediate state). Once the host's tracker finalizes a game, it broadcasts the record to every other seat via the existing opaque `relay { kind: 'event' }` channel. Guests display and persist that authoritative record instead of reconstructing their own.

## Changes

- `useOnlineSkipBoGame.ts` / `useOnlineSkipBoGame/useOnlineConnection.ts`: add `broadcastGameStats` (host → all seats) and `receivedGameStats` (guest-side state), reset on `gameStarted`/session teardown.
- `OnlineGameScreen.tsx`: only feed the local stats snapshot into the tracker when `isLocalHost`; broadcast the host's finalized record; guests persist and display the received record instead of self-tracking.
- `docs/protocols/realtime-events.md`: document the new `relay { kind: 'event', payload: { gameStats } }` usage.
- Added unit tests covering the broadcast/receive/reset wiring in both `useOnlineSkipBoGame` and `OnlineGameScreen`.

## Test plan

- [x] `pnpm typecheck` (all packages)
- [x] `pnpm lint` (all packages)
- [x] `pnpm test` (all packages) — 299 web tests pass, including new coverage for the broadcast/receive/reset flow


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fq5rUqNmrhnEfbifShMa23)_