### PR TITLE
fix(metro): show corner number on front discard card & hide "+" behind piles

### DIFF
--- a/apps/web/src/themes/metro.css
+++ b/apps/web/src/themes/metro.css
@@ -247,6 +247,20 @@
       @apply z-11!;
     }
 
+    /* Always show the corner number on the top (front) numbered card too.
+       The base rule is `invisible lg:visible`, and card.css only bumps the
+       collapsed non-top cards to `visible`, so on mobile the front card was
+       the only one in the pile without a corner number. */
+    .card.normal-card:nth-last-child(1 of :not(.empty-card)) .card-corner-number {
+      @apply visible;
+    }
+
+    /* Once a discard pile holds cards, hide the build-pile "+" hint that
+       would otherwise show through the empty-card sitting behind them. */
+    &:has(.card.normal-card, .card.skip-bo) .empty-card::after {
+      @apply content-none;
+    }
+
     /* Collapse non-top NUMBERED cards down to just their corner number
        (card-corner-number is bumped to `visible` from card.css). Skip-Bo
        cards are intentionally excluded so their top sliver remains

--- a/apps/web/tests/ui/metro-discard.spec.ts
+++ b/apps/web/tests/ui/metro-discard.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+import { expectThemeClass, gotoFixture } from './helpers.ts';
+
+/**
+ * Targeted computed-style guards for the Metro discard-pile tweaks in
+ * `src/themes/metro.css`. These assert the exact CSS effects directly, rather
+ * than relying on the whole-board screenshot diff (whose ~1.5% tolerance is
+ * large enough that an accidental revert of either rule could pass silently).
+ *
+ * Scoped to `@mobile` because that is where the corner-number rule matters —
+ * the base `.card-corner-number` rule is `invisible lg:visible`, so on desktop
+ * the front card's corner number is already shown regardless of these rules.
+ */
+test.describe('Metro discard piles', () => {
+  test('@mobile the front numbered card shows its corner number', async ({ page }) => {
+    await gotoFixture(page, 'one-of-each', 'theme-metro');
+    await expectThemeClass(page, 'theme-metro');
+
+    // Human discard pile 0 is [1, 5, 9] — three numbered cards, so the front
+    // (topmost, last in DOM) card is a plain numbered card.
+    const pile = page.getByTestId('human-player-area').locator('.discard-pile-stack').first();
+    const frontCornerNumber = pile.locator('.card.normal-card').last().locator('.card-corner-number');
+
+    const visibility = await frontCornerNumber.evaluate((el) => getComputedStyle(el).visibility);
+    expect(visibility, 'front discard card corner number must be visible on mobile').toBe('visible');
+  });
+
+  test('@mobile a populated pile hides the build-pile "+" hint', async ({ page }) => {
+    await gotoFixture(page, 'one-of-each', 'theme-metro');
+    await expectThemeClass(page, 'theme-metro');
+
+    const pile = page.getByTestId('human-player-area').locator('.discard-pile-stack').first();
+    const afterContent = await pile
+      .locator('.empty-card')
+      .evaluate((el) => getComputedStyle(el, '::after').content);
+
+    expect(afterContent, 'the "+" hint must be suppressed behind a populated discard pile').toBe('none');
+  });
+
+  test('@mobile an empty pile still shows the "+" hint', async ({ page }) => {
+    // ready-human's human discard piles are [[3,SkipBo],[8],[],[2,SkipBo,6]];
+    // index 2 is empty and must keep its "+".
+    await gotoFixture(page, 'ready-human', 'theme-metro');
+    await expectThemeClass(page, 'theme-metro');
+
+    const emptyPile = page.getByTestId('human-player-area').locator('.discard-pile-stack').nth(2);
+    // Guard against fixture drift: this pile must actually be empty.
+    await expect(emptyPile.locator('.card.normal-card, .card.skip-bo')).toHaveCount(0);
+
+    const afterContent = await emptyPile
+      .locator('.empty-card')
+      .evaluate((el) => getComputedStyle(el, '::after').content);
+
+    expect(afterContent, 'an empty discard pile must keep its "+" hint').toBe('"+"');
+  });
+});

--- a/apps/web/tests/ui/metro-discard.spec.ts
+++ b/apps/web/tests/ui/metro-discard.spec.ts
@@ -31,9 +31,7 @@ test.describe('Metro discard piles', () => {
     await expectThemeClass(page, 'theme-metro');
 
     const pile = page.getByTestId('human-player-area').locator('.discard-pile-stack').first();
-    const afterContent = await pile
-      .locator('.empty-card')
-      .evaluate((el) => getComputedStyle(el, '::after').content);
+    const afterContent = await pile.locator('.empty-card').evaluate((el) => getComputedStyle(el, '::after').content);
 
     expect(afterContent, 'the "+" hint must be suppressed behind a populated discard pile').toBe('none');
   });


### PR DESCRIPTION
## Summary

Two small fixes to the **Metro** theme's discard piles, most visible on mobile.

1. **Corner number on the front card.** The base `.card-corner-number` rule is `invisible lg:visible`, and `card.css` only bumps the *collapsed non-top* discard cards to `visible`. That left the front (top) numbered card as the only card in a Metro discard pile without a corner number on mobile. It now shows its corner number too, so every numbered card in the pile is labelled consistently — including single-card piles.

2. **Hide the "+" behind populated piles.** The build-pile "+" hint drawn on the `.empty-card` sitting behind a discard pile showed through once the pile held cards. It's now hidden as soon as a pile contains cards; empty piles still show the "+".

Both changes are scoped to `.theme-metro .discard-pile-stack` — no other theme or component is affected.

## Changes

- `apps/web/src/themes/metro.css`
  - Reveal `.card-corner-number` on the top numbered card of a Metro discard stack.
  - `content-none` on `.empty-card::after` when the stack `:has()` a real card.

## Verification

- `pnpm --filter @skipbo/web lint` — passes
- `pnpm --filter @skipbo/web build` — passes
- Visual check via the `one-of-each` fixture (Metro theme) at mobile (390×844) and desktop widths, plus the `ready-human` fixture to confirm empty piles still render the "+".
- CI `ui` (visual regression, macOS) — passes. The Metro mobile change stays within the `maxDiffPixelRatio: 0.015` tolerance, so no baseline regeneration was needed; desktop Metro baselines are unaffected (the corner number was already visible at `lg`).

### Before (mobile) — front card of each pile has no corner number; "+" bleeds through

Piles read `1,2` / `4,5` / `7,8` / `10,11` (front cards `3/6/9/12` unlabelled).

### After (mobile) — every numbered card labelled; no "+" behind cards

Piles read `1,2,3` / `4,5,6` / `7,8,9` / `10,11,12`; empty piles keep their "+".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U2zU2tnbXTuKg7MBsTMg8