### PR TITLE
fix(ui): show discard corner numbers on mobile stacks

### DIFF
--- a/apps/web/src/styles/card.css
+++ b/apps/web/src/styles/card.css
@@ -120,7 +120,19 @@
   @apply absolute top-0 left-0 z-2;
 }
 
-.discard-pile-stack .card.normal-card:not(:nth-last-child(1 of :not(.empty-card))) .card-corner-number {
+/* A discard pile holding more than one card keeps its corner numbers at every
+   breakpoint — on *every* card, top one included, not just the buried ones.
+   The buried cards are reduced to a sliver (or, in Metro, clipped down to the
+   badge itself), so the numbers read as a column; dropping the top card's
+   number below `lg` would leave that column a card short. A pile down to a
+   single card falls back to the base `invisible lg:visible`, since there is
+   nothing to enumerate.
+
+   The pile is counted with `:not(.empty-card)` — the same marker Metro's
+   collapse rule uses — so the zero-opacity placeholder standing in for a card
+   mid-animation counts too: it is what makes the card beneath it a buried one,
+   and that card must keep the badge it has been collapsed to. */
+.discard-pile-stack:has(.card:not(.empty-card) ~ .card:not(.empty-card)) .card.normal-card .card-corner-number {
   @apply visible;
 }
 

--- a/apps/web/tests/ui/discard-corner-numbers.spec.ts
+++ b/apps/web/tests/ui/discard-corner-numbers.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect, type Page } from '@playwright/test';
+
+import { expectThemeClass, gotoFixture } from './helpers.ts';
+
+/**
+ * The base `.card-corner-number` utility is `invisible lg:visible`, so these
+ * assertions only mean anything below the `lg` breakpoint — hence `@mobile`.
+ *
+ * Themed on `theme-paper` on purpose: Metro shows the corner tile on every card
+ * at every breakpoint as part of its card identity (covered by
+ * `metro-discard.spec.ts`), so it cannot tell the discard-pile rule apart from
+ * its own.
+ */
+test.describe('Discard pile corner numbers', () => {
+  const pileNumbers = (page: Page, pileIndex: number) =>
+    page
+      .getByTestId('human-player-area')
+      .locator('.discard-pile-stack')
+      .nth(pileIndex)
+      .locator('.card.normal-card .card-corner-number')
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).visibility));
+
+  test('@mobile a stacked pile shows the corner number on every card, top one included', async ({ page }) => {
+    // ready-human's human discard piles are [[3,SkipBo],[8],[],[2,SkipBo,6]].
+    await gotoFixture(page, 'ready-human', 'theme-paper');
+    await expectThemeClass(page, 'theme-paper');
+
+    // Pile 3 holds three cards, two of them numbered — the buried `2` and the
+    // top `6`. Both must carry a corner number: the cards underneath are down
+    // to a sliver, so the numbers are what makes the pile readable, and a top
+    // card missing its own would leave that column a card short.
+    const stacked = await pileNumbers(page, 3);
+    expect(stacked.length, 'fixture must render two numbered cards in pile 3').toBe(2);
+    expect(new Set(stacked), 'every numbered card in a stacked pile keeps its corner number').toEqual(
+      new Set(['visible']),
+    );
+
+    // Pile 0 is [3, SkipBo]: the buried numbered card still counts even though
+    // the card on top of it is a Skip-Bo with no number of its own.
+    const underSkipBo = await pileNumbers(page, 0);
+    expect(underSkipBo, 'a numbered card buried under a Skip-Bo keeps its corner number').toEqual(['visible']);
+  });
+
+  test('@mobile a single-card pile keeps its corner number hidden', async ({ page }) => {
+    await gotoFixture(page, 'ready-human', 'theme-paper');
+    await expectThemeClass(page, 'theme-paper');
+
+    // Pile 1 is [8] — one card, nothing to enumerate, so it falls back to the
+    // base `invisible lg:visible` and shows only the large centre number.
+    const single = await pileNumbers(page, 1);
+    expect(single, 'fixture must render exactly one numbered card in pile 1').toHaveLength(1);
+    expect(single[0], 'a lone discard card needs no corner number on mobile').toBe('hidden');
+  });
+
+  test('@desktop every discard card shows its corner number regardless of pile depth', async ({ page }) => {
+    await gotoFixture(page, 'ready-human', 'theme-paper');
+    await expectThemeClass(page, 'theme-paper');
+
+    // Above `lg` the base utility already turns the corner number on, so the
+    // depth-dependent rule must not be what makes it visible there.
+    const all = await page
+      .getByTestId('human-player-area')
+      .locator('.discard-pile-stack .card.normal-card .card-corner-number')
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).visibility));
+
+    expect(all.length, 'fixture must render numbered discard cards').toBeGreaterThan(0);
+    expect(new Set(all), 'desktop shows every corner number').toEqual(new Set(['visible']));
+  });
+});


