### PR TITLE
Metro: wipe discard cards to their corner badge + fix page background layering

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,10 +43,5 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # TEMPORARY (diagnostic): the action hides the result message when
-          # is_error is true (anthropics/claude-code-action#880), so every recent
-          # run only reports "result is_error:true" with no cause. Revert once the
-          # underlying failure is identified.
-          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,5 +43,10 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # TEMPORARY (diagnostic): the action hides the result message when
+          # is_error is true (anthropics/claude-code-action#880), so every recent
+          # run only reports "result is_error:true" with no cause. Revert once the
+          # underlying failure is identified.
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/apps/web/src/hooks/__tests__/useThemeColorMeta.test.tsx
+++ b/apps/web/src/hooks/__tests__/useThemeColorMeta.test.tsx
@@ -1,0 +1,94 @@
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useThemeColorMeta } from '../useThemeColorMeta';
+
+let resolvedTheme: string | undefined = 'metro';
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme }),
+}));
+
+function Harness() {
+  useThemeColorMeta();
+  return null;
+}
+
+/** The hook defers to rAF; run the callback inline so `render` is enough. */
+function runFramesSynchronously() {
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0);
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+}
+
+function setTokens(tokens: { themeColor?: string; background?: string }) {
+  const root = document.documentElement;
+  root.style.removeProperty('--theme-color');
+  root.style.removeProperty('--background');
+  if (tokens.themeColor) root.style.setProperty('--theme-color', tokens.themeColor);
+  if (tokens.background) root.style.setProperty('--background', tokens.background);
+}
+
+const metaContent = () => document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')?.content;
+
+beforeEach(() => {
+  resolvedTheme = 'metro';
+  runFramesSynchronously();
+  document.querySelector('meta[name="theme-color"]')?.remove();
+  setTokens({});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setTokens({});
+});
+
+describe('useThemeColorMeta', () => {
+  test('publishes the theme-color token and creates the meta tag', () => {
+    setTokens({ themeColor: '#234f52', background: '#086b6e' });
+
+    render(<Harness />);
+
+    expect(metaContent(), 'a theme that tints the page wins over the board colour').toBe('#234f52');
+  });
+
+  test('falls back to the board background when the theme sets no page tint', () => {
+    // Only Metro splits the two; every other theme leaves `--theme-color` unset
+    // and must still get its own background in the status bar.
+    setTokens({ background: '#0a0a0a' });
+
+    render(<Harness />);
+
+    expect(metaContent()).toBe('#0a0a0a');
+  });
+
+  test('reuses an existing meta tag rather than appending a second one', () => {
+    const existing = document.createElement('meta');
+    existing.name = 'theme-color';
+    existing.content = '#stale';
+    document.head.appendChild(existing);
+    setTokens({ background: '#f1e7cc' });
+
+    render(<Harness />);
+
+    expect(document.querySelectorAll('meta[name="theme-color"]')).toHaveLength(1);
+    expect(existing.content).toBe('#f1e7cc');
+  });
+
+  test('leaves the meta tag alone when neither token resolves', () => {
+    render(<Harness />);
+
+    expect(document.querySelector('meta[name="theme-color"]')).toBeNull();
+  });
+
+  test('cancels the pending frame on unmount', () => {
+    const cancel = vi.fn();
+    vi.stubGlobal('requestAnimationFrame', () => 42);
+    vi.stubGlobal('cancelAnimationFrame', cancel);
+
+    render(<Harness />).unmount();
+
+    expect(cancel).toHaveBeenCalledWith(42);
+  });
+});

