### PR TITLE
fix(web): skip stale view echoes for optimistic guest moves

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -40,8 +40,12 @@ the views the host relays.
 Both roles share **one** rendering path: `ingestView(view)` — the host generates
 the view locally, a guest receives it over the wire. `useOnlineSkipBoGame` still
 applies **optimistic updates** for `PLAY_CARD`/`DISCARD_CARD`, reconciled when the
-next authoritative view arrives. Lobby data comes from `presence` (there is no
-game view during `WAITING`).
+next authoritative view arrives. The host echoes exactly one view per relayed
+move; when several guest moves are in flight (select→play within one round-trip,
+e.g. a drag), `ingestRelayedView` skips the earlier, stale echoes — rendering
+them would revert the optimistic play and fake a deck→hand draw animation — and
+renders only the final one. Lobby data comes from `presence` (there is no game
+view during `WAITING`).
 
 **Placeholder gotcha:** `useOnlineSkipBoGame` returns a seat-capacity placeholder
 `gameState` (`createPlaceholderGameState` — 4 seats, no `displayName`, `isAI` by

--- a/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
+++ b/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
@@ -970,6 +970,173 @@ describe('useOnlineSkipBoGame', () => {
     expect(drawCall[4]).toBe(discardDuration);
   });
 
+  // --- Stale view echoes (fast select→play, drag-and-drop) --------------------
+
+  const createFastPlayStates = (): { baseState: GameState; selectedState: GameState; playedState: GameState } => {
+    const baseState = initialGameState();
+
+    baseState.currentPlayerIndex = 0;
+    baseState.buildPiles = [[], [], [], []];
+    baseState.completedBuildPiles = [];
+    baseState.deck = [card(8), card(9)];
+    baseState.players[0].hand = [card(1), card(5), null, null, null];
+    baseState.players[1].isAI = false;
+    baseState.selectedCard = null;
+    baseState.message = "C'est votre tour";
+
+    const selectedState = structuredClone(baseState);
+    selectedState.selectedCard = { card: card(1), source: 'hand', index: 0 };
+    selectedState.message = 'Sélectionnez une destination';
+
+    const playedState = gameReducer(selectedState, { type: 'PLAY_CARD', buildPile: 0 });
+
+    return { baseState, selectedState, playedState };
+  };
+
+  it('does not revert an optimistic play when the stale SELECT_CARD echo arrives late', async () => {
+    const session = createSession();
+    const { baseState, selectedState, playedState } = createFastPlayStates();
+    const initialView = createOnlineView(baseState, 1);
+    const staleSelectEcho = createOnlineView(selectedState, 2);
+    const playEcho = createOnlineView(playedState, 3);
+
+    const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+
+    const socket = MockWebSocket.instances[0];
+    await act(async () => {
+      socket.open();
+      socket.emitView(initialView);
+      await Promise.resolve();
+    });
+
+    // Select then play within one round-trip (a drag does exactly this).
+    act(() => {
+      result.current.selectCard('hand', 0);
+    });
+    await act(async () => {
+      const moveResult = await result.current.playCard(0);
+      expect(moveResult).toEqual({ success: true, message: 'Carte jouée' });
+    });
+
+    expect(result.current.gameState.buildPiles[0]).toHaveLength(1);
+    expect(result.current.gameState.players[0].hand[0]).toBeNull();
+
+    // The SELECT_CARD echo still shows the card in hand and an empty build
+    // pile: rendering it would revert the play and fake a deck→hand draw.
+    await act(async () => {
+      socket.emitView(staleSelectEcho);
+      await Promise.resolve();
+    });
+
+    expect(result.current.gameState.buildPiles[0]).toHaveLength(1);
+    expect(result.current.gameState.players[0].hand[0]).toBeNull();
+    expect(triggerMultipleDrawAnimations).not.toHaveBeenCalled();
+
+    // The PLAY_CARD echo reflects every local move and is rendered normally.
+    await act(async () => {
+      socket.emitView(playEcho);
+      await Promise.resolve();
+    });
+
+    expect(result.current.gameState.buildPiles[0]).toHaveLength(1);
+    expect(result.current.gameState.players[0].hand[0]).toBeNull();
+    expect(result.current.gameState.selectedCard).toBeNull();
+    expect(triggerMultipleDrawAnimations).not.toHaveBeenCalled();
+  });
+
+  it('renders the first view after a reconnect even when echoes were outstanding', async () => {
+    const session = createSession();
+    const { baseState, playedState } = createFastPlayStates();
+    const initialView = createOnlineView(baseState, 1);
+    const resyncView = createOnlineView(playedState, 2);
+
+    const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+
+    const socket = MockWebSocket.instances[0];
+    await act(async () => {
+      socket.open();
+      socket.emitView(initialView);
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.selectCard('hand', 0);
+    });
+    await act(async () => {
+      await result.current.playCard(0);
+    });
+
+    // The socket drops before any echo arrives; those echoes are lost.
+    await act(async () => {
+      socket.close();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    const reconnectedSocket = MockWebSocket.instances.at(-1)!;
+    expect(reconnectedSocket).not.toBe(socket);
+
+    await act(async () => {
+      reconnectedSocket.open();
+      reconnectedSocket.emitView(resyncView);
+      await Promise.resolve();
+    });
+
+    expect(result.current.gameState.message).toBe(resyncView.message);
+    expect(result.current.gameState.buildPiles[0]).toHaveLength(1);
+  });
+
+  it('stops waiting for view echoes after a server-side actionRejected', async () => {
+    const session = createSession();
+    const { baseState, playedState } = createFastPlayStates();
+    const initialView = createOnlineView(baseState, 1);
+    const correctionView = createOnlineView(playedState, 2);
+
+    const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+
+    const socket = MockWebSocket.instances[0];
+    await act(async () => {
+      socket.open();
+      socket.emitView(initialView);
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.selectCard('hand', 0);
+    });
+    await act(async () => {
+      await result.current.playCard(0);
+    });
+
+    await act(async () => {
+      socket.emitMessage({ type: 'actionRejected', code: 'invalid_action', reason: 'Invalid move' });
+      await Promise.resolve();
+    });
+
+    // With the pending echoes cleared, the next view must render.
+    await act(async () => {
+      socket.emitView(correctionView);
+      await Promise.resolve();
+    });
+
+    expect(result.current.gameState.message).toBe(correctionView.message);
+    expect(result.current.gameState.buildPiles[0]).toHaveLength(1);
+  });
+
   it('allows the host to start a waiting room as soon as all connected players are ready', async () => {
     const session = createHostSession();
     const allReadyLobbySeats: LobbySeatInfo[] = [

--- a/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
+++ b/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
@@ -1137,6 +1137,93 @@ describe('useOnlineSkipBoGame', () => {
     expect(result.current.gameState.buildPiles[0]).toHaveLength(1);
   });
 
+  it('relays guest debug actions as events without counting a view echo', async () => {
+    const session = createSession();
+    const { baseState } = createFastPlayStates();
+    const initialView = createOnlineView(baseState, 1);
+
+    const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+
+    const socket = MockWebSocket.instances[0];
+    await act(async () => {
+      socket.open();
+      socket.emitView(initialView);
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.debugWin();
+    });
+
+    expect(JSON.parse(socket.sent.at(-1) ?? '{}')).toMatchObject({
+      type: 'relay',
+      kind: 'event',
+      payload: { move: { type: 'DEBUG_WIN' } },
+    });
+    expect(getMoveMessages(socket)).toHaveLength(0);
+
+    // Debug events produce no guaranteed echo, so the next view must render.
+    await act(async () => {
+      socket.emitView(createOnlineView(baseState, 2));
+      await Promise.resolve();
+    });
+
+    expect(result.current.gameState.message).toBe(initialView.message);
+  });
+
+  it('drops sends while the socket is not open instead of counting an echo', async () => {
+    const session = createSession();
+    const { baseState } = createFastPlayStates();
+    const initialView = createOnlineView(baseState, 1);
+
+    const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+    });
+
+    const socket = MockWebSocket.instances[0];
+
+    // Socket still CONNECTING: nothing goes on the wire.
+    act(() => {
+      result.current.sendSetReady('Alice');
+    });
+    expect(socket.sent).toHaveLength(0);
+
+    await act(async () => {
+      socket.open();
+      socket.emitView(initialView);
+      await Promise.resolve();
+    });
+
+    // Socket closed: the move is dropped and must not be counted as owed —
+    // otherwise the first view after reconnecting would be swallowed.
+    await act(async () => {
+      socket.close();
+      await Promise.resolve();
+    });
+    act(() => {
+      result.current.clearSelection();
+    });
+    expect(getMoveMessages(socket).filter((m) => m.payload?.type === 'CLEAR_SELECTION')).toHaveLength(0);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+    const reconnectedSocket = MockWebSocket.instances.at(-1)!;
+    await act(async () => {
+      reconnectedSocket.open();
+      reconnectedSocket.emitView(createOnlineView(baseState, 2));
+      await Promise.resolve();
+    });
+
+    expect(result.current.gameState.message).toBe(initialView.message);
+  });
+
   it('allows the host to start a waiting room as soon as all connected players are ready', async () => {
     const session = createHostSession();
     const allReadyLobbySeats: LobbySeatInfo[] = [

--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -69,6 +69,15 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
   // is held back by this much so the acting player sees the same sequence
   // (own move first, then the next player drawing) that remote players see.
   const pendingLocalActionAnimationRef = useRef(0);
+  // Guest only: number of authoritative view echoes the host still owes us for
+  // moves already applied optimistically. The host answers every relayed move
+  // with exactly one view (the new state on success, a correction on
+  // rejection). While more than one echo is outstanding — e.g. a drag sends
+  // SELECT_CARD then PLAY_CARD within a round-trip — the earlier echoes are
+  // stale snapshots taken before the latest local action: rendering them would
+  // briefly revert the optimistic play and make the reappearing hand card look
+  // like a deck→hand draw. Only the final echo is rendered.
+  const pendingViewEchoesRef = useRef(0);
   const { removeAnimation, startAnimation, waitForAnimations } = useCardAnimation();
 
   const isHost = session != null && session.seatIndex === session.hostSeatIndex;
@@ -96,18 +105,18 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
   // ---------------------------------------------------------------------------
   // Wire helpers
   // ---------------------------------------------------------------------------
-  const sendRaw = useCallback((message: unknown): void => {
+  const sendRaw = useCallback((message: unknown): boolean => {
     if (!websocketRef.current || websocketRef.current.readyState !== WebSocket.OPEN) {
-      return;
+      return false;
     }
 
     websocketRef.current.send(JSON.stringify(message));
+    return true;
   }, []);
 
   const sendRelay = useCallback(
-    (kind: 'move' | 'event' | 'view', payload: unknown, toSeats?: number[]): void => {
-      sendRaw({ type: 'relay', kind, payload, toSeats });
-    },
+    (kind: 'move' | 'event' | 'view', payload: unknown, toSeats?: number[]): boolean =>
+      sendRaw({ type: 'relay', kind, payload, toSeats }),
     [sendRaw],
   );
 
@@ -248,6 +257,33 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     [clearTurnPresentationTimeout, commitView, setInteractionLocked],
   );
 
+  // Guest entry point for views relayed by the host. Drops stale echoes (see
+  // pendingViewEchoesRef); everything else flows into ingestView unchanged.
+  const ingestRelayedView = useCallback(
+    (incomingView: ClientGameView): void => {
+      if (pendingViewEchoesRef.current > 0) {
+        pendingViewEchoesRef.current -= 1;
+        if (pendingViewEchoesRef.current > 0) {
+          // Stale echo: a newer view reflecting our latest move is on its way.
+          // Record it as the authoritative fallback (actionRejected recovery)
+          // without rendering it.
+          authoritativeViewRef.current = incomingView;
+          return;
+        }
+      }
+
+      ingestView(incomingView);
+    },
+    [ingestView],
+  );
+
+  // Outstanding echoes belong to a socket + host lifetime: after a reconnect or
+  // a server-side rejection the missing echoes will never arrive, and the next
+  // view (resync or correction) must not be swallowed.
+  const resetPendingViewEchoes = useCallback((): void => {
+    pendingViewEchoesRef.current = 0;
+  }, []);
+
   // ---------------------------------------------------------------------------
   // Host authority: push each guest its redacted view, the abstract turn, the
   // reconnection snapshot, and the game-over signal.
@@ -316,8 +352,10 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
 
       if (isDebugAction(action)) {
         sendRelay('event', { move: action });
-      } else {
-        sendRelay('move', action);
+      } else if (sendRelay('move', action)) {
+        // The host will echo exactly one view for this move; count it so
+        // ingestRelayedView can skip echoes that predate later local moves.
+        pendingViewEchoesRef.current += 1;
       }
     },
     [applyHostAction, isHost, sendRelay],
@@ -345,6 +383,8 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     setInteractionLocked,
     clearTurnPresentationTimeout,
     ingestView,
+    ingestRelayedView,
+    resetPendingViewEchoes,
     pushAuthority,
     sendRaw,
     sendRelay,

--- a/apps/web/src/hooks/useOnlineSkipBoGame/useOnlineConnection.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame/useOnlineConnection.ts
@@ -36,6 +36,10 @@ export interface UseOnlineConnectionParams {
   setInteractionLocked: (locked: boolean) => void;
   clearTurnPresentationTimeout: () => void;
   ingestView: (incomingView: ClientGameView) => void;
+  /** Guest path for host-relayed views: skips echoes made stale by newer local moves. */
+  ingestRelayedView: (incomingView: ClientGameView) => void;
+  /** Clears the outstanding-echo count when the missing echoes can no longer arrive. */
+  resetPendingViewEchoes: () => void;
   pushAuthority: () => void;
   sendRaw: (message: unknown) => void;
   sendRelay: (kind: 'move' | 'event' | 'view', payload: unknown, toSeats?: number[]) => void;
@@ -83,6 +87,8 @@ export function useOnlineConnection(params: UseOnlineConnectionParams): void {
       setInteractionLocked,
       clearTurnPresentationTimeout,
       ingestView,
+      ingestRelayedView,
+      resetPendingViewEchoes,
       pushAuthority,
       sendRaw,
       sendRelay,
@@ -111,6 +117,7 @@ export function useOnlineConnection(params: UseOnlineConnectionParams): void {
 
     if (!session) {
       setInteractionLocked(false);
+      resetPendingViewEchoes();
       clearReconnectTimeout();
       clearPingInterval();
       clearTurnPresentationTimeout();
@@ -173,6 +180,9 @@ export function useOnlineConnection(params: UseOnlineConnectionParams): void {
       const currentSocket = new WebSocket(activeSession.wsUrl);
       socket = currentSocket;
       websocketRef.current = currentSocket;
+      // Echoes owed on the previous socket will never arrive on this one; the
+      // resync view requested below must not be swallowed as a stale echo.
+      resetPendingViewEchoes();
       // Guests request a fresh view from the host once per socket (covers
       // reconnect mid-game; the host has no other way to know we came back).
       let resyncRequested = false;
@@ -210,6 +220,7 @@ export function useOnlineConnection(params: UseOnlineConnectionParams): void {
           switch (message.type) {
             case 'gameStarted': {
               setInteractionLocked(false);
+              resetPendingViewEchoes();
               setConnectionStatus('connected');
               setLastError(null);
               setReceivedGameStats(null);
@@ -296,7 +307,7 @@ export function useOnlineConnection(params: UseOnlineConnectionParams): void {
                 }
                 // Host ignores relayed 'view'.
               } else if (message.kind === 'view') {
-                ingestView(message.payload as ClientGameView);
+                ingestRelayedView(message.payload as ClientGameView);
               } else if (message.kind === 'event') {
                 const payload = message.payload as { gameStats?: GameStatsRecord } | null;
                 if (payload?.gameStats) {
@@ -329,6 +340,9 @@ export function useOnlineConnection(params: UseOnlineConnectionParams): void {
             }
             case 'actionRejected': {
               setInteractionLocked(false);
+              // The rejected move never reached the host, so its echo is not
+              // coming; stop waiting for it before restoring the fallback view.
+              resetPendingViewEchoes();
               const knownStatus = authoritativeViewRef.current?.room.status ?? roomMetaRef.current?.status ?? null;
               if (knownStatus === null) {
                 intentionalLeaveRef.current = true;

--- a/docs/architecture/online-multiplayer.md
+++ b/docs/architecture/online-multiplayer.md
@@ -67,6 +67,7 @@ The exact contract lives in [../protocols/realtime-events.md](../protocols/realt
 - `OnlineGameBoard` owns the viewer-relative online presentation and room-aware status controls.
 - `OnlineStatusStrip` is the waiting-room control surface on the play screen; lobby data comes from `presence`.
 - Host and guest share one rendering path (`ingestView`); online animations are inferred from successive `ClientGameView` diffs.
+- Guests apply moves optimistically and the host echoes one authoritative view per move. Echoes that predate a newer in-flight local move (fast select→play, drag-and-drop) are stale and are skipped, not rendered — otherwise they would briefly revert the optimistic play and be mis-inferred as a draw animation.
 
 ## Runtime Topology
 


### PR DESCRIPTION
## Problem

In online games, guests often saw two sync glitches right after playing a card from their hand:

- a bogus **deck→hand draw animation** on their own hand, and
- the play appearing to **revert** for a moment before snapping forward again ("I guess I play it too fast").

## Root cause

Guests apply moves optimistically and the host echoes **one authoritative view per relayed move**. When two moves are in flight within one round-trip — `SELECT_CARD` then `PLAY_CARD`, which **every drag-and-drop does** (select fires at drag start, play at drop) — the `SELECT_CARD` echo arrives *after* the optimistic play was applied. Rendering that stale echo:

1. puts the card back in the hand and removes it from the build pile (the visible "revert"), and
2. makes `collectDrawTransitions` see a hand slot going `null → card`, which it mis-infers as a deck→hand draw animation.

The `PLAY_CARD` echo then lands and snaps everything forward again.

## Fix

`useOnlineSkipBoGame` now counts how many view echoes the host still owes for moves actually sent on the wire (`pendingViewEchoesRef`). `ingestRelayedView` drops every echo except the last one, which reflects all local moves. Skipped echoes still update `authoritativeViewRef` so the `actionRejected` fallback stays correct.

The counter resets whenever the missing echoes can no longer arrive:

- a new socket is opened (reconnect; the resync view must not be swallowed),
- server-side `actionRejected`,
- `gameStarted`,
- session teardown.

`sendRaw`/`sendRelay` now return whether the message was actually sent, so moves dropped on a closed socket are never counted.

## Tests

- New regression tests in `useOnlineSkipBoGame.test.tsx`:
  - fast select→play: the stale `SELECT_CARD` echo neither reverts the play nor triggers a draw animation; the final echo renders normally,
  - the first view after a reconnect renders even with echoes outstanding,
  - `actionRejected` clears the pending count so the next view renders.
- Verified the main regression test fails without the source fix.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (296/296) all pass.

Docs updated: `apps/web/CLAUDE.md` and `docs/architecture/online-multiplayer.md` now describe the stale-echo skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvZJihAeJnvuZXr8a6bDz9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvZJihAeJnvuZXr8a6bDz9)_