### PR TITLE
test(web): cover forceRefreshFromNetwork error and fallback paths

### DIFF
--- a/apps/web/src/lib/__tests__/pwaUpdates.test.ts
+++ b/apps/web/src/lib/__tests__/pwaUpdates.test.ts
@@ -323,6 +323,11 @@ describe('pwaUpdates', () => {
     });
 
     it('force-reloads even when the service worker never registered', async () => {
+      // Also drop serviceWorker/CacheStorage support entirely — the cleanup must
+      // tolerate their absence, not just empty results.
+      Reflect.deleteProperty(window.navigator, 'serviceWorker');
+      vi.unstubAllGlobals();
+
       const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
       initializePwaUpdates();
 
@@ -330,6 +335,33 @@ describe('pwaUpdates', () => {
       const applied = await applyServiceWorkerUpdate(undefined, { forceReloadIfNotStaged: true });
 
       expect(applied).toBe(true);
+      expect(reloadMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false with no registration when force is not requested', async () => {
+      const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
+      initializePwaUpdates();
+
+      const applied = await applyServiceWorkerUpdate();
+
+      expect(applied).toBe(false);
+      expect(reloadMock).not.toHaveBeenCalled();
+    });
+
+    it('still reloads when unregistering or cache cleanup fails', async () => {
+      Object.defineProperty(window.navigator, 'serviceWorker', {
+        configurable: true,
+        value: { getRegistrations: vi.fn().mockRejectedValue(new Error('sw registry unavailable')) },
+      });
+      cacheKeysMock.mockRejectedValueOnce(new Error('cache storage unavailable'));
+
+      const { initializePwaUpdates, applyServiceWorkerUpdate } = await loadPwaUpdates();
+      initializePwaUpdates();
+
+      const applied = await applyServiceWorkerUpdate(undefined, { forceReloadIfNotStaged: true });
+
+      expect(applied).toBe(true);
+      expect(sentryCaptureException).toHaveBeenCalledTimes(2);
       expect(reloadMock).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
Follow-up to #195, addressing the Codecov patch report on that PR (5 uncovered lines in `apps/web/src/lib/pwaUpdates.ts`, merged before the tests landed).

New coverage for the force-refresh recovery path:

- the `Sentry.captureException` catch blocks when `getRegistrations()` or `caches.keys()` reject — the reload must still fire
- the `?? []` fallbacks when `navigator.serviceWorker` / `CacheStorage` are absent entirely
- the non-forced no-registration path returning `false`

Test-only change; `pnpm --filter @skipbo/web test` passes (14 tests in the file, full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUDHkqUQN5aB69euqb9tJw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUDHkqUQN5aB69euqb9tJw)_