### PR TITLE
Fix animated card border and colour flash in rummy theme

### DIFF
--- a/apps/web/src/components/AnimatedCard.tsx
+++ b/apps/web/src/components/AnimatedCard.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
 import { createPortal, flushSync } from 'react-dom';
 import { Card } from '@/components/Card';
 import type { CardAnimationData } from '@/contexts/CardAnimationContext';
 import { useCardAnimation } from '@/contexts/useCardAnimation';
-import { cn } from '@/lib/utils';
 
 interface AnimatedCardProps {
   animation: CardAnimationData;
@@ -167,17 +167,46 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({ animation }) => {
   const node = (
     <div
       ref={rootRef}
-      className={cn('animated-card', `animation-${animation.animationType}`)}
-      style={{
-        zIndex,
-      }}
+      className="animated-card"
+      style={
+        {
+          zIndex,
+          // `.card`'s own transform (rotate(var(--card-rotate))) is what makes it
+          // a containing block for `.card-inner`/`.card-inner-2` (its bordered
+          // face layers). Board containers (hand/piles) always set this var, but
+          // nothing does inside the animation layer, so it resolves to an
+          // invalid `inherit` and the whole transform computes to `none` —
+          // `.card` stops being a containing block and the face layers fall
+          // back to sizing against this wrapper instead, painting over `.card`'s
+          // border. Pin a concrete value so `.card` keeps its own transform.
+          '--card-rotate': '0deg',
+        } as CSSProperties
+      }
     >
       {needsFlip ? (
+        // `filter` (below, via the animation-* class) forces the browser to
+        // flatten and re-rasterize its whole subtree every frame — which
+        // glitches a `rotateY` 3D flip happening underneath it, flashing the
+        // card's own unstyled white background for a frame or two. Keep the
+        // filtered element (Card's root) *inside* flipRef, as a descendant of
+        // the rotation rather than an ancestor of it.
         <div ref={flipRef}>
-          <Card hint="AnimatedCard" card={animation.card} isRevealed={isRevealed} canBeGrabbed={false} />
+          <Card
+            hint="AnimatedCard"
+            card={animation.card}
+            isRevealed={isRevealed}
+            canBeGrabbed={false}
+            className={`animation-${animation.animationType}`}
+          />
         </div>
       ) : (
-        <Card hint="AnimatedCard" card={animation.card} isRevealed={animation.sourceRevealed} canBeGrabbed={false} />
+        <Card
+          hint="AnimatedCard"
+          card={animation.card}
+          isRevealed={animation.sourceRevealed}
+          canBeGrabbed={false}
+          className={`animation-${animation.animationType}`}
+        />
       )}
     </div>
   );

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -40,8 +40,18 @@
       @apply relative z-[11];
       /* Remove flexbox properties that conflict with absolute positioning */
       .card {
-        /* Left positioning is handled by inline styles from Card component */
-        @apply absolute top-0 transition-all duration-200 ease-in-out;
+        /* Left positioning is handled by inline styles from Card component.
+           Scope the transition to layout/hover-lift properties only —
+           `transition-all` also caught background-color/color/border-color,
+           so a draw animation's flip (which swaps isRevealed, and with it
+           the card's colour classes, via flushSync mid-flight) smoothly
+           cross-faded from white to the revealed colour over 200ms instead
+           of snapping, since draw animations portal into this hand-area and
+           inherit the rule. */
+        @apply absolute top-0;
+        transition-property: left, top, transform;
+        transition-duration: 200ms;
+        transition-timing-function: ease-in-out;
 
         &.selected {
           z-index: 101 !important;


### PR DESCRIPTION
## Summary
- `.card` lost its own `transform` (and thus its containing-block status) inside the animation layer, since `--card-rotate` is only ever set by board containers. Its bordered face layers (`.card-inner`/`-2`) then sized against the unbordered `.animated-card` wrapper instead, painting over the card's border for the whole flight. Pin `--card-rotate` to a concrete value so `.card` keeps a valid transform.
- The `animation-*` filter classes sat on `.animated-card`, an ancestor of the flip's `rotateY` transform; `filter` forces the browser to flatten and re-rasterize that subtree, glitching the 3D flip. Move the class onto `Card` itself so `filter` no longer wraps the rotation.
- `.hand-area.overlap-hand .card` used `transition-all`, which also caught `background-color`/`color`/`border-color`. Draw animations portal into this hand-area, so a flip's mid-flight class swap (revealed colours) faded in from white over 200ms instead of snapping. Scope the transition to `left`/`top`/`transform` only.

## Test plan
- [x] `pnpm --filter @skipbo/web exec tsc --noEmit`
- [x] `pnpm --filter @skipbo/web exec eslint src/components/AnimatedCard.tsx src/styles/layout.css`
- [x] Verified live in-browser (rummy theme): animated card's `.card-inner` is now inset by the 1px border instead of overlapping it, and its background snaps to the correct colour immediately post-flip instead of fading from white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)