### PR TITLE
fix(web): force network refresh when update can't stage a worker

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -285,9 +285,13 @@ function LiveApp() {
   const hasUpdateNotice = showResumeBanner || showUpdatedBanner;
 
   // Fire-and-forget form for void-returning UI callbacks; the start handlers
-  // above await the promise instead to know whether to abort.
+  // above await the promise instead to know whether to abort. Explicit user
+  // presses (the update button, the forced-update overlay) escalate a no-op
+  // apply to a network force-refresh — without it, a client whose service
+  // worker never stages the advertised build (seen on iOS standalone PWAs)
+  // presses the button, the label flashes, and nothing else ever happens.
   const updateNow = () => {
-    void reloadToUpdate();
+    void reloadToUpdate({ forceReloadIfNotStaged: true });
   };
 
   const screen =

--- a/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
@@ -271,6 +271,21 @@ describe('usePwaVersionGate', () => {
     });
   });
 
+  it('forwards the force option so explicit user presses can escape a stuck worker', async () => {
+    const { result } = renderHook(() => usePwaVersionGate());
+
+    await waitFor(() => {
+      expect(fetchRuntimeConfigMock).toHaveBeenCalledTimes(1);
+    });
+
+    applyServiceWorkerUpdateMock.mockResolvedValueOnce(true);
+    await act(async () => {
+      await expect(result.current.reloadToUpdate({ forceReloadIfNotStaged: true })).resolves.toBe(true);
+    });
+
+    expect(applyServiceWorkerUpdateMock).toHaveBeenCalledWith(undefined, { forceReloadIfNotStaged: true });
+  });
+
   it('resolves false for a reload requested while another apply is in flight', async () => {
     let resolveApply: ((committed: boolean) => void) | undefined;
     applyServiceWorkerUpdateMock.mockImplementation(

--- a/apps/web/src/hooks/usePwaVersionGate.ts
+++ b/apps/web/src/hooks/usePwaVersionGate.ts
@@ -6,6 +6,7 @@ import {
   getPwaUpdateSnapshot,
   refreshServiceWorkerRegistration,
   subscribeToPwaUpdates,
+  type ApplyServiceWorkerUpdateOptions,
 } from '@/lib/pwaUpdates';
 import { fetchRuntimeConfig } from '@/lib/runtimeConfig';
 import { compareAppVersions, normalizeVersionTag } from '@/lib/versionUtils';
@@ -85,7 +86,9 @@ export interface PwaVersionGateState {
   // navigate), false when there was nothing to apply — no staged worker yet, or
   // an apply already in flight. Callers that want to abort an action when the
   // reload fires (e.g. starting an online game) await this instead of racing it.
-  reloadToUpdate: () => Promise<boolean>;
+  // `forceReloadIfNotStaged` escalates a no-op apply to a network force-refresh
+  // (unregister + clear caches + reload); reserve it for explicit user actions.
+  reloadToUpdate: (options?: ApplyServiceWorkerUpdateOptions) => Promise<boolean>;
   shouldShowSoftUpdate: boolean;
 }
 
@@ -132,24 +135,29 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
     });
   });
 
-  const runReloadToUpdate = useCallback(async (onReloadCommitted?: () => void): Promise<boolean> => {
-    if (isApplyingUpdateRef.current) {
-      return false;
-    }
+  const runReloadToUpdate = useCallback(
+    async (onReloadCommitted?: () => void, options?: ApplyServiceWorkerUpdateOptions): Promise<boolean> => {
+      if (isApplyingUpdateRef.current) {
+        return false;
+      }
 
-    isApplyingUpdateRef.current = true;
-    setIsApplyingUpdate(true);
+      isApplyingUpdateRef.current = true;
+      setIsApplyingUpdate(true);
 
-    try {
-      // No `location.reload()` fallback: reloading without a freshly installed
-      // worker re-serves the same precached bundle, which on iOS standalone
-      // PWAs loops splash → blank → reload whenever a hard update is required.
-      return await applyServiceWorkerUpdate(onReloadCommitted).catch(() => false);
-    } finally {
-      isApplyingUpdateRef.current = false;
-      setIsApplyingUpdate(false);
-    }
-  }, []);
+      try {
+        // No bare `location.reload()` fallback: reloading without a freshly
+        // installed worker re-serves the same precached bundle, which on iOS
+        // standalone PWAs loops splash → blank → reload whenever a hard update is
+        // required. The only escape hatch is the caller-opted force option, which
+        // drops the worker and its caches first so the reload hits the network.
+        return await applyServiceWorkerUpdate(onReloadCommitted, options).catch(() => false);
+      } finally {
+        isApplyingUpdateRef.current = false;
+        setIsApplyingUpdate(false);
+      }
+    },
+    [],
+  );
 
   const reloadToUpdate = useEffectEvent(() => {
     void runReloadToUpdate();
@@ -291,7 +299,7 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
         setDismissedUpdateKey(updateKey);
       }
     },