### PR DESCRIPTION
## What

On mobile, a discard pile that holds more than one card now shows the corner number on **every** card in it — the top one included, not just the buried ones.

## Why

`.card-corner-number` is `invisible lg:visible`, with a discard-pile override that turned it back on. That override was keyed off the card's *position* in the pile:

```css
.discard-pile-stack .card.normal-card:not(:nth-last-child(1 of :not(.empty-card))) .card-corner-number
```

`:not(:nth-last-child(1 of …))` excludes the top card, so below `lg` a stacked pile read as a column of corner numbers with a gap where the top card sits — the one card whose value you most need.

## How

The override is now keyed off the pile's *depth* instead:

```css
.discard-pile-stack:has(.card:not(.empty-card) ~ .card:not(.empty-card)) .card.normal-card .card-corner-number
```

- More than one card in the pile → every numbered card in it shows its corner number at every breakpoint.
- A pile down to a single card keeps the base `invisible lg:visible` — there is nothing to enumerate, and the large centre number already reads.
- Scoped to `.card.normal-card`, so Skip-Bo cards (which have no number to show and hide the badge per-theme) are untouched.

The `:has()` counts cards with `:not(.empty-card)` — the same marker Metro's collapse rule uses — so the zero-opacity placeholder that stands in for a card mid-animation counts as well. That placeholder is what makes the card beneath it a buried one, and Metro has already clipped that card down to its badge; counting only rendered cards would blank the badge and make the card vanish for the duration of the animation.

Metro is unaffected in practice: it already forces the corner tile visible on every numbered card at every breakpoint as part of its card identity.

## Tests

New `apps/web/tests/ui/discard-corner-numbers.spec.ts`, themed on `theme-paper` on purpose — Metro can't distinguish this rule from its own always-on tile:

- `@mobile` a 3-card pile shows the corner number on both of its numbered cards (buried `2` and top `6`)
- `@mobile` a numbered card buried under a Skip-Bo keeps its corner number
- `@mobile` a single-card pile keeps its corner number hidden
- `@desktop` every discard card shows its corner number regardless of pile depth, so the base utility is still what does the work above `lg`

## Validation

- `pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` ✅ (466 unit tests)
- `pnpm test:e2e` run in full locally on Linux: the new spec and `metro-discard.spec.ts` pass in both projects. The only failures are 74 screenshot assertions in `theme-contract` / `layout-and-accessibility` / `game-stats-dialog`, all of them `A snapshot doesn't exist at …-linux.png` — this repo commits `*-darwin.png` baselines and gitignores the Linux ones, so a Linux run has nothing to compare against. No behavioural or visual-diff failures.
- Visual baselines were **not** regenerated, since that has to happen on macOS. The only mobile screenshot fixture is `victory-human`, where this change adds one small badge (pile 3's top `6`) — well inside the 1.5% `maxDiffPixelRatio`. The macOS `ui` job on this PR passes against the existing baselines, confirming that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kcaccwiLpnTdqWPDkWCYQ