### PR TITLE
ci(deps): add 3-day Dependabot cooldown for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    # pnpm rejects lockfile entries younger than its 24h minimumReleaseAge;
+    # hold updates a few days so CI can install what Dependabot proposes.
+    cooldown:
+      default-days: 3
     groups:
       react:
         patterns:


### PR DESCRIPTION
## Problem

pnpm 11.6.0 (pinned via `packageManager`) enforces a default **24-hour `minimumReleaseAge`** supply-chain policy on lockfile entries. Nothing in this repo configures it, so the default applies in CI.

Dependabot has no matching restriction, so it regularly opens PRs bumping packages published only hours earlier. `pnpm install` then rejects the lockfile and every job dies before running:

```
✗ Lockfile failed supply-chain policy check (894 entries in 3.5s)
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 3 lockfile entries failed verification:
  @hookform/resolvers@5.5.1 was published at 2026-07-25T23:06:16.335Z, within the minimumReleaseAge cutoff (2026-07-25T00:08:51.693Z)
  lucide-react@1.27.0 was published at 2026-07-25T21:02:57.000Z, ...
  react-hook-form@7.83.0 was published at 2026-07-25T00:29:33.990Z, ...
```

That is exactly what happened in #222 — `ui`, `workspace (22.x)` and `workspace (24.x)` all failed at install, ~15s in, with a perfectly valid lockfile.

## Change

Adds a `cooldown` block to the npm ecosystem entry in `.github/dependabot.yml`:

```yaml
cooldown:
  default-days: 3
```

Three days rather than one, so versions clear pnpm's window with margin for queued jobs and CI re-runs (the cutoff is recomputed at each install, not at PR creation).

The `github-actions` ecosystem is left alone — it does not go through `pnpm-lock.yaml`.

## Notes

- This does not fix #222 itself; that PR just needs a CI re-run now that the three packages have aged past the cutoff.
- Trade-off: dependency updates land up to 3 days later than before. Given the weekly schedule, this mostly shifts which weekly batch a release lands in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)