### PR TITLE
fix(web): recover clients stuck below the PWA hard-update floor

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/testing/uiFixtures';
 import { DebugStrip } from '@/components/DebugStrip';
 import { usePwaVersionGate } from '@/hooks/usePwaVersionGate';
+import type { ApplyServiceWorkerUpdateOptions } from '@/lib/pwaUpdates';
 import { useThemeColorMeta } from '@/hooks/useThemeColorMeta';
 import { useThemeUsageReporter } from '@/hooks/useThemeUsageReporter';
 import { buildGameStatsSnapshot, useGameStatsRecorder } from '@/hooks/useGameStatsRecorder';
@@ -34,6 +35,14 @@ import { buildGameStatsSnapshot, useGameStatsRecorder } from '@/hooks/useGameSta
 const OnlineGameScreen = lazy(() => import('@/components/OnlineGameScreen'));
 
 const fixtureActionResult = Promise.resolve({ success: true, message: 'Fixture mode' });
+
+// A hard update is blocking — the build sits below the protocol floor — so a
+// no-op apply strands the player there rather than merely delaying a feature.
+// Every use below is an explicit user action (New Game / Play Online / Join /
+// the update button / the overlay), which is exactly the bar
+// `forceReloadIfNotStaged` sets, and in local mode `ForcedUpdateOverlay` isn't
+// rendered, so those handlers are the only recovery path a stuck client has.
+const FORCE_UPDATE: ApplyServiceWorkerUpdateOptions = { forceReloadIfNotStaged: true };
 
 function FixtureApp({ fixtureName }: { fixtureName: UiFixtureName }) {
   const gameState = getUiFixture(fixtureName);
@@ -173,7 +182,7 @@ function LiveApp() {
     // A required hard update was deferred while in local mode — apply it now and
     // abort the start (the reload boots into a fresh local game).
     if (isHardUpdateRequired) {
-      void reloadToUpdate();
+      void reloadToUpdate(FORCE_UPDATE);
       return;
     }
 
@@ -193,7 +202,7 @@ function LiveApp() {
     // Never contact the server on a build below the protocol floor — apply the
     // deferred hard update first (the reload aborts this start).
     if (isHardUpdateRequired) {
-      void reloadToUpdate();
+      void reloadToUpdate(FORCE_UPDATE);
       return;
     }
 
@@ -213,7 +222,7 @@ function LiveApp() {
 
   const joinGame = async (roomCode: string) => {
     if (isHardUpdateRequired) {
-      void reloadToUpdate();
+      void reloadToUpdate(FORCE_UPDATE);
       return;
     }
 
@@ -284,7 +293,7 @@ function LiveApp() {
   // worker never stages the advertised build (seen on iOS standalone PWAs)
   // presses the button, the label flashes, and nothing else ever happens.
   const updateNow = () => {
-    void reloadToUpdate({ forceReloadIfNotStaged: true });
+    void reloadToUpdate(FORCE_UPDATE);
   };
 
   const screen =

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -2,6 +2,7 @@ import { act, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { GameConfig, GameState } from '@skipbo/game-core';
+import type { ApplyServiceWorkerUpdateOptions } from '@/lib/pwaUpdates';
 
 // Controllable stand-in for the version gate so tests can flip pending/hard
 // update states and observe what the start handlers do with reloadToUpdate.
@@ -18,9 +19,12 @@ const versionGate = {
   lastCheckAt: null,
   latestAppVersion: null,
   minimumSupportedVersion: null as string | null,
-  reloadToUpdate: vi.fn<() => Promise<boolean>>(),
+  reloadToUpdate: vi.fn<(options?: ApplyServiceWorkerUpdateOptions) => Promise<boolean>>(),
   shouldShowSoftUpdate: false,
 };
+// A blocking hard update (and any explicit update press) must escalate a no-op
+// apply to a network force-refresh; the automatic soft path must not.
+const FORCE_UPDATE: ApplyServiceWorkerUpdateOptions = { forceReloadIfNotStaged: true };
 vi.mock('@/hooks/usePwaVersionGate', () => ({
   usePwaVersionGate: () => ({ ...versionGate }),
 }));
@@ -190,7 +194,7 @@ describe('App online start handlers and pending updates', () => {
       await lastShellProps().onStartOnlineGame();
     });
 
-    expect(versionGate.reloadToUpdate).toHaveBeenCalled();
+    expect(versionGate.reloadToUpdate).toHaveBeenCalledWith(FORCE_UPDATE);
     expect(createOnlineRoomMock).not.toHaveBeenCalled();
   });
 
@@ -203,7 +207,7 @@ describe('App online start handlers and pending updates', () => {
       await lastShellProps().onJoinOnlineGame('ABCD');
     });
 
-    expect(versionGate.reloadToUpdate).toHaveBeenCalled();
+    expect(versionGate.reloadToUpdate).toHaveBeenCalledWith(FORCE_UPDATE);
     expect(joinOnlineRoomMock).not.toHaveBeenCalled();
   });
 
@@ -217,7 +221,10 @@ describe('App online start handlers and pending updates', () => {
       lastShellProps().onStartLocalGame();
     });
 
+    // ForcedUpdateOverlay is not rendered in local mode, so this handler is the
+    // only escape a stuck client has — it must force rather than no-op.
     expect(versionGate.reloadToUpdate).toHaveBeenCalledTimes(1);
+    expect(versionGate.reloadToUpdate).toHaveBeenCalledWith(FORCE_UPDATE);
   });
 
   it('gates joining a room on the pending update the same way as creating one', async () => {
@@ -258,6 +265,7 @@ describe('App online start handlers and pending updates', () => {
     });
 
     expect(versionGate.reloadToUpdate).toHaveBeenCalledTimes(1);
+    expect(versionGate.reloadToUpdate).toHaveBeenCalledWith(FORCE_UPDATE);
   });
 
   it('fires the reload alongside starting a fresh local game while an update is pending', async () => {
@@ -272,6 +280,9 @@ describe('App online start handlers and pending updates', () => {
     });
 
     expect(versionGate.reloadToUpdate).toHaveBeenCalledTimes(1);
+    // A soft update is not blocking, so this path must stay a no-op when nothing
+    // is staged rather than nuking caches on every "New Game" press.
+    expect(versionGate.reloadToUpdate).toHaveBeenCalledWith();
     // The local start is not aborted — a lagging service worker must not leave
     // the "New Game" button stuck.
     expect(appShellCalls.length).toBeGreaterThan(0);

--- a/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePwaVersionGate.test.tsx
@@ -383,10 +383,16 @@ describe('usePwaVersionGate', () => {
     expect(applyServiceWorkerUpdateMock).not.toHaveBeenCalled();
   });
 
-  it('records the minimum supported version in sessionStorage before the auto-reload runs', async () => {
+  it('records the minimum supported version in sessionStorage when the auto-reload commits', async () => {
     fetchRuntimeConfigMock.mockResolvedValue({
       appVersion: 'v1.2.0',
       minimumSupportedVersion: 'v1.1.0',
+    });
+    // A committed reload invokes onReloadCommitted before navigating, so the
+    // guard lands in sessionStorage and survives the reload.
+    applyServiceWorkerUpdateMock.mockImplementation(async (onReloadCommitted?: () => void) => {
+      onReloadCommitted?.();
+      return true;
     });
 
     renderHook(() => usePwaVersionGate());
@@ -396,6 +402,26 @@ describe('usePwaVersionGate', () => {
     });
 
     expect(globalThis.sessionStorage?.getItem(AUTO_RELOAD_SESSION_STORAGE_KEY)).toBe('v1.1.0');
+  });
+
+  it('leaves the sessionStorage guard unset when the auto-reload finds nothing staged', async () => {
+    fetchRuntimeConfigMock.mockResolvedValue({
+      appVersion: 'v1.2.0',
+      minimumSupportedVersion: 'v1.1.0',
+    });
+    // No waiting worker: applyServiceWorkerUpdate returns false without ever
+    // calling onReloadCommitted. Burning the guard here would permanently
+    // disable the automatic hard update for this tab and strand the client
+    // below the protocol floor, so it must stay unset for the next load.
+    applyServiceWorkerUpdateMock.mockResolvedValue(false);
+
+    renderHook(() => usePwaVersionGate());
+
+    await waitFor(() => {
+      expect(applyServiceWorkerUpdateMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(globalThis.sessionStorage?.getItem(AUTO_RELOAD_SESSION_STORAGE_KEY)).toBeNull();
   });
 
   it('rechecks runtime config when the document becomes visible again', async () => {

--- a/apps/web/src/hooks/usePwaVersionGate.ts
+++ b/apps/web/src/hooks/usePwaVersionGate.ts
@@ -159,10 +159,6 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
     [],
   );
 
-  const reloadToUpdate = useEffectEvent(() => {
-    void runReloadToUpdate();
-  });
-
   useEffect(() => {
     void checkForUpdates();
 
@@ -260,7 +256,9 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
   }, []);
 
   useEffect(() => {
-    if (!isHardUpdateRequired || !runtimeVersionSnapshot.minimumSupportedVersion) {
+    const requiredVersion = runtimeVersionSnapshot.minimumSupportedVersion;
+
+    if (!isHardUpdateRequired || !requiredVersion) {
       return;
     }
 
@@ -273,14 +271,22 @@ export const usePwaVersionGate = ({ deferHardUpdate = false }: UsePwaVersionGate
 
     // sessionStorage survives `location.reload()`, so this guard keeps a single
     // tab from re-auto-triggering the flow for the same minimum version after
-    // a reload — required retries must come from `ForcedUpdateOverlay`.
-    if (readAutoReloadVersion() === runtimeVersionSnapshot.minimumSupportedVersion) {
+    // a reload — required retries must come from `ForcedUpdateOverlay` or the
+    // explicit start handlers in `App`.
+    if (readAutoReloadVersion() === requiredVersion) {
       return;
     }
 
-    writeAutoReloadVersion(runtimeVersionSnapshot.minimumSupportedVersion);
-    void reloadToUpdate();
-  }, [deferHardUpdate, isHardUpdateRequired, runtimeVersionSnapshot.minimumSupportedVersion]);
+    // Same discipline as the soft path above: stamp the guard from
+    // `onReloadCommitted`, so it is only burned once a reload actually fires.
+    // Writing it up front made a no-op apply — the `runtime:` channel
+    // advertising a build the service worker hasn't staged, which Safari hits
+    // regularly — permanently disable the automatic hard update for this tab,
+    // leaving the client stuck below the protocol floor while it logged
+    // `pwa.apply-update.no-waiting-worker` on every attempt. Leaving the guard
+    // unset lets the next load retry; a no-op doesn't reload, so this can't loop.
+    void runReloadToUpdate(() => writeAutoReloadVersion(requiredVersion));
+  }, [deferHardUpdate, isHardUpdateRequired, runtimeVersionSnapshot.minimumSupportedVersion, runReloadToUpdate]);
 
   return {
     currentAppVersion: APP_VERSION,

--- a/apps/web/src/lib/pwaUpdates.ts
+++ b/apps/web/src/lib/pwaUpdates.ts
@@ -165,7 +165,8 @@ export interface ApplyServiceWorkerUpdateOptions {
   // Escape hatch for clients whose service worker never stages the advertised
   // build: fall back to `forceRefreshFromNetwork` instead of returning false.
   // Only set this on an explicit user action (the update button, the forced
-  // update overlay) — automatic apply paths must keep the no-op behavior, or a
+  // update overlay, the hard-update branches of the New Game / Play Online /
+  // Join handlers) — automatic apply paths must keep the no-op behavior, or a
   // stale runtime config could reload-loop the app.
   forceReloadIfNotStaged?: boolean;
 }


### PR DESCRIPTION
Fixes [SKIP-BO-FRONTEND-2](https://pierre-luc.sentry.io/issues/SKIP-BO-FRONTEND-2) — `pwa.apply-update.no-waiting-worker`.

## What the telemetry shows

All 5 events in the last 90 days are Safari / Mobile Safari (macOS + iOS), across releases `v2.12.1`, `v2.12.2`, `v2.12.7`, and `v2.12.27`. The force-refresh escape hatch from #195 shipped in `v2.12.12`, so the most recent event is *after* that fix — it did not cover these clients, because it only applies to the update button and `ForcedUpdateOverlay`.

The warning itself is deliberate instrumentation, not a crash. It fires when the runtime-config channel advertises a version the service worker has not staged, and `applyServiceWorkerUpdate` correctly no-ops. The bug is that for a **blocking** hard update, that no-op left the client permanently stranded below the protocol floor.

## Two gaps

**1. The hard-update guard was burned on a no-op.** `usePwaVersionGate` stamped `AUTO_RELOAD_SESSION_STORAGE_KEY` *before* calling the apply. When the apply no-opped, the guard was already written, so the automatic hard update never retried for that minimum version in that tab. The soft path already avoids this by writing its guard from `onReloadCommitted` — and says so in a comment explaining that a transient miss must not burn the version's one attempt. The blocking path now follows the same discipline. A no-op does not reload, so nothing can loop; the retry only happens on a subsequent page load.

**2. The hard-update start handlers never forced.** `startLocalGame`, `startOnlineGame`, and `joinGame` called `reloadToUpdate()` with no options. `ForcedUpdateOverlay` renders only when `!isLocalMode`, so in local mode those three handlers are the *only* recovery path — and all three no-opped. They are explicit user actions (New Game / Play Online / Join), which is exactly the bar `forceReloadIfNotStaged` documents, so they now escalate to the network force-refresh.

The automatic soft-update path is deliberately left alone: it still no-ops when nothing is staged, so a lagging service worker can't nuke caches on every "New Game" press. A test now pins that asymmetry.

## Tests

- New: `leaves the sessionStorage guard unset when the auto-reload finds nothing staged`. Verified it fails against the old behavior (guard read back as `v1.1.0` instead of `null`) and passes with the fix.
- Updated `records the minimum supported version in sessionStorage…` to drive `onReloadCommitted`, matching how a committed reload actually behaves.
- Tightened the three hard-update `App` tests plus `onUpdateNow` to assert `{ forceReloadIfNotStaged: true }`, and the soft local-start test to assert it is called with no options.

## Validation

- `pnpm test` — 467 passed across all packages (61 web files)
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test:e2e` — **could not be validated in this container.** The image ships chromium build 1194 against the repo's pinned 1234, individual specs take 28–35s against a 30s timeout, and the visual baselines are macOS-only (`*-darwin.png`). Two runs of the identical subset produced different failure sets, and the failures are `frame.evaluate: Test timeout of 30000ms exceeded` plus screenshot diffs. None reach the changed code — `playwright.config.ts` sets `serviceWorkers: 'block'`, so the PWA update path is unreachable in E2E. The macOS CI job is the real gate here.

---
_Generated by [Claude Code](https://claude.ai/code/session_017azALSm7BQixthxvumXbBx)_