### PR TITLE
fix(web): tone down paper theme's card-move brighten filter

### DIFF
--- a/apps/web/src/themes/paper.css
+++ b/apps/web/src/themes/paper.css
@@ -167,4 +167,19 @@
         cover;
     }
   }
+
+  /* Paper's cream card front (#fbf6e7 ≈ rgb(251,246,231)) sits only a few
+     points shy of white on every channel. The shared brighten filters in
+     styles/animations.css (up to brightness(1.1)) clip all three channels to
+     255 mid-flight, so a played/dragged/drawn card flashes solid white
+     instead of a subtle highlight. Scale the boost down to what this card
+     front can take before clipping. */
+  .animation-play,
+  .animation-draw {
+    filter: brightness(1.02);
+  }
+
+  .animation-complete {
+    filter: brightness(1.02) saturate(1.02);
+  }
 }


### PR DESCRIPTION
## Summary
- Paper theme's cream card front (`#fbf6e7` ≈ rgb(251,246,231)) sits only a few points shy of white on every channel
- The shared `.animation-play`/`.animation-draw`/`.animation-complete` brighten filters (up to `brightness(1.1)`) clip all three channels to 255 mid-flight, so a played/dragged/drawn card flashes solid white instead of a subtle highlight
- Scoped an override to `.theme-paper` that scales the brightness boost down to what this card front can take before clipping; other themes are unaffected

## Test plan
- [x] `pnpm --filter @skipbo/web lint`
- [x] Verified in browser preview: computed `filter` for `.animation-play`/`.animation-draw`/`.animation-complete` under `.theme-paper` resolves to the toned-down values
- [x] Performed a live drag-and-drop play in paper theme; no white flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)