-    reloadToUpdate: () => runReloadToUpdate(),
+    reloadToUpdate: (options?: ApplyServiceWorkerUpdateOptions) => runReloadToUpdate(undefined, options),
     shouldShowSoftUpdate,
   };
 };

--- a/apps/web/src/lib/__tests__/pwaUpdates.test.ts
+++ b/apps/web/src/lib/__tests__/pwaUpdates.test.ts
@@ -36,19 +36,15 @@ class FakeServiceWorker extends EventTarget implements Partial<ServiceWorker> {
   }
 }
 
-interface FakeRegistration {
-  installing: FakeServiceWorker | null;
-  waiting: FakeServiceWorker | null;
-  active: FakeServiceWorker | null;
-  update: ReturnType<typeof vi.fn>;
+// EventTarget so the production code can listen for `updatefound`.
+class FakeRegistration extends EventTarget {
+  installing: FakeServiceWorker | null = null;
+  waiting: FakeServiceWorker | null = null;
+  active: FakeServiceWorker | null = null;
+  update = vi.fn().mockResolvedValue(undefined);
 }
 
-const buildFakeRegistration = (): FakeRegistration => ({
-  installing: null,
-  waiting: null,
-  active: null,
-  update: vi.fn().mockResolvedValue(undefined),
-});
+const buildFakeRegistration = (): FakeRegistration => new FakeRegistration();
 
 const loadPwaUpdates = async () => {
   vi.resetModules();
@@ -71,18 +67,51 @@ describe('pwaUpdates', () => {
   });
 
   it('does not call updateServiceWorker when no installing or waiting worker is found', async () => {
+    vi.useFakeTimers();
+
     const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
     initializePwaUpdates();
 
     const registration = buildFakeRegistration();
     registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
 
-    const applied = await applyServiceWorkerUpdate();
+    const pending = applyServiceWorkerUpdate();
+    // Sit out the `updatefound` grace window — no worker ever surfaces.
+    await vi.advanceTimersByTimeAsync(5000);
+    const applied = await pending;
 
     expect(registration.update).toHaveBeenCalledTimes(1);
     expect(updateServiceWorkerMock).not.toHaveBeenCalled();
     expect(applied).toBe(false);
     expect(sentryCaptureMessage).toHaveBeenCalledWith('pwa.apply-update.no-waiting-worker', 'warning');
+  });
+
+  it('applies an update that surfaces via updatefound after registration.update() resolves', async () => {
+    vi.useFakeTimers();
+
+    const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
+    initializePwaUpdates();
+
+    const registration = buildFakeRegistration();
+    registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
+
+    const pending = applyServiceWorkerUpdate();
+    // update() has resolved with nothing staged; the grace listener is armed.
+    await vi.advanceTimersByTimeAsync(0);
+
+    const installingWorker = new FakeServiceWorker();
+    registration.installing = installingWorker;
+    registration.dispatchEvent(new Event('updatefound'));
+    await vi.advanceTimersByTimeAsync(0);
+
+    registration.installing = null;
+    registration.waiting = installingWorker;
+    installingWorker.setState('installed');
+
+    const applied = await pending;
+
+    expect(updateServiceWorkerMock).toHaveBeenCalledWith(true);
+    expect(applied).toBe(true);
   });
 
   it('reports a captured exception when the registration update rejects', async () => {
@@ -169,6 +198,8 @@ describe('pwaUpdates', () => {
   });
 
   it('invokes onReloadCommitted only when a reload actually fires', async () => {
+    vi.useFakeTimers();
+
     const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
     initializePwaUpdates();
 
@@ -178,7 +209,9 @@ describe('pwaUpdates', () => {
     // per-version guard isn't burned on a no-op apply).
     const noWorker = buildFakeRegistration();
     registerOptions.onRegisteredSW?.('/sw.js', noWorker as unknown as ServiceWorkerRegistration);
-    expect(await applyServiceWorkerUpdate(onReloadCommitted)).toBe(false);
+    const noWorkerPending = applyServiceWorkerUpdate(onReloadCommitted);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(await noWorkerPending).toBe(false);
     expect(onReloadCommitted).not.toHaveBeenCalled();
 
     // Waiting worker present → reload fires → callback runs once, before the
@@ -212,5 +245,119 @@ describe('pwaUpdates', () => {
     expect(updateServiceWorkerMock).not.toHaveBeenCalled();
     expect(applied).toBe(false);
     expect(sentryCaptureMessage).toHaveBeenCalledWith('pwa.apply-update.install-timeout', 'warning');
+  });
+
+  describe('forceReloadIfNotStaged', () => {
+    const originalLocation = window.location;
+    const reloadMock = vi.fn();
+    const unregisterMock = vi.fn().mockResolvedValue(true);
+    const cacheKeysMock = vi.fn().mockResolvedValue(['workbox-precache-v2']);
+    const cacheDeleteMock = vi.fn().mockResolvedValue(true);
+
+    beforeEach(() => {
+      reloadMock.mockClear();
+      unregisterMock.mockClear();
+      cacheKeysMock.mockClear();
+      cacheDeleteMock.mockClear();
+
+      // jsdom's location.reload is non-configurable, so swap the whole object.
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, reload: reloadMock },
+      });
+      Object.defineProperty(window.navigator, 'serviceWorker', {
+        configurable: true,
+        value: { getRegistrations: vi.fn().mockResolvedValue([{ unregister: unregisterMock }]) },
+      });
+      vi.stubGlobal('caches', { keys: cacheKeysMock, delete: cacheDeleteMock });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+      Reflect.deleteProperty(window.navigator, 'serviceWorker');
+      vi.unstubAllGlobals();
+    });
+
+    it('drops the worker and its caches, then reloads, when no update can be staged', async () => {
+      vi.useFakeTimers();
+
+      const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
+      initializePwaUpdates();
+
+      const registration = buildFakeRegistration();
+      registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
+
+      const onReloadCommitted = vi.fn();
+      const pending = applyServiceWorkerUpdate(onReloadCommitted, { forceReloadIfNotStaged: true });
+      await vi.advanceTimersByTimeAsync(5000);
+      const applied = await pending;
+
+      expect(applied).toBe(true);
+      expect(unregisterMock).toHaveBeenCalledTimes(1);
+      expect(cacheDeleteMock).toHaveBeenCalledWith('workbox-precache-v2');
+      expect(onReloadCommitted).toHaveBeenCalledTimes(1);
+      expect(reloadMock).toHaveBeenCalledTimes(1);
+      expect(updateServiceWorkerMock).not.toHaveBeenCalled();
+      expect(sentryCaptureMessage).toHaveBeenCalledWith('pwa.apply-update.force-refresh', 'warning');
+      expect(sentryCaptureMessage).not.toHaveBeenCalledWith('pwa.apply-update.no-waiting-worker', 'warning');
+    });
+
+    it('prefers a cleanly staged worker over the force reload', async () => {
+      const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
+      initializePwaUpdates();
+
+      const registration = buildFakeRegistration();
+      registration.waiting = new FakeServiceWorker();
+      registration.waiting.state = 'installed';
+      registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
+
+      const applied = await applyServiceWorkerUpdate(undefined, { forceReloadIfNotStaged: true });
+
+      expect(applied).toBe(true);
+      expect(updateServiceWorkerMock).toHaveBeenCalledWith(true);
+      expect(reloadMock).not.toHaveBeenCalled();
+      expect(unregisterMock).not.toHaveBeenCalled();
+    });
+
+    it('force-reloads even when the service worker never registered', async () => {
+      const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
+      initializePwaUpdates();
+
+      // No onRegisteredSW callback — snapshot.registration is null.
+      const applied = await applyServiceWorkerUpdate(undefined, { forceReloadIfNotStaged: true });
+
+      expect(applied).toBe(true);
+      expect(reloadMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not force-reload while offline (a reload would strand the client)', async () => {
+      vi.useFakeTimers();
+
+      Object.defineProperty(window.navigator, 'onLine', {
+        configurable: true,
+        value: false,
+      });
+
+      try {
+        const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
+        initializePwaUpdates();
+
+        const registration = buildFakeRegistration();
+        registerOptions.onRegisteredSW?.('/sw.js', registration as unknown as ServiceWorkerRegistration);
+
+        const pending = applyServiceWorkerUpdate(undefined, { forceReloadIfNotStaged: true });
+        await vi.advanceTimersByTimeAsync(5000);
+        const applied = await pending;
+
+        expect(applied).toBe(false);
+        expect(reloadMock).not.toHaveBeenCalled();
+        expect(sentryCaptureMessage).toHaveBeenCalledWith('pwa.apply-update.no-waiting-worker', 'warning');
+      } finally {
+        Reflect.deleteProperty(window.navigator, 'onLine');
+      }
+    });
   });
 });

--- a/apps/web/src/lib/pwaUpdates.ts
+++ b/apps/web/src/lib/pwaUpdates.ts
@@ -79,6 +79,7 @@ export const refreshServiceWorkerRegistration = async (): Promise<void> => {
 };
 
 const SERVICE_WORKER_INSTALL_TIMEOUT_MS = 8000;
+const SERVICE_WORKER_UPDATE_FOUND_TIMEOUT_MS = 2000;
 
 type InstallWaitResult = 'settled' | 'timeout';
 
@@ -109,15 +110,82 @@ const waitForInstallingWorker = (worker: ServiceWorker, timeoutMs: number): Prom
     worker.addEventListener('statechange', handleStateChange);
   });
 
+// `registration.update()` can resolve before the freshly fetched worker is
+// exposed on the registration (Safari surfaces it via `updatefound` a beat
+// later). Give that event a short window before concluding nothing is staged.
+const waitForUpdateFound = (registration: ServiceWorkerRegistration, timeoutMs: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    const handleUpdateFound = () => {
+      cleanup();
+      resolve();
+    };
+
+    const cleanup = () => {
+      registration.removeEventListener('updatefound', handleUpdateFound);
+      globalThis.clearTimeout(timeoutId);
+    };
+
+    const timeoutId = globalThis.setTimeout(() => {
+      cleanup();
+      resolve();
+    }, timeoutMs);
+
+    registration.addEventListener('updatefound', handleUpdateFound);
+  });
+
+// Last-resort recovery for a client stuck on an old build: some clients (iOS
+// standalone PWAs in particular) keep reporting "no update" from
+// `registration.update()` even though the server advertises a newer version.
+// Dropping the registration and its caches makes the reload below fetch the
+// app from the network — without that, reloading would re-serve the same
+// precached bundle and change nothing.
+const forceRefreshFromNetwork = async (onReloadCommitted?: () => void): Promise<boolean> => {
+  Sentry.captureMessage('pwa.apply-update.force-refresh', 'warning');
+
+  try {
+    const registrations = (await globalThis.navigator?.serviceWorker?.getRegistrations()) ?? [];
+    await Promise.all(registrations.map((registration) => registration.unregister()));
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+
+  try {
+    const cacheKeys = (await globalThis.caches?.keys()) ?? [];
+    await Promise.all(cacheKeys.map((cacheKey) => globalThis.caches.delete(cacheKey)));
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+
+  onReloadCommitted?.();
+  globalThis.location.reload();
+  return true;
+};
+
+export interface ApplyServiceWorkerUpdateOptions {
+  // Escape hatch for clients whose service worker never stages the advertised
+  // build: fall back to `forceRefreshFromNetwork` instead of returning false.
+  // Only set this on an explicit user action (the update button, the forced
+  // update overlay) — automatic apply paths must keep the no-op behavior, or a
+  // stale runtime config could reload-loop the app.
+  forceReloadIfNotStaged?: boolean;
+}
+
 // `onReloadCommitted` runs at the single instant the update is about to be
 // applied — after a waiting worker is confirmed, just before the activate +
 // reload. Callers use it to record a per-version guard that must survive the
 // reload yet must not be written on the no-op path (no waiting worker), so a
 // transient miss doesn't burn that version's one attempt.
-export const applyServiceWorkerUpdate = async (onReloadCommitted?: () => void): Promise<boolean> => {
+export const applyServiceWorkerUpdate = async (
+  onReloadCommitted?: () => void,
+  { forceReloadIfNotStaged = false }: ApplyServiceWorkerUpdateOptions = {},
+): Promise<boolean> => {
+  // Forcing only makes sense with a network to reload from — offline it would
+  // strand the client on an unloadable page instead of a stale one.
+  const canForceReload = forceReloadIfNotStaged && globalThis.navigator?.onLine !== false;
+
   const registration = snapshot.registration;
   if (!registration || !updateServiceWorker) {
-    return false;
+    return canForceReload ? forceRefreshFromNetwork(onReloadCommitted) : false;
   }
 
   Sentry.addBreadcrumb({ category: 'pwa', message: 'apply-update:start', level: 'info' });
@@ -125,6 +193,10 @@ export const applyServiceWorkerUpdate = async (onReloadCommitted?: () => void): 
   await registration.update().catch((error: unknown) => {
     Sentry.captureException(error);
   });
+
+  if (!registration.installing && !registration.waiting && !snapshot.needRefresh) {
+    await waitForUpdateFound(registration, SERVICE_WORKER_UPDATE_FOUND_TIMEOUT_MS);
+  }
 
   // `registration.update()` resolves before a freshly fetched worker leaves
   // `installing`. Wait it out so the `waiting`/`needRefresh` check below
@@ -140,6 +212,10 @@ export const applyServiceWorkerUpdate = async (onReloadCommitted?: () => void): 
     onReloadCommitted?.();
     await updateServiceWorker(true);
     return true;
+  }
+
+  if (canForceReload) {
+    return forceRefreshFromNetwork(onReloadCommitted);
   }
 
   // No worker is staged yet: this is the runtime-config channel advertising a


### PR DESCRIPTION
## Problem

Pressing the « Mettre à jour » button briefly flips the label to « Mise à jour… » and then nothing happens — the client stays on the old version (reported on v2.12.7 while the site serves v2.12.11).

**Diagnosis** (confirmed via Sentry issue [SKIP-BO-FRONTEND-2](https://pierre-luc.sentry.io/issues/SKIP-BO-FRONTEND-2)): on some installed PWAs — iOS standalone in particular — `registration.update()` never stages the newly deployed service worker even though `runtime-config.json` advertises a newer version. The button press then hits the `no-waiting-worker` path in `applyServiceWorkerUpdate`, which silently returns `false`. Telemetry shows 5 users hitting this over 23 days, with error events still arriving from v2.12.0 through v2.12.7 — these clients are stuck on old builds with no way out.

## Fix

Two changes in `apps/web/src/lib/pwaUpdates.ts`:

1. **`updatefound` grace window** — `registration.update()` can resolve before the freshly fetched worker is exposed on the registration (Safari surfaces it a beat later). The apply flow now waits up to 2s for `updatefound` before concluding nothing is staged, so a slow-surfacing update is applied cleanly.

2. **`forceReloadIfNotStaged` escape hatch** — when nothing can be staged, escalate a no-op apply to a network force-refresh: unregister the service worker, delete its caches, then `location.reload()`. With the worker and precache gone, the reload must fetch the app from the network, unsticking the client. Telemetry message `pwa.apply-update.force-refresh` replaces the silent failure.

Guard rails:
- Only **explicit user actions** opt in — the update button and the forced-update overlay retry (both via `updateNow` in `App.tsx`). Automatic apply paths (safe-moment soft updates, hard-update auto-reload, online-start gates) keep their no-op semantics, so a stale runtime config still cannot reload-loop the app.
- The force path is skipped while offline (`navigator.onLine === false`) — reloading without a network would strand the client on an unloadable page instead of a stale one.

## Validation

- `pnpm --filter @skipbo/web test` — 336 tests pass, including new coverage: force path (unregister + cache clear + reload + `onReloadCommitted`), staged-worker preference over force, force with no registration, offline no-op, and the `updatefound` grace apply
- `pnpm --filter @skipbo/web lint` / `typecheck` — clean

Fixes SKIP-BO-FRONTEND-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUDHkqUQN5aB69euqb9tJw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUDHkqUQN5aB69euqb9tJw)_