### PR TITLE
fix(web): stop reloading for updates while the lobby dialog is open

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { LocalGameBoard } from '@/components/LocalGameBoard';
 import { useCardAnimation } from '@/contexts/useCardAnimation';
 import { animationServiceBridge } from '@/lib/animationServiceBridge';
 import { isSafeToApplyLocalUpdate } from '@/lib/localUpdateGate';
+import { applyPendingUpdateBeforeOnlineStart } from '@/lib/onlineUpdateGate';
 import { canPlayCard } from '@/lib/validators';
 import { createOnlineRoom, joinOnlineRoom } from '@/online/api';
 import { getStoredStockSize } from '@/state/initialGameState';
@@ -179,7 +180,7 @@ function LiveApp() {
     // A required hard update was deferred while in local mode — apply it now and
     // abort the start (the reload boots into a fresh local game).
     if (isHardUpdateRequired) {
-      reloadToUpdate();
+      void reloadToUpdate();
       return;
     }
 
@@ -188,7 +189,7 @@ function LiveApp() {
     // worker has staged it, in which case `reloadToUpdate()` is a no-op. Fire it
     // and still start the game so a lagging SW can't leave "New Game" stuck.
     if (isUpdatePending) {
-      reloadToUpdate();
+      void reloadToUpdate();
     }
 
     setCurrentGameType('local-ai');
@@ -199,7 +200,14 @@ function LiveApp() {
     // Never contact the server on a build below the protocol floor — apply the
     // deferred hard update first (the reload aborts this start).
     if (isHardUpdateRequired) {
-      reloadToUpdate();
+      void reloadToUpdate();
+      return;
+    }
+
+    // Apply a pending soft update now, before a room code exists to share —
+    // the lobby is no longer a safe auto-apply moment. A committed reload
+    // aborts this start; otherwise fall through and create the room.
+    if (await applyPendingUpdateBeforeOnlineStart(isUpdatePending, reloadToUpdate)) {
       return;
     }
 
@@ -212,7 +220,13 @@ function LiveApp() {
 
   const joinGame = async (roomCode: string) => {
     if (isHardUpdateRequired) {
-      reloadToUpdate();
+      void reloadToUpdate();
+      return;
+    }
+
+    // Same as startOnlineGame: land a pending soft update on this deliberate
+    // action rather than reloading the lobby out from under the player.
+    if (await applyPendingUpdateBeforeOnlineStart(isUpdatePending, reloadToUpdate)) {
       return;
     }
 
@@ -270,6 +284,12 @@ function LiveApp() {
   );
   const hasUpdateNotice = showResumeBanner || showUpdatedBanner;
 
+  // Fire-and-forget form for void-returning UI callbacks; the start handlers
+  // above await the promise instead to know whether to abort.
+  const updateNow = () => {
+    void reloadToUpdate();
+  };
+
   const screen =
     currentGameType === 'online-human' && onlineSession ? (
       <Suspense fallback={null}>
@@ -283,7 +303,7 @@ function LiveApp() {
           onReplay={replayCurrentGame}
           onStartLocalGame={startLocalGame}
           onStartOnlineGame={startOnlineGame}
-          onUpdateNow={reloadToUpdate}
+          onUpdateNow={updateNow}
           session={onlineSession}
           updateNotice={hasUpdateNotice ? updateNotice : undefined}
         />
@@ -298,7 +318,7 @@ function LiveApp() {
         onReplay={replayCurrentGame}
         onStartLocalGame={startLocalGame}
         onStartOnlineGame={startOnlineGame}
-        onUpdateNow={reloadToUpdate}
+        onUpdateNow={updateNow}
         updateNotice={hasUpdateNotice ? updateNotice : undefined}
       />
     );
@@ -312,7 +332,7 @@ function LiveApp() {
           isReloading={isApplyingUpdate}
           latestVersion={latestAppVersion}
           minimumSupportedVersion={minimumSupportedVersion}
-          onReload={reloadToUpdate}
+          onReload={updateNow}
         />
       ) : null}
     </>

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -1,0 +1,279 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { GameConfig, GameState } from '@/types';
+
+// Controllable stand-in for the version gate so tests can flip pending/hard
+// update states and observe what the start handlers do with reloadToUpdate.
+const versionGate = {
+  applyUpdateOnceForCurrentTarget: vi.fn(),
+  currentAppVersion: 'v1.0.0',
+  dismissJustUpdated: vi.fn(),
+  dismissSoftUpdate: vi.fn(),
+  hasPendingServiceWorkerUpdate: false,
+  isApplyingUpdate: false,
+  isHardUpdateRequired: false,
+  isUpdatePending: false,
+  justUpdatedFromVersion: null as string | null,
+  lastCheckAt: null,
+  latestAppVersion: null,
+  minimumSupportedVersion: null as string | null,
+  reloadToUpdate: vi.fn<() => Promise<boolean>>(),
+  shouldShowSoftUpdate: false,
+};
+vi.mock('@/hooks/usePwaVersionGate', () => ({
+  usePwaVersionGate: () => ({ ...versionGate }),
+}));
+
+const createOnlineRoomMock = vi.fn();
+const joinOnlineRoomMock = vi.fn();
+vi.mock('@/online/api', () => ({
+  createOnlineRoom: (...args: unknown[]) => createOnlineRoomMock(...args),
+  joinOnlineRoom: (...args: unknown[]) => joinOnlineRoomMock(...args),
+}));
+
+vi.mock('@/state/sessionPersistence', () => ({
+  clearOnlineSession: vi.fn(),
+  loadOnlineSession: () => null,
+  saveOnlineSession: vi.fn(),
+}));
+
+function makeGameState(): GameState {
+  return {
+    deck: [],
+    buildPiles: [[], [], [], []],
+    completedBuildPiles: [],
+    players: Array.from({ length: 2 }, (_, index) => ({
+      isAI: index !== 0,
+      stockPile: [],
+      hand: [null, null, null, null, null],
+      discardPiles: [[], [], [], []],
+    })),
+    currentPlayerIndex: 0,
+    gameIsOver: false,
+    winnerIndex: null,
+    selectedCard: null,
+    message: '',
+    config: { STOCK_SIZE: 30 } as GameConfig,
+  } as GameState;
+}
+
+vi.mock('@/hooks/useLocalSkipBoGame', () => ({
+  useLocalSkipBoGame: () => ({
+    clearSelection: vi.fn(),
+    debugFillBuildPile: vi.fn(),
+    debugFillHandSkipBo: vi.fn(),
+    debugClearStockPile: vi.fn(),
+    debugClearAiStockPile: vi.fn(),
+    debugWin: vi.fn(),
+    discardCard: vi.fn(),
+    gameState: makeGameState(),
+    playCard: vi.fn(),
+    selectCard: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useGameStatsRecorder', () => ({
+  buildGameStatsSnapshot: () => null,
+  useGameStatsRecorder: () => ({ lastRecord: null }),
+}));
+
+vi.mock('@/contexts/useCardAnimation', () => ({
+  useCardAnimation: () => ({ waitForAnimations: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useThemeColorMeta', () => ({ useThemeColorMeta: () => undefined }));
+vi.mock('@/hooks/useThemeUsageReporter', () => ({ useThemeUsageReporter: () => undefined }));
+
+// Presentational children are irrelevant here — render nothing, but capture the
+// AppShell props each render so the session handlers can be driven directly.
+interface CapturedShellProps {
+  onStartOnlineGame: (stockSize?: number) => Promise<void>;
+  onJoinOnlineGame: (roomCode: string) => Promise<void>;
+  onStartLocalGame: () => void;
+  onUpdateNow?: () => void;
+}
+const appShellCalls: CapturedShellProps[] = [];
+vi.mock('@/components/AppShell', () => ({
+  AppShell: (props: CapturedShellProps) => {
+    appShellCalls.push(props);
+    return null;
+  },
+}));
+const onlineScreenCalls: unknown[] = [];
+vi.mock('@/components/OnlineGameScreen', () => ({
+  default: (props: unknown) => {
+    onlineScreenCalls.push(props);
+    return null;
+  },
+}));
+vi.mock('@/components/LocalGameBoard', () => ({ LocalGameBoard: () => null }));
+vi.mock('@/components/DebugStrip', () => ({ DebugStrip: () => null }));
+vi.mock('@/components/AppUpdatedBanner', () => ({ AppUpdatedBanner: () => null }));
+vi.mock('@/components/ResumeGameBanner', () => ({ ResumeGameBanner: () => null }));
+vi.mock('@/components/ForcedUpdateOverlay', () => ({ ForcedUpdateOverlay: () => null }));
+
+import App from '@/App';
+
+const lastShellProps = () => {
+  const props = appShellCalls.at(-1);
+  if (!props) throw new Error('AppShell never rendered');
+  return props;
+};
+
+const session = { roomCode: 'ABCD', seatIndex: 0, seatToken: 'token', seatCapacity: 4, hostSeatIndex: 0 };
+
+beforeEach(() => {
+  versionGate.isHardUpdateRequired = false;
+  versionGate.isUpdatePending = false;
+  versionGate.reloadToUpdate.mockResolvedValue(false);
+  createOnlineRoomMock.mockResolvedValue(session);
+  joinOnlineRoomMock.mockResolvedValue(session);
+});
+
+afterEach(() => {
+  appShellCalls.length = 0;
+  onlineScreenCalls.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('App online start handlers and pending updates', () => {
+  it('creates the room when no update is pending', async () => {
+    render(<App />);
+
+    await act(async () => {
+      await lastShellProps().onStartOnlineGame();
+    });
+
+    expect(versionGate.reloadToUpdate).not.toHaveBeenCalled();
+    expect(createOnlineRoomMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(onlineScreenCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('applies a pending update and aborts the start when the reload commits', async () => {
+    versionGate.isUpdatePending = true;
+    versionGate.reloadToUpdate.mockResolvedValue(true);
+
+    render(<App />);
+
+    await act(async () => {
+      await lastShellProps().onStartOnlineGame();
+    });
+
+    expect(versionGate.reloadToUpdate).toHaveBeenCalled();
+    expect(createOnlineRoomMock).not.toHaveBeenCalled();
+    expect(onlineScreenCalls).toHaveLength(0);
+  });
+
+  it('still creates the room when the pending update has no staged worker (reload no-op)', async () => {
+    versionGate.isUpdatePending = true;
+    versionGate.reloadToUpdate.mockResolvedValue(false);
+
+    render(<App />);
+
+    await act(async () => {
+      await lastShellProps().onStartOnlineGame();
+    });
+
+    expect(versionGate.reloadToUpdate).toHaveBeenCalled();
+    expect(createOnlineRoomMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies a deferred hard update instead of contacting the server', async () => {
+    versionGate.isHardUpdateRequired = true;
+
+    render(<App />);
+
+    await act(async () => {
+      await lastShellProps().onStartOnlineGame();
+    });
+
+    expect(versionGate.reloadToUpdate).toHaveBeenCalled();
+    expect(createOnlineRoomMock).not.toHaveBeenCalled();
+  });
+
+  it('applies a deferred hard update instead of joining a room', async () => {
+    versionGate.isHardUpdateRequired = true;
+
+    render(<App />);
+
+    await act(async () => {
+      await lastShellProps().onJoinOnlineGame('ABCD');
+    });
+
+    expect(versionGate.reloadToUpdate).toHaveBeenCalled();
+    expect(joinOnlineRoomMock).not.toHaveBeenCalled();
+  });
+
+  it('applies a deferred hard update instead of starting a fresh local game', async () => {
+    versionGate.isHardUpdateRequired = true;
+
+    render(<App />);
+    versionGate.reloadToUpdate.mockClear();
+
+    act(() => {
+      lastShellProps().onStartLocalGame();
+    });
+
+    expect(versionGate.reloadToUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('gates joining a room on the pending update the same way as creating one', async () => {
+    versionGate.isUpdatePending = true;
+    versionGate.reloadToUpdate.mockResolvedValue(true);
+
+    render(<App />);
+
+    await act(async () => {
+      await lastShellProps().onJoinOnlineGame('ABCD');
+    });
+
+    expect(versionGate.reloadToUpdate).toHaveBeenCalled();
+    expect(joinOnlineRoomMock).not.toHaveBeenCalled();
+  });
+
+  it('joins the room once the pending update turns out to be a no-op', async () => {
+    versionGate.isUpdatePending = true;
+    versionGate.reloadToUpdate.mockResolvedValue(false);
+
+    render(<App />);
+
+    await act(async () => {
+      await lastShellProps().onJoinOnlineGame('ABCD');
+    });
+
+    expect(joinOnlineRoomMock).toHaveBeenCalledWith('ABCD');
+    await waitFor(() => {
+      expect(onlineScreenCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('fires a fire-and-forget reload from the update-now callback', async () => {
+    render(<App />);
+
+    act(() => {
+      lastShellProps().onUpdateNow?.();
+    });
+
+    expect(versionGate.reloadToUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the reload alongside starting a fresh local game while an update is pending', async () => {
+    versionGate.isUpdatePending = true;
+
+    render(<App />);
+    versionGate.applyUpdateOnceForCurrentTarget.mockClear();
+    versionGate.reloadToUpdate.mockClear();
+
+    act(() => {
+      lastShellProps().onStartLocalGame();
+    });
+
+    expect(versionGate.reloadToUpdate).toHaveBeenCalledTimes(1);
+    // The local start is not aborted — a lagging service worker must not leave
+    // the "New Game" button stuck.
+    expect(appShellCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/OnlineGameScreen.tsx
+++ b/apps/web/src/components/OnlineGameScreen.tsx
@@ -116,9 +116,12 @@ function OnlineGameScreen({
   // a pending update is lossless. Only do it at a "safe" moment — never while it
   // is the local player's active turn (index 0 in the recentred view), to avoid
   // cutting off an in-progress action, and never on a finished game so the
-  // victory/defeat screen is preserved. The update then lands during an
-  // opponent's turn, in the next lobby, or on the user's next deliberate action.
-  const isSafeToApplyUpdate = !gameState.gameIsOver && (roomStatus === 'WAITING' || gameState.currentPlayerIndex !== 0);
+  // victory/defeat screen is preserved. The WAITING lobby is deliberately NOT
+  // safe either: the lobby dialog is showing the room code the player is trying
+  // to share, and a reload would yank it away and bounce them through the resume
+  // banner. Updates instead apply before the room is even created (see
+  // startOnlineGame/joinGame in App.tsx) or during an opponent's turn.
+  const isSafeToApplyUpdate = !gameState.gameIsOver && roomStatus === 'ACTIVE' && gameState.currentPlayerIndex !== 0;
 
   useEffect(() => {
     if (isUpdatePending && isSafeToApplyUpdate) {

--- a/apps/web/src/components/__tests__/OnlineGameScreen.test.tsx
+++ b/apps/web/src/components/__tests__/OnlineGameScreen.test.tsx
@@ -150,6 +150,40 @@ describe('OnlineGameScreen stats gate', () => {
   });
 });
 
+describe('OnlineGameScreen pending-update safe gate', () => {
+  it('does not auto-apply while the lobby is open (the room code is being shared)', () => {
+    onlineHook.mockReturnValue({ ...baseHookReturn(), roomStatus: 'WAITING' });
+    render(<OnlineGameScreen {...screenProps} isUpdatePending />);
+    expect(screenProps.applyUpdateWhenSafe).not.toHaveBeenCalled();
+  });
+
+  it("auto-applies during an opponent's turn in an active game", () => {
+    onlineHook.mockReturnValue({
+      ...baseHookReturn(),
+      roomStatus: 'ACTIVE',
+      gameState: { ...makeGameState(), currentPlayerIndex: 1 },
+    });
+    render(<OnlineGameScreen {...screenProps} isUpdatePending />);
+    expect(screenProps.applyUpdateWhenSafe).toHaveBeenCalled();
+  });
+
+  it("does not auto-apply during the local player's turn", () => {
+    onlineHook.mockReturnValue({ ...baseHookReturn(), roomStatus: 'ACTIVE' });
+    render(<OnlineGameScreen {...screenProps} isUpdatePending />);
+    expect(screenProps.applyUpdateWhenSafe).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-apply on a finished game (victory screen stays up)', () => {
+    onlineHook.mockReturnValue({
+      ...baseHookReturn(),
+      roomStatus: 'FINISHED',
+      gameState: { ...makeGameState(), currentPlayerIndex: 1, gameIsOver: true, winnerIndex: 1 },
+    });
+    render(<OnlineGameScreen {...screenProps} isUpdatePending />);
+    expect(screenProps.applyUpdateWhenSafe).not.toHaveBeenCalled();
+  });
+});
+
 describe('OnlineGameScreen stats broadcast/receive', () => {
   const statsRecord: GameStatsRecord = {
     id: 'game-1',

--- a/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
@@ -250,6 +250,27 @@ describe('usePwaVersionGate', () => {
     expect(applyServiceWorkerUpdateMock).not.toHaveBeenCalled();
   });
 
+  it('resolves reloadToUpdate with whether a reload actually committed', async () => {
+    const { result } = renderHook(() => usePwaVersionGate());
+
+    await waitFor(() => {
+      expect(fetchRuntimeConfigMock).toHaveBeenCalledTimes(1);
+    });
+
+    // No worker staged yet — the apply is a no-op, callers may proceed.
+    applyServiceWorkerUpdateMock.mockResolvedValueOnce(false);
+    await act(async () => {
+      await expect(result.current.reloadToUpdate()).resolves.toBe(false);
+    });
+
+    // A staged worker commits the reload — callers must abort what they were
+    // about to do (the page is navigating).
+    applyServiceWorkerUpdateMock.mockResolvedValueOnce(true);
+    await act(async () => {
+      await expect(result.current.reloadToUpdate()).resolves.toBe(true);
+    });
+  });
+
   it('reports the previous version when the build just moved to a newer one', async () => {
     globalThis.localStorage?.setItem('skipbo:last-seen-version', 'v0.9.0');
 

--- a/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
@@ -271,6 +271,32 @@ describe('usePwaVersionGate', () => {
     });
   });
 
+  it('resolves false for a reload requested while another apply is in flight', async () => {
+    let resolveApply: ((committed: boolean) => void) | undefined;
+    applyServiceWorkerUpdateMock.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveApply = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => usePwaVersionGate());
+
+    await waitFor(() => {
+      expect(fetchRuntimeConfigMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      const first = result.current.reloadToUpdate();
+      // The guard is set synchronously, so a second request short-circuits.
+      await expect(result.current.reloadToUpdate()).resolves.toBe(false);
+      resolveApply?.(true);
+      await expect(first).resolves.toBe(true);
+    });
+
+    expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
+  });
+
   it('reports the previous version when the build just moved to a newer one', async () => {
     globalThis.localStorage?.setItem('skipbo:last-seen-version', 'v0.9.0');
 

--- a/apps/web/src/hooks/usePwaVersionGate.ts
+++ b/apps/web/src/hooks/usePwaVersionGate.ts
@@ -81,7 +81,11 @@ export interface PwaVersionGateState {
   applyUpdateOnceForCurrentTarget: () => void;
   dismissJustUpdated: () => void;
   dismissSoftUpdate: () => void;
-  reloadToUpdate: () => void;
+  // Resolves true when a reload actually committed (the page is about to
+  // navigate), false when there was nothing to apply — no staged worker yet, or
+  // an apply already in flight. Callers that want to abort an action when the
+  // reload fires (e.g. starting an online game) await this instead of racing it.
+  reloadToUpdate: () => Promise<boolean>;
   shouldShowSoftUpdate: boolean;
 }
 
@@ -128,9 +132,9 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
     });
   });
 
-  const runReloadToUpdate = useCallback(async (onReloadCommitted?: () => void) => {
+  const runReloadToUpdate = useCallback(async (onReloadCommitted?: () => void): Promise<boolean> => {
     if (isApplyingUpdateRef.current) {
-      return;
+      return false;
     }
 
     isApplyingUpdateRef.current = true;
@@ -140,7 +144,7 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
       // No `location.reload()` fallback: reloading without a freshly installed
       // worker re-serves the same precached bundle, which on iOS standalone
       // PWAs loops splash → blank → reload whenever a hard update is required.
-      await applyServiceWorkerUpdate(onReloadCommitted).catch(() => false);
+      return await applyServiceWorkerUpdate(onReloadCommitted).catch(() => false);
     } finally {
       isApplyingUpdateRef.current = false;
       setIsApplyingUpdate(false);
@@ -287,9 +291,7 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
         setDismissedUpdateKey(updateKey);
       }
     },
-    reloadToUpdate: () => {
-      void runReloadToUpdate();
-    },
+    reloadToUpdate: () => runReloadToUpdate(),
     shouldShowSoftUpdate,
   };
 };

--- a/apps/web/src/lib/__tests__/onlineUpdateGate.test.ts
+++ b/apps/web/src/lib/__tests__/onlineUpdateGate.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { applyPendingUpdateBeforeOnlineStart } from '@/lib/onlineUpdateGate';
+
+describe('applyPendingUpdateBeforeOnlineStart', () => {
+  it('does not touch the reload path when no update is pending', async () => {
+    const reloadToUpdate = vi.fn().mockResolvedValue(true);
+
+    await expect(applyPendingUpdateBeforeOnlineStart(false, reloadToUpdate)).resolves.toBe(false);
+
+    expect(reloadToUpdate).not.toHaveBeenCalled();
+  });
+
+  it('aborts the start when a pending update commits a reload', async () => {
+    const reloadToUpdate = vi.fn().mockResolvedValue(true);
+
+    await expect(applyPendingUpdateBeforeOnlineStart(true, reloadToUpdate)).resolves.toBe(true);
+
+    expect(reloadToUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets the start proceed when no service worker is staged yet (reload no-op)', async () => {
+    const reloadToUpdate = vi.fn().mockResolvedValue(false);
+
+    await expect(applyPendingUpdateBeforeOnlineStart(true, reloadToUpdate)).resolves.toBe(false);
+
+    expect(reloadToUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/onlineUpdateGate.ts
+++ b/apps/web/src/lib/onlineUpdateGate.ts
@@ -1,0 +1,17 @@
+/**
+ * Apply a pending soft update at the moment the player creates or joins an
+ * online room — the last lossless moment before a room code exists to share.
+ * The lobby itself is not a safe auto-apply moment (the dialog is showing the
+ * code; see OnlineGameScreen), so this deliberate action is where a pending
+ * update lands instead.
+ *
+ * Resolves true when a reload actually committed: the caller must abort the
+ * start, since the page is about to boot into the new build. Resolves false
+ * when there is nothing to apply or no service worker is staged yet (the
+ * `runtime:` channel can advertise a version before the worker has fetched
+ * it) — the caller proceeds so a lagging download can't block starting a game.
+ */
+export const applyPendingUpdateBeforeOnlineStart = async (
+  isUpdatePending: boolean,
+  reloadToUpdate: () => Promise<boolean>,
+): Promise<boolean> => (isUpdatePending ? reloadToUpdate() : false);


### PR DESCRIPTION
## Problem

Creating a multiplayer game and trying to share the room code often got interrupted by a PWA update reload. Two things combined to cause this:

1. Update detection at app open is asynchronous — the runtime-config fetch plus the service-worker download/install typically finish a few seconds after launch, so at the moment the app opens there is usually nothing pending yet. By the time the update is detected, the player is already in the flow.
2. The online safe-moment gate in `OnlineGameScreen` treated the `WAITING` lobby as a safe point to auto-apply a pending update — but that is exactly when the lobby dialog is showing the room code the player is trying to share. The reload closed the dialog and bounced them through the resume banner.

## Fix

- **`OnlineGameScreen`**: the lobby is no longer a safe auto-apply moment. Mid-game, updates still auto-apply during an opponent's turn (lossless — online state rebuilds from the server snapshot), never on the local player's turn or a finished game.
- **`App`**: creating or joining an online room now applies a pending soft update *before* contacting the server — the last lossless moment before a room code exists to share (new `applyPendingUpdateBeforeOnlineStart` helper). If a reload actually commits, the start is aborted (the page boots into the new build); if no service worker is staged yet (the runtime channel can advertise a version before the worker fetched it), the start proceeds so a lagging download can't block the button.
- **`usePwaVersionGate`**: `reloadToUpdate` now resolves with whether a reload actually committed, so callers can make that abort decision. UI callbacks (`onUpdateNow`, `ForcedUpdateOverlay.onReload`) use a fire-and-forget wrapper.

## Tests

- New unit tests for `applyPendingUpdateBeforeOnlineStart` (pending/commit/no-op paths).
- New `OnlineGameScreen` tests pinning the safe gate: no auto-apply in the lobby, on the local player's turn, or on a finished game; auto-apply during an opponent's turn.
- New `usePwaVersionGate` test for the `reloadToUpdate` result.
- `pnpm --filter @skipbo/web test` (314 passed), lint, and typecheck are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eyjEu8SUbPYAwb5vnCqdQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011eyjEu8SUbPYAwb5vnCqdQ)_