--- a/apps/web/src/hooks/useThemeColorMeta.ts
+++ b/apps/web/src/hooks/useThemeColorMeta.ts
@@ -6,8 +6,11 @@ export function useThemeColorMeta() {
 
   useEffect(() => {
     const handle = requestAnimationFrame(() => {
-      let background = getComputedStyle(document.documentElement).getPropertyValue('--theme-color').trim();
-      if (!background) background = getComputedStyle(document.documentElement).getPropertyValue('--background').trim();
+      // A theme may tint the page separately from the board via `--theme-color`
+      // (see `#root` in base.css); otherwise the board colour is the page colour.
+      const styles = getComputedStyle(document.documentElement);
+      const background =
+        styles.getPropertyValue('--theme-color').trim() || styles.getPropertyValue('--background').trim();
       if (!background) return;
 
       let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');

--- a/apps/web/src/hooks/useThemeColorMeta.ts
+++ b/apps/web/src/hooks/useThemeColorMeta.ts
@@ -6,7 +6,8 @@ export function useThemeColorMeta() {
 
   useEffect(() => {
     const handle = requestAnimationFrame(() => {
-      const background = getComputedStyle(document.documentElement).getPropertyValue('--background').trim();
+      let background = getComputedStyle(document.documentElement).getPropertyValue('--theme-color').trim();
+      if (!background) background = getComputedStyle(document.documentElement).getPropertyValue('--background').trim();
       if (!background) return;
 
       let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -72,6 +72,13 @@
   }
 
   #root {
+    /* Opt-in, and transparent by default: a theme only needs to restore the
+       board colour here if it tints the page separately via `--theme-color`
+       (the padding below is inside the background box, so an opaque `#root`
+       would otherwise swallow the gutter tint). Themes that paint a gradient
+       or texture on `body` — glass, rainbow, cinema… — need this to stay
+       transparent so that artwork still shows through the board. */
+    background-color: var(--board-bg, transparent);
     padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
   }
 
@@ -84,7 +91,12 @@
   }
 
   body {
-    @apply bg-background;
+    /* Themes may tint the safe-area gutter separately from the board via
+       `--theme-color` (iOS Safari also samples this for the status bar).
+       The fallback is load-bearing: an unresolved `var()` is invalid at
+       computed-value time, which makes `background-color` fall back to its
+       initial value — transparent — not to an earlier declaration. */
+    background-color: var(--theme-color, var(--background));
     color: var(--text-color);
     font-family: 'Inter', sans-serif;
   }

--- a/apps/web/src/themes/metro.css
+++ b/apps/web/src/themes/metro.css
@@ -45,6 +45,22 @@
   --metro-tile-11: #e51400;
   --metro-tile-12: #da532c;
 
+  --toolbar-bg: #234f52;
+  /* Page/status-bar tint matches the toolbar stripe, so the board keeps its
+     own colour via `--board-bg` (see `#root` in base.css). */
+  --theme-color: var(--toolbar-bg);
+  --board-bg: var(--background);
+
+  /* Size of the corner badge, and the matching clip target for the discard
+     collapse (badge + the card's 1px border, measured from the border box).
+     One token because the collapse has to land exactly on the badge edge. */
+  --metro-corner-size: 1rem;
+  --metro-corner-tile: calc(var(--metro-corner-size) + 1px);
+
+  @variant lg {
+    --metro-corner-size: 1.125rem;
+  }
+
   font-family:
     'Segoe UI',
     'Segoe UI Light',
@@ -131,9 +147,15 @@
       letter-spacing: -0.02em;
     }
 
+    /* The corner tile is part of Metro's card identity, so it shows on every
+       numbered card at every breakpoint — the base utility is
+       `invisible lg:visible`, which would drop it on mobile outside the
+       discard piles. Skip-Bo cards still hide it (see `&.skipbo-text`). */
     .card-corner-number {
-      @apply font-semibold absolute flex items-center justify-center text-2xs lg:text-xs text-white
-        w-4 lg:w-4.5 h-4 lg:h-4.5 top-0 left-0;
+      @apply visible font-semibold absolute flex items-center justify-center text-2xs lg:text-xs text-white
+        top-0 left-0;
+      width: var(--metro-corner-size);
+      height: var(--metro-corner-size);
       background: var(--card-corner-bg);
       letter-spacing: 0;
     }
@@ -181,7 +203,8 @@
   /* #4 Top toolbar as a full-width accent stripe */
 
   [data-testid='app-toolbar'] {
-    @apply bg-black/25 -mx-4 -mt-4 mb-4 px-4 py-3 items-center;
+    @apply -mx-4 -mt-4 mb-4 px-4 py-3 items-center;
+    background-color: var(--toolbar-bg);
   }
 
   /* #5 Tile-tilt press animation */
@@ -242,17 +265,18 @@
   }
 
   .discard-pile-stack {
+    /* The z-bumps below only order cards *within* one pile, so keep them in
+       their own stacking context. Without this the stack is `position:
+       relative; z-index: auto`, so a z-11 top card competes directly with
+       `.hand-area.overlap-hand` (also z-11) in the player-area context and
+       wins on DOM order — which made a draw animation portaled into the hand
+       fly *behind* the discard piles in the landscape-mobile layout, where
+       the défausses sit between the pioche and the main. */
+    @apply isolate;
+
     /* The topmost real card (numbered or Skip-Bo) wins z-order. */
     .card:not(.empty-card):nth-last-child(1 of :not(.empty-card)) {
       @apply z-11!;
-    }
-
-    /* Always show the corner number on the top (front) numbered card too.
-       The base rule is `invisible lg:visible`, and card.css only bumps the
-       collapsed non-top cards to `visible`, so on mobile the front card was
-       the only one in the pile without a corner number. */
-    .card.normal-card:nth-last-child(1 of :not(.empty-card)) .card-corner-number {
-      @apply visible;
     }
 
     /* Once a discard pile holds cards, hide the build-pile "+" hint that
@@ -261,20 +285,39 @@
       @apply content-none;
     }
 
+    /* The collapse is a wipe down to the corner tile, not a fade: the tile
+       retracts into its own number badge and grows back out of it, which is
+       the Metro motion vocabulary (and the same easing as the active-turn
+       wipe). Clipping to the badge also removes the card's inner layers,
+       number, border and shadow for free — no per-child rules needed.
+
+       The clip lives on the base card, and the top card must state
+       `inset(0)` explicitly: `none` does not interpolate, so leaving it
+       unset would make the reveal snap. `transform` is repeated because this
+       selector outranks the tile-tilt rule above. */
+
+    .card.normal-card {
+      clip-path: inset(0 0 0 0);
+      transition:
+        transform 0.15s ease-out,
+        clip-path 0.2s cubic-bezier(0.1, 0.9, 0.2, 1);
+
+      @variant motion-reduce {
+        transition: transform 0.15s ease-out;
+      }
+    }
+
     /* Collapse non-top NUMBERED cards down to just their corner number
        (card-corner-number is bumped to `visible` from card.css). Skip-Bo
        cards are intentionally excluded so their top sliver remains
        visible when stacked between or beneath numbered cards. */
     .card.normal-card:not(:nth-last-child(1 of :not(.empty-card))) {
-      @apply bg-transparent shadow-none border-transparent pointer-events-none z-10!;
-      transition: background-color 0.3s ease-in 0.1s !important;
+      @apply pointer-events-none z-10!;
+      clip-path: inset(0 calc(100% - var(--metro-corner-tile)) calc(100% - var(--metro-corner-tile)) 0);
 
-      .card-inner,
-      .card-inner-2,
-      .card-number,
-      .card-corner-inset {
-        @apply hidden;
-      }
+      /* Collapse direction only — the incoming card lands before the one
+         beneath it retracts. Entry order matches the base `transition`. */
+      transition-delay: 0s, 0.1s;
     }
   }
 

--- a/apps/web/tests/ui/metro-discard.spec.ts
+++ b/apps/web/tests/ui/metro-discard.spec.ts
@@ -13,19 +13,6 @@ import { expectThemeClass, gotoFixture } from './helpers.ts';
  * the front card's corner number is already shown regardless of these rules.
  */
 test.describe('Metro discard piles', () => {
-  test('@mobile the front numbered card shows its corner number', async ({ page }) => {
-    await gotoFixture(page, 'one-of-each', 'theme-metro');
-    await expectThemeClass(page, 'theme-metro');
-
-    // Human discard pile 0 is [1, 5, 9] — three numbered cards, so the front
-    // (topmost, last in DOM) card is a plain numbered card.
-    const pile = page.getByTestId('human-player-area').locator('.discard-pile-stack').first();
-    const frontCornerNumber = pile.locator('.card.normal-card').last().locator('.card-corner-number');
-
-    const visibility = await frontCornerNumber.evaluate((el) => getComputedStyle(el).visibility);
-    expect(visibility, 'front discard card corner number must be visible on mobile').toBe('visible');
-  });
-
   test('@mobile a populated pile hides the build-pile "+" hint', async ({ page }) => {
     await gotoFixture(page, 'one-of-each', 'theme-metro');
     await expectThemeClass(page, 'theme-metro');
@@ -34,6 +21,87 @@ test.describe('Metro discard piles', () => {
     const afterContent = await pile.locator('.empty-card').evaluate((el) => getComputedStyle(el, '::after').content);
 
     expect(afterContent, 'the "+" hint must be suppressed behind a populated discard pile').toBe('none');
+  });
+
+  test('@mobile every numbered card shows its corner number, Skip-Bo cards do not', async ({ page }) => {
+    await gotoFixture(page, 'one-of-each', 'theme-metro');
+    await expectThemeClass(page, 'theme-metro');
+
+    // The corner tile is part of Metro's card identity everywhere, not just in
+    // the discard piles — the base utility is `invisible lg:visible`, so hand /
+    // stock / build-pile cards used to lose it below the `lg` breakpoint. Being
+    // page-wide, this also covers the front card of a discard pile, whose
+    // corner number is the only part of it the collapse leaves on screen.
+    const numbered = await page
+      .locator('.card.normal-card:not(.skip-bo) .card-corner-number')
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).visibility));
+
+    expect(numbered.length, 'fixture must render numbered cards').toBeGreaterThan(0);
+    expect(new Set(numbered), 'every numbered card keeps its corner number on mobile').toEqual(new Set(['visible']));
+
+    const skipBo = await page
+      .locator('.card.skip-bo .card-corner-number')
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).display));
+
+    expect(skipBo.length, 'fixture must render Skip-Bo cards').toBeGreaterThan(0);
+    expect(new Set(skipBo), 'Skip-Bo cards have no number to show').toEqual(new Set(['none']));
+  });
+
+  test('@desktop @mobile the collapse clips exactly to the corner badge', async ({ page }) => {
+    await gotoFixture(page, 'one-of-each', 'theme-metro');
+    await expectThemeClass(page, 'theme-metro');
+
+    const pile = page.getByTestId('human-player-area').locator('.discard-pile-stack').first();
+
+    const geometry = await pile.evaluate((stack) => {
+      const cards = [...stack.querySelectorAll<HTMLElement>('.card.normal-card')];
+      const collapsed = cards[0];
+
+      // `--metro-corner-tile` is a calc() that getComputedStyle returns
+      // unresolved, so measure it by rendering a probe at that width.
+      const probe = document.createElement('div');
+      probe.style.cssText = 'position:absolute;width:var(--metro-corner-tile);height:0';
+      collapsed.appendChild(probe);
+      const tilePx = probe.getBoundingClientRect().width;
+      probe.remove();
+
+      const cardBox = collapsed.getBoundingClientRect();
+      const badge = collapsed.querySelector('.card-corner-number')!.getBoundingClientRect();
+      return {
+        tilePx,
+        badgeRight: badge.right - cardBox.left,
+        badgeBottom: badge.bottom - cardBox.top,
+        collapsedClip: getComputedStyle(collapsed).clipPath,
+        topClip: getComputedStyle(cards[cards.length - 1]).clipPath,
+      };
+    });
+
+    // Runs at both viewports, so it also pins the `lg` step of the corner-size
+    // token to the badge that reads it — 17px at 390 wide, 19px at 1440.
+    expect(geometry.tilePx, 'clip target must reach the badge edge').toBeCloseTo(geometry.badgeRight, 1);
+    expect(geometry.tilePx, 'badge is square').toBeCloseTo(geometry.badgeBottom, 1);
+
+    // The top card must state inset(0) rather than leaving clip-path at `none`:
+    // `none` does not interpolate, so the reveal would snap instead of wiping.
+    expect(geometry.topClip, 'top card needs an interpolable clip-path').toBe('inset(0px)');
+    expect(geometry.collapsedClip, 'collapsed card must be clipped to its badge').toContain('calc(100%');
+  });
+
+  test('@mobile the pile keeps its z-bumps in its own stacking context', async ({ page }) => {
+    await gotoFixture(page, 'one-of-each', 'theme-metro');
+    await expectThemeClass(page, 'theme-metro');
+
+    // The pile bumps its cards to z-10/z-11 to order them within the pile. The
+    // stack must isolate, otherwise those bumps leak into the player-area
+    // context and tie with `.hand-area.overlap-hand` (also z-11), which made a
+    // draw animation portaled into the hand fly *behind* the défausses in the
+    // landscape-mobile layout where they sit between the pioche and the main.
+    const isolation = await page
+      .locator('.discard-pile-stack')
+      .first()
+      .evaluate((el) => getComputedStyle(el).isolation);
+
+    expect(isolation, 'discard stack must not leak its z-bumps to the player area').toBe('isolate');
   });
 
   test('@mobile an empty pile still shows the "+" hint', async ({ page }) => {


### PR DESCRIPTION
## Summary

Two related changes to the Metro theme's discard piles and the shared page background.

## Metro discard collapse

Non-top cards in a discard pile collapse to just their corner badge. That collapse snapped instantly in both directions: the transition was declared only inside the collapsed rule, so it stopped applying the moment a card became top again (its neighbour was played), and `display:none` children cannot animate at all.

It is now a `clip-path` wipe down to the corner badge — the tile retracts into its own number badge and grows back out of it, which matches Metro's motion vocabulary better than a fade. Clipping also removes the card's inner layers, number, border and shadow for free, so the per-child rules are gone; the rule is smaller than what it replaced.

`--metro-corner-size` is now the single source of truth for the badge size and the clip target, replacing two hand-copied `1rem`/`1.125rem` literals that had to agree.

Note: `clip-path: none` does not interpolate, so the top card states `inset(0)` explicitly — without it the reveal snaps, which is the same class of bug as the original one.

## Background layering fix

Verifying the above surfaced a regression in the page background:

- An opaque `#root` painted over `body`, hiding the body-level gradients and textures in glass, rainbow, cinema and others. `#root` is now opt-in via `--board-bg`, transparent by default.
- `body`'s `background-color: var(--theme-color)` had no fallback. An unresolved `var()` is invalid at computed-value time and computes to **transparent** — not to the declaration above it — so 15 non-metro themes lost their body colour. Now `var(--theme-color, var(--background))`.

Metro keeps the split it wanted: gutter and status bar tinted `#234f52` to match the toolbar stripe, board at `#086b6e`.

## Testing

- 186 Playwright tests pass (chromium-desktop + chromium-mobile), no baseline drift
- 405 unit tests pass
- `pnpm lint` and `pnpm typecheck` clean
- New `@desktop @mobile` test pins the clip target to the badge's real edge at both viewports (17px at 390 wide, 19px at 1440), so the token and the badge cannot drift apart
- All 16 themes verified to compute an opaque `body` background

🤖 Generated with [Claude Code](https://claude.com/claude-code)