### PR TITLE
fix(web): align duration pausing with per-player play time by mode

### DIFF
--- a/apps/web/src/hooks/__tests__/useGameStatsRecorder.test.tsx
+++ b/apps/web/src/hooks/__tests__/useGameStatsRecorder.test.tsx
@@ -207,3 +207,60 @@ describe('useGameStatsRecorder', () => {
     expect(recorded.winnerName).toBe('Bob');
   });
 });
+
+describe('visibility pausing', () => {
+  function ModeHarness({ snapshot, mode }: { snapshot: GameStatsSnapshot | null; mode: 'local' | 'online' }) {
+    const { lastRecord } = useGameStatsRecorder(snapshot, { mode, isCentralReporter: true });
+    captured = lastRecord;
+    return null;
+  }
+
+  const originalVisibilityState = Object.getOwnPropertyDescriptor(document, 'visibilityState');
+
+  const setVisibility = (state: 'visible' | 'hidden') => {
+    Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => state });
+    document.dispatchEvent(new Event('visibilitychange'));
+  };
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalVisibilityState) {
+      Object.defineProperty(document, 'visibilityState', originalVisibilityState);
+    }
+  });
+
+  it('local: pauses both play time and total duration while the tab is hidden', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    captured = null;
+
+    const { rerender } = render(<ModeHarness snapshot={activeSnapshot} mode="local" />);
+
+    setVisibility('hidden');
+    vi.setSystemTime(4000);
+    setVisibility('visible');
+
+    rerender(<ModeHarness snapshot={overSnapshot} mode="local" />);
+
+    expect(captured).not.toBeNull();
+    // The whole 4s elapsed while hidden, so both duration and play time are 0.
+    expect(captured!.durationMs).toBe(0);
+  });
+
+  it("online: keeps counting through a hidden tab (a guest's own tab does not pause the game)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    captured = null;
+
+    const { rerender } = render(<ModeHarness snapshot={activeSnapshot} mode="online" />);
+
+    setVisibility('hidden');
+    vi.setSystemTime(4000);
+    setVisibility('visible');
+
+    rerender(<ModeHarness snapshot={overSnapshot} mode="online" />);
+
+    expect(captured).not.toBeNull();
+    expect(captured!.durationMs).toBe(4000);
+  });
+});

--- a/apps/web/src/hooks/useGameStatsRecorder.ts
+++ b/apps/web/src/hooks/useGameStatsRecorder.ts
@@ -108,9 +108,15 @@ export function useGameStatsRecorder(
     }
   }, [lastRecord]);
 
-  // Pause play-time counting while the tab is hidden, like the theme timer, so
-  // background time is not attributed to whoever's turn it is.
+  // Pause play-time (and duration) counting while the tab is hidden, like the
+  // theme timer, so background time is not attributed to whoever's turn it
+  // is. Local only: in a local game a hidden tab means nobody can act, so the
+  // whole game is genuinely paused. Online, this client's own tab visibility
+  // says nothing about whether the game is paused — other seats keep playing
+  // regardless — so online games never pause.
   useEffect(() => {
+    if (mode !== 'local') return;
+
     const onVisibilityChange = () => tracker.setHidden(document.visibilityState === 'hidden', Date.now());
     const onPageHide = () => tracker.setHidden(true, Date.now());
 
@@ -121,7 +127,7 @@ export function useGameStatsRecorder(
       document.removeEventListener('visibilitychange', onVisibilityChange);
       window.removeEventListener('pagehide', onPageHide);
     };
-  }, [tracker]);
+  }, [mode, tracker]);
 
   return { lastRecord };
 }

--- a/apps/web/src/monitoring/__tests__/gameStats.test.ts
+++ b/apps/web/src/monitoring/__tests__/gameStats.test.ts
@@ -155,6 +155,60 @@ describe('createGameStatsTracker', () => {
     expect(record.durationMs).toBe(1000); // the 8000ms hidden span never counted
   });
 
+  it('begins a recording already paused if the tab is hidden when the game starts', () => {
+    const onComplete = vi.fn();
+    const tracker = makeTracker(onComplete);
+
+    // Hidden before any game is open — setHidden must not touch a nonexistent recording.
+    tracker.setHidden(true, 0);
+    // The game starts while still hidden; the opening segment must not run.
+    tracker.observe(
+      snap(false, 0, null, [
+        ['Alice', false, 10],
+        ['Bot', true, 10],
+      ]),
+      100,
+    );
+    tracker.setHidden(false, 500); // resume 400ms later
+    tracker.observe(
+      snap(true, 0, 0, [
+        ['Alice', false, 0],
+        ['Bot', true, 10],
+      ]),
+      700,
+    );
+
+    const record = onComplete.mock.calls[0][0] as GameStatsRecord;
+    expect(record.players[0].playTimeMs).toBe(200); // only the post-resume 500->700 span
+    expect(record.durationMs).toBe(200); // the 100->500 hidden span never counted
+  });
+
+  it('ignores a zero-length hidden span', () => {
+    const onComplete = vi.fn();
+    const tracker = makeTracker(onComplete);
+
+    tracker.observe(
+      snap(false, 0, null, [
+        ['Alice', false, 10],
+        ['Bot', true, 10],
+      ]),
+      0,
+    );
+    tracker.setHidden(true, 500);
+    tracker.setHidden(false, 500); // hidden and resumed at the exact same instant
+    tracker.observe(
+      snap(true, 0, 0, [
+        ['Alice', false, 0],
+        ['Bot', true, 5],
+      ]),
+      1000,
+    );
+
+    const record = onComplete.mock.calls[0][0] as GameStatsRecord;
+    expect(record.players[0].playTimeMs).toBe(1000); // no time excluded
+    expect(record.durationMs).toBe(1000);
+  });
+
   it('does not increment turns when the current player is unchanged', () => {
     const onComplete = vi.fn();
     const tracker = makeTracker(onComplete);

--- a/apps/web/src/monitoring/__tests__/gameStats.test.ts
+++ b/apps/web/src/monitoring/__tests__/gameStats.test.ts
@@ -103,7 +103,7 @@ describe('createGameStatsTracker', () => {
     });
   });
 
-  it('excludes hidden time from a player play time', () => {
+  it('excludes hidden time from a player play time and from the total duration', () => {
     const onComplete = vi.fn();
     const tracker = makeTracker(onComplete);
 
@@ -126,7 +126,33 @@ describe('createGameStatsTracker', () => {
 
     const record = onComplete.mock.calls[0][0] as GameStatsRecord;
     expect(record.players[0].playTimeMs).toBe(2000); // 1000 before hide + 1000 after resume
-    expect(record.durationMs).toBe(6000); // wall-clock duration is unaffected
+    expect(record.durationMs).toBe(2000); // hidden span is paused in lockstep with play time
+  });
+
+  it('keeps duration paused if the game ends while still hidden', () => {
+    const onComplete = vi.fn();
+    const tracker = makeTracker(onComplete);
+
+    tracker.observe(
+      snap(false, 0, null, [
+        ['Alice', false, 10],
+        ['Bot', true, 10],
+      ]),
+      0,
+    );
+    tracker.setHidden(true, 1000); // P0 has played 1000ms so far
+    // The game ends (e.g. a debug win) while the tab is still hidden.
+    tracker.observe(
+      snap(true, 0, 0, [
+        ['Alice', false, 0],
+        ['Bot', true, 5],
+      ]),
+      9000,
+    );
+
+    const record = onComplete.mock.calls[0][0] as GameStatsRecord;
+    expect(record.players[0].playTimeMs).toBe(1000);
+    expect(record.durationMs).toBe(1000); // the 8000ms hidden span never counted
   });
 
   it('does not increment turns when the current player is unchanged', () => {
@@ -290,6 +316,7 @@ describe('createGameStatsTracker', () => {
     expect(record.totalTurns).toBe(2);
     expect(record.players[0].playTimeMs).toBe(1000); // only the pre-hide time
     expect(record.players[1].playTimeMs).toBe(1000); // only the post-resume time
+    expect(record.durationMs).toBe(2000); // the 5000ms hidden span is excluded too
   });
 
   it('does not open a recording for an empty-player snapshot', () => {

--- a/apps/web/src/monitoring/gameStats.ts
+++ b/apps/web/src/monitoring/gameStats.ts
@@ -12,6 +12,13 @@
  * The tracker takes explicit `now` timestamps so its turn-counting and
  * play-time arithmetic can be unit-tested deterministically; the React hook
  * that owns it injects `Date.now()` and tab-visibility changes.
+ *
+ * `setHidden` pauses both the active player's segment and the overall
+ * duration in lockstep, so `durationMs` always equals the sum of every
+ * player's `playTimeMs` — hidden time simply doesn't happen. Online games
+ * never call `setHidden` (see `useGameStatsRecorder`): a guest's own tab
+ * visibility says nothing about whether the game itself is paused, since
+ * other seats keep playing regardless.
  */
 
 export const GAME_STATS_SCHEMA_VERSION = 1;
@@ -90,7 +97,7 @@ export interface GameStatsTrackerOptions {
 export interface GameStatsTracker {
   /** Feed the current game snapshot and the current wall-clock instant. */
   observe: (snapshot: GameStatsSnapshot, nowMs: number) => void;
-  /** Pause/resume play-time counting (e.g. while the tab is hidden). */
+  /** Pause/resume play-time and duration counting (e.g. while the tab is hidden). */
   setHidden: (hidden: boolean, nowMs: number) => void;
   /** Whether a game is currently being recorded. */
   isRecording: () => boolean;
@@ -112,6 +119,10 @@ interface OpenRecording {
   players: PlayerAccumulator[];
   /** Start of the running play-time segment, or null while paused/hidden. */
   segmentStartMs: number | null;
+  /** Start of the current hidden span, or null while visible. */
+  hiddenSinceMs: number | null;
+  /** Accumulated hidden time, subtracted from wall-clock duration at finalize. */
+  totalHiddenMs: number;
 }
 
 const defaultGenerateId = (): string => {
@@ -158,6 +169,8 @@ export function createGameStatsTracker(options: GameStatsTrackerOptions): GameSt
         playTimeMs: 0,
       })),
       segmentStartMs: null,
+      hiddenSinceMs: hidden ? nowMs : null,
+      totalHiddenMs: 0,
     };
     // The opening player's first turn is already underway.
     if (open.players[snapshot.currentPlayerIndex]) {
@@ -166,9 +179,21 @@ export function createGameStatsTracker(options: GameStatsTrackerOptions): GameSt
     startSegment(nowMs);
   };
 
+  /** Credit the running hidden span to the total and stop counting it. */
+  const closeHiddenSpan = (nowMs: number): void => {
+    if (open && open.hiddenSinceMs !== null) {
+      const elapsed = nowMs - open.hiddenSinceMs;
+      if (elapsed > 0) {
+        open.totalHiddenMs += elapsed;
+      }
+      open.hiddenSinceMs = null;
+    }
+  };
+
   const finalize = (snapshot: GameStatsSnapshot, nowMs: number): void => {
     if (!open) return;
     closeSegment(nowMs);
+    closeHiddenSpan(nowMs);
 
     const winnerIndex = snapshot.winnerIndex;
     const players: GameStatsPlayer[] = open.players.map((accumulator, index) => {
@@ -194,7 +219,7 @@ export function createGameStatsTracker(options: GameStatsTrackerOptions): GameSt
       mode: options.mode,
       startedAt: new Date(open.startedAtMs).toISOString(),
       endedAt: new Date(nowMs).toISOString(),
-      durationMs: Math.max(0, nowMs - open.startedAtMs),
+      durationMs: Math.max(0, nowMs - open.startedAtMs - open.totalHiddenMs),
       totalTurns: open.totalTurns,
       playerCount: players.length,
       stockSize: open.stockSize,
@@ -241,7 +266,9 @@ export function createGameStatsTracker(options: GameStatsTrackerOptions): GameSt
       hidden = nextHidden;
       if (hidden) {
         closeSegment(nowMs);
+        if (open) open.hiddenSinceMs = nowMs;
       } else {
+        closeHiddenSpan(nowMs);
         startSegment(nowMs);
       }
     },


### PR DESCRIPTION
## Summary

Follow-up to #181 — that PR fixed the *online* endgame stats bug (every seat computing different numbers). This PR fixes a separate discrepancy, reported for a **local** game: the "Durée" (total game duration) could be noticeably longer than the sum of every player's "Temps" (per-player play time).

- **Local mode**: play-time counting already paused while the tab was hidden (screen locked, app backgrounded), but the total duration kept running as pure wall-clock time. So a backgrounded stretch mid-game inflated "Durée" without being credited to anyone in "Temps". Fix: pause the total duration in lockstep with the per-player segment, so `Durée == sum(Temps)` always holds for local games.
- **Online mode**: the opposite problem — a guest's own tab visibility says nothing about whether the *shared* game is paused, since other seats keep playing regardless (e.g. "even if a player takes a call, I still have to wait for them"). Fix: online games now never pause on visibility changes at all — the previously-shared visibility wiring is gated to `mode === 'local'` only.

## Changes

- `apps/web/src/monitoring/gameStats.ts`: track accumulated hidden time (`hiddenSinceMs`/`totalHiddenMs`) on the open recording and subtract it from `durationMs` at finalize, mirroring the existing per-player segment pause/resume logic.
- `apps/web/src/hooks/useGameStatsRecorder.ts`: only attach the `visibilitychange`/`pagehide` listeners (i.e. only ever call `tracker.setHidden`) when `mode === 'local'`.
- Updated/added unit tests in `gameStats.test.ts` and `useGameStatsRecorder.test.tsx` covering both behaviors.

## Test plan

- [x] `pnpm typecheck` (all packages)
- [x] `pnpm lint` (all packages)
- [x] `pnpm test` (all packages) — 328 web tests pass, including new coverage for duration pausing (local) and no-pause (online)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fq5rUqNmrhnEfbifShMa23)_