### PR TITLE
feat(web): play the board from the keyboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Use this decision tree, not guesswork:
 ## Common Traps
 
 - `players[0]` and `players[1]` are state order; the rendered board order is different.
+- Adding a child to a pile container (`.discard-pile-stack`, `.build-pile`) can silently retarget structural CSS (`:only-child`, `:nth-last-child(… of …)`) that identifies "the pile's cards". Scope those selectors to `.card`, and run `test:visual`.
 - `END_TURN` is not the place to add start-of-turn draw logic.
 - Removing a hand card means writing `null`, not splicing.
 - Online play is host-authoritative: the server relays opaque messages and never sees game state; the host seat owns the game and redacts hidden information.

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -69,6 +69,49 @@ seat order unless `shuffleSeats: true` — so tests know the host plays first.
   `MOCK_RELAY_PORT`), then `VITE_SKIPBO_API_URL=http://127.0.0.1:8787 pnpm dev`
   and open two tabs.
 
+## Keyboard Layer (desktop)
+
+`BoardKeyboardProvider` (`src/contexts/BoardKeyboardContext.tsx`) mounts a global
+keydown listener over a board. The bindings are **positional** — the digit row
+drives the construction piles, the top letter row the local seat's own zone,
+mirroring the on-screen layout:
+
+```
+        2   3   4   5           construction piles 1-4
+    q   w e r t y   u i o p     talon | main 1-5 | défausses 1-4
+```
+
+- All mapping and legality lives in the pure `resolveKeyboardIntent`
+  (`src/game/keyboardActions.ts`); the provider is a thin listener. Add bindings
+  there, not in the hook.
+- Bind on `event.code`, never `event.key` — the layout is positional, and `code`
+  preserves the finger pattern on AZERTY. `?` is the one exception (no stable
+  code across layouts). Badge labels come from `navigator.keyboard.getLayoutMap()`
+  where it exists, so an AZERTY player is shown their own legends.
+- Build plays commit immediately; **discards arm and wait for Space**, since they
+  are irreversible and end the turn.
+- Mounted **per screen** (`LocalGameScreen`, `OnlineGameScreen`), never inside the
+  board: `GameBoard` is also rendered by `OnlineGameBoard` and as an inert lobby
+  placeholder with stub callbacks. Online it is gated on `hasGameView`, not
+  `roomStatus` (see the placeholder gotcha above).
+- It needs a `CardAnimationProvider` above it (it reads the animation queue to
+  know when the board has settled). Fixtures mount no provider at all.
+
+### Hint badges
+
+`.key-hint-badge` is **always mounted and transparent**, absolutely positioned so
+it takes no layout — that is what keeps the committed visual baselines valid.
+Visibility is a `body[data-key-hints]` attribute, the same trick `DragProvider`
+uses for drop targets. Two reveals: one unprompted per session (sessionStorage,
+`pointer: fine` only, on the first settled local turn), and an on-demand one from
+any key press or a held Alt.
+
+**Trap:** pile containers are targeted by structural CSS (`:only-child`,
+`:nth-last-child(… of …)`). Adding any child to `.discard-pile-stack` or
+`.build-pile` can silently retarget those rules — the badges broke Metro's
+discard collapse until the selectors were scoped to `.card` explicitly. Run
+`test:visual` after touching pile children.
+
 ## AI
 
 Entry point: `src/ai/computeBestMove.ts`  

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -69,6 +69,27 @@ seat order unless `shuffleSeats: true` — so tests know the host plays first.
   `MOCK_RELAY_PORT`), then `VITE_SKIPBO_API_URL=http://127.0.0.1:8787 pnpm dev`
   and open two tabs.
 
+## Pile Presses
+
+`resolvePileIntent` (`src/game/pileIntents.ts`) is the **single** statement of what
+pressing a pile does, whatever pressed it. Click, Enter/Space on a focused pile and
+the keyboard shortcut layer all translate their own event into a `PilePressTarget`,
+call it, and perform the returned `BoardIntent` via `applyBoardIntent`. Three rules
+live there and nowhere else:
+
+1. A discard pile is a **discard target** while a hand card is selected, and a
+   **card source** otherwise.
+2. Pressing the source that is already selected deselects it.
+3. An empty slot is inert **as a source** (an empty pile is still a valid discard
+   target).
+
+It never returns a play — that is what keeps the "selection first, then play or
+discard" invariant true for every input method. The drag path shares rule 1 through
+`canDiscardFromSource`.
+
+Do not re-derive any of this in a component. These rules used to be restated per
+input method, and the copies drifted.
+
 ## Keyboard Layer (desktop)
 
 `BoardKeyboardProvider` (`src/contexts/BoardKeyboardContext.tsx`) mounts a global
@@ -84,6 +105,9 @@ mirroring the on-screen layout:
 - All mapping and legality lives in the pure `resolveKeyboardIntent`
   (`src/game/keyboardActions.ts`); the provider is a thin listener. Add bindings
   there, not in the hook.
+- **What a pile press means is not decided there.** `resolveKeyboardIntent` maps a
+  key onto a pile and defers to `resolvePileIntent` — see [Pile Presses](#pile-presses)
+  below. Its only departure is turning a returned `discard` into `armDiscard`.
 - Bind on `event.code`, never `event.key` — the layout is positional, and `code`
   preserves the finger pattern on AZERTY. `?` is the one exception (no stable
   code across layouts). Badge labels come from `navigator.keyboard.getLayoutMap()`

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import { AppUpdatedBanner } from '@/components/AppUpdatedBanner';
 import { ForcedUpdateOverlay } from '@/components/ForcedUpdateOverlay';
 import { ResumeGameBanner } from '@/components/ResumeGameBanner';
 import { LocalGameBoard } from '@/components/LocalGameBoard';
+import { BoardKeyboardProvider } from '@/contexts/BoardKeyboardContext';
 import { isSafeToApplyLocalUpdate } from '@/lib/localUpdateGate';
 import { applyPendingUpdateBeforeOnlineStart } from '@/lib/onlineUpdateGate';
 import { canPlayCard } from '@skipbo/game-core';
@@ -118,14 +119,22 @@ function LocalGameScreen({
   }, [isUpdatePending, isSafeToApplyUpdate, applyUpdateWhenSafe]);
 
   const gameBoard = (
-    <LocalGameBoard
+    <BoardKeyboardProvider
       gameState={gameState}
       selectCard={selectCard}
       playCard={playCard}
       discardCard={discardCard}
       clearSelection={clearSelection}
-      canPlayCard={canPlayCard}
-    />
+    >
+      <LocalGameBoard
+        gameState={gameState}
+        selectCard={selectCard}
+        playCard={playCard}
+        discardCard={discardCard}
+        clearSelection={clearSelection}
+        canPlayCard={canPlayCard}
+      />
+    </BoardKeyboardProvider>
   );
 
   return (

--- a/apps/web/src/components/CenterArea.tsx
+++ b/apps/web/src/components/CenterArea.tsx
@@ -1,6 +1,8 @@
 import type { Card as CardType, GameState } from '@skipbo/game-core';
 import { Card } from '@/components/Card';
 import { EmptyCard } from '@/components/EmptyCard.tsx';
+import { KeyHint } from '@/components/KeyHint';
+import { BUILD_KEYS } from '@/game/keyboardActions';
 import { cn } from '@/lib/utils';
 import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
 import { useDrag } from '@/contexts/useDrag';
@@ -195,6 +197,7 @@ export function CenterArea({ gameState, playCard, canPlayCard }: CenterAreaProps
                       className={cn('drop-indicator', canDropSelectedCard && 'can-drop')}
                     />
                   )}
+                  <KeyHint code={BUILD_KEYS[index]} />
                 </div>
               );
             })}

--- a/apps/web/src/components/KeyHint.tsx
+++ b/apps/web/src/components/KeyHint.tsx
@@ -1,12 +1,15 @@
-import type { CSSProperties } from 'react';
-
 import { useBoardKeyboard } from '@/contexts/useBoardKeyboard';
+import { LOCAL_PLAYER_INDEX } from '@/game/keyboardActions';
 
 interface KeyHintProps {
   /** `KeyboardEvent.code` of the binding this pile answers to. */
   code: string;
-  /** Overrides the default centring when the badge cannot anchor to its slot. */
-  style?: CSSProperties;
+  /**
+   * Seat this pile belongs to. Only the local seat is keyboard-driven, so an
+   * opponent's pile renders nothing. Omit for piles shared by every seat (the
+   * construction piles).
+   */
+  playerIndex?: number;
 }
 
 /**
@@ -21,16 +24,16 @@ interface KeyHintProps {
  * annotates already has its own accessible name, and the badge is a visual
  * reminder of a shortcut, not content.
  */
-export function KeyHint({ code, style }: KeyHintProps) {
+export function KeyHint({ code, playerIndex }: KeyHintProps) {
   const { keyLabels } = useBoardKeyboard();
   const label = keyLabels[code];
 
-  if (!label) {
+  if (!label || (playerIndex !== undefined && playerIndex !== LOCAL_PLAYER_INDEX)) {
     return null;
   }
 
   return (
-    <span className="key-hint-badge" aria-hidden="true" data-key-hint={code} style={style}>
+    <span className="key-hint-badge" aria-hidden="true" data-key-hint={code}>
       {label}
     </span>
   );

--- a/apps/web/src/components/KeyHint.tsx
+++ b/apps/web/src/components/KeyHint.tsx
@@ -1,0 +1,37 @@
+import type { CSSProperties } from 'react';
+
+import { useBoardKeyboard } from '@/contexts/useBoardKeyboard';
+
+interface KeyHintProps {
+  /** `KeyboardEvent.code` of the binding this pile answers to. */
+  code: string;
+  /** Overrides the default centring when the badge cannot anchor to its slot. */
+  style?: CSSProperties;
+}
+
+/**
+ * The key badge under a pile.
+ *
+ * Always mounted, never taking layout: absolutely positioned and transparent at
+ * rest, faded in by a body-level attribute the provider toggles. That is what
+ * keeps the board pixel-identical when the hints are down, so the committed
+ * visual baselines never have to account for this feature.
+ *
+ * `aria-hidden` because it is redundant for a screen reader — the pile it
+ * annotates already has its own accessible name, and the badge is a visual
+ * reminder of a shortcut, not content.
+ */
+export function KeyHint({ code, style }: KeyHintProps) {
+  const { keyLabels } = useBoardKeyboard();
+  const label = keyLabels[code];
+
+  if (!label) {
+    return null;
+  }
+
+  return (
+    <span className="key-hint-badge" aria-hidden="true" data-key-hint={code} style={style}>
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/apps/web/src/components/KeyboardShortcutsDialog.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react';
+
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { BUILD_KEYS, DISCARD_KEYS, HAND_KEYS, STOCK_KEY } from '@/game/keyboardActions';
 
@@ -31,7 +33,7 @@ const Row = ({ children, label }: { children: React.ReactNode; label: string }) 
  * Labels come from the context rather than being hardcoded, so on a non-QWERTY
  * layout the sheet lists the letters actually printed on the keys.
  */
-export function KeyboardShortcutsDialog({ keyLabels, onOpenChange, open }: KeyboardShortcutsDialogProps) {
+function KeyboardShortcutsDialogComponent({ keyLabels, onOpenChange, open }: KeyboardShortcutsDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent data-testid="keyboard-shortcuts-dialog">
@@ -78,3 +80,8 @@ export function KeyboardShortcutsDialog({ keyLabels, onOpenChange, open }: Keybo
     </Dialog>
   );
 }
+
+// The provider renders this on every one of its own renders, and all three props
+// are stable references — memo keeps the closed sheet from re-allocating its
+// element tree each time.
+export const KeyboardShortcutsDialog = memo(KeyboardShortcutsDialogComponent);

--- a/apps/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/apps/web/src/components/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,80 @@
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { BUILD_KEYS, DISCARD_KEYS, HAND_KEYS, STOCK_KEY } from '@/game/keyboardActions';
+
+interface KeyboardShortcutsDialogProps {
+  keyLabels: Record<string, string>;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}
+
+const Keys = ({ codes, labels }: { codes: readonly string[]; labels: Record<string, string> }) => (
+  <span className="flex flex-wrap gap-1">
+    {codes.map((code) => (
+      <kbd key={code} className="shortcut-key">
+        {labels[code] ?? ''}
+      </kbd>
+    ))}
+  </span>
+);
+
+const Row = ({ children, label }: { children: React.ReactNode; label: string }) => (
+  <div className="flex items-center justify-between gap-4 py-1.5">
+    <span className="text-sm">{label}</span>
+    {children}
+  </div>
+);
+
+/**
+ * The full key map. Reached with `?`, which works on the opponent's turn too —
+ * that is when a player has the attention to go looking for it.
+ *
+ * Labels come from the context rather than being hardcoded, so on a non-QWERTY
+ * layout the sheet lists the letters actually printed on the keys.
+ */
+export function KeyboardShortcutsDialog({ keyLabels, onOpenChange, open }: KeyboardShortcutsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="keyboard-shortcuts-dialog">
+        <DialogHeader>
+          <DialogTitle>Raccourcis clavier</DialogTitle>
+          <DialogDescription>
+            Les touches suivent la disposition du plateau&nbsp;: la rangée de chiffres pour les piles de construction,
+            au-dessus de la rangée de lettres pour votre zone.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="divide-y divide-border/60">
+          <Row label="Piles de construction">
+            <Keys codes={BUILD_KEYS} labels={keyLabels} />
+          </Row>
+          <Row label="Talon">
+            <Keys codes={[STOCK_KEY]} labels={keyLabels} />
+          </Row>
+          <Row label="Main">
+            <Keys codes={HAND_KEYS} labels={keyLabels} />
+          </Row>
+          <Row label="Défausses">
+            <Keys codes={DISCARD_KEYS} labels={keyLabels} />
+          </Row>
+          <Row label="Confirmer une défausse">
+            <span className="flex gap-1">
+              <kbd className="shortcut-key">Espace</kbd>
+              <kbd className="shortcut-key">Entrée</kbd>
+            </span>
+          </Row>
+          <Row label="Annuler">
+            <kbd className="shortcut-key">Échap</kbd>
+          </Row>
+          <Row label="Afficher les touches">
+            <kbd className="shortcut-key">Alt</kbd>
+          </Row>
+        </div>
+
+        <p className="text-muted-sm">
+          Choisissez une carte, puis sa destination. Un dépôt sur une pile de construction part aussitôt&nbsp;; une
+          défausse, qui termine le tour, attend une confirmation.
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/LobbyDialog.tsx
+++ b/apps/web/src/components/LobbyDialog.tsx
@@ -140,7 +140,9 @@ export function LobbyDialog({
           <div className="flex items-center justify-between">
             <div>
               <p className="text-xs text-muted-foreground">Code de partie</p>
-              <p className="font-mono text-2xl font-bold tracking-[0.25em]">{roomCode}</p>
+              <p className="font-mono text-2xl font-bold tracking-[0.25em]" data-testid="lobby-room-code">
+                {roomCode}
+              </p>
             </div>
             {import.meta.env.DEV && (
               <Button type="button" size="sm" variant="outline" onClick={() => void handleCopy()}>

--- a/apps/web/src/components/OnlineGameScreen.tsx
+++ b/apps/web/src/components/OnlineGameScreen.tsx
@@ -8,6 +8,7 @@ import { LobbyDialog, LobbyRemovedDialog } from '@/components/LobbyDialog';
 import { LocalGameBoard } from '@/components/LocalGameBoard';
 import { OnlineGameBoard } from '@/components/OnlineGameBoard';
 import { OnlineStatusStrip } from '@/components/OnlineStatusStrip';
+import { BoardKeyboardProvider } from '@/contexts/BoardKeyboardContext';
 import { useLocalSkipBoGame } from '@/hooks/useLocalSkipBoGame';
 import { useOnlineSkipBoGame } from '@/hooks/useOnlineSkipBoGame';
 import { buildGameStatsSnapshot, shouldRecordOnlineStats, useGameStatsRecorder } from '@/hooks/useGameStatsRecorder';
@@ -145,14 +146,26 @@ function OnlineGameScreen({
         canPlayCard={canPlayCard}
       />
     ) : (
-      <OnlineGameBoard
+      // Gated on a real game view: `useOnlineSkipBoGame` hands back a seat-capacity
+      // placeholder state until the first view is ingested, and driving the
+      // keyboard against that would resolve moves on cards nobody holds.
+      <BoardKeyboardProvider
+        enabled={hasGameView}
         gameState={gameState}
         selectCard={selectCard}
         playCard={playCard}
         discardCard={discardCard}
         clearSelection={clearSelection}
-        canPlayCard={canPlayCard}
-      />
+      >
+        <OnlineGameBoard
+          gameState={gameState}
+          selectCard={selectCard}
+          playCard={playCard}
+          discardCard={discardCard}
+          clearSelection={clearSelection}
+          canPlayCard={canPlayCard}
+        />
+      </BoardKeyboardProvider>
     );
 
   return (

--- a/apps/web/src/components/player-area/DiscardPiles.tsx
+++ b/apps/web/src/components/player-area/DiscardPiles.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from 'react';
 
 import { Card } from '@/components/Card';
 import { EmptyCard } from '@/components/EmptyCard.tsx';
+import { useIsDiscardPileArmed } from '@/contexts/useBoardKeyboard';
 import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
 import { useDrag, useIsDragSource } from '@/contexts/useDrag';
 import { useDraggableCard } from '@/hooks/useDraggableCard';
@@ -80,6 +81,7 @@ function DiscardPile({
 }: DiscardPileProps) {
   const { activeAnimations, isCardBeingAnimated } = useCardAnimation();
   const { session: dragSession } = useDrag();
+  const isArmed = useIsDiscardPileArmed(pileIndex, playerIndex);
   const isHuman = !player.isAI;
   const hasIncomingDiscardAnimation = activeAnimations.some(
     (animation) =>
@@ -137,10 +139,16 @@ function DiscardPile({
 
   return (
     <div
-      className={cn('drop-indicator discard-pile-stack relative', canDrop && 'can-drop', isDragOver && 'is-drag-over')}
+      className={cn(
+        'drop-indicator discard-pile-stack relative',
+        canDrop && 'can-drop',
+        isDragOver && 'is-drag-over',
+        isArmed && 'is-armed',
+      )}
       data-pile-index={pileIndex}
       data-drop-target={canDropFromDrag ? 'discard' : undefined}
       data-drop-index={canDropFromDrag ? pileIndex : undefined}
+      data-armed={isArmed ? 'true' : undefined}
       role={canInteract ? 'button' : undefined}
       tabIndex={canInteract ? 0 : undefined}
       aria-label={`Défausse ${pileIndex + 1}`}

--- a/apps/web/src/components/player-area/DiscardPiles.tsx
+++ b/apps/web/src/components/player-area/DiscardPiles.tsx
@@ -3,7 +3,9 @@ import type { CSSProperties } from 'react';
 
 import { Card } from '@/components/Card';
 import { EmptyCard } from '@/components/EmptyCard.tsx';
+import { KeyHint } from '@/components/KeyHint';
 import { useIsDiscardPileArmed } from '@/contexts/useBoardKeyboard';
+import { DISCARD_KEYS } from '@/game/keyboardActions';
 import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
 import { useDrag, useIsDragSource } from '@/contexts/useDrag';
 import { useDraggableCard } from '@/hooks/useDraggableCard';
@@ -202,6 +204,7 @@ function DiscardPile({
           />
         );
       })}
+      {isHuman && playerIndex === 0 ? <KeyHint code={DISCARD_KEYS[pileIndex]} /> : null}
     </div>
   );
 }

--- a/apps/web/src/components/player-area/DiscardPiles.tsx
+++ b/apps/web/src/components/player-area/DiscardPiles.tsx
@@ -6,6 +6,7 @@ import { EmptyCard } from '@/components/EmptyCard.tsx';
 import { KeyHint } from '@/components/KeyHint';
 import { useIsDiscardPileArmed } from '@/contexts/useBoardKeyboard';
 import { DISCARD_KEYS } from '@/game/keyboardActions';
+import { applyBoardIntent, canDiscardFromSource, resolvePileIntent } from '@/game/pileIntents';
 import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
 import { useDrag, useIsDragSource } from '@/contexts/useDrag';
 import { useDraggableCard } from '@/hooks/useDraggableCard';
@@ -113,22 +114,15 @@ function DiscardPile({
   const canInteract = isHuman && isCurrentPlayer;
 
   const handleDiscardPilePress = () => {
-    if (isHuman && isCurrentPlayer && gameState.selectedCard?.source === 'hand') {
-      void discardCard(pileIndex);
-    } else if (isHuman && isCurrentPlayer) {
-      if (
-        gameState.selectedCard?.source === 'discard' &&
-        gameState.selectedCard.discardPileIndex === pileIndex &&
-        gameState.currentPlayerIndex === playerIndex
-      ) {
-        clearSelection();
-      } else {
-        selectCard('discard', pile.length - 1, pileIndex);
-      }
-    }
+    applyBoardIntent(resolvePileIntent({ kind: 'discard', playerIndex, index: pileIndex }, gameState), {
+      selectCard,
+      clearSelection,
+      discardCard,
+    });
   };
 
-  const canDropFromSelection = isHuman && isCurrentPlayer && gameState.selectedCard?.source === 'hand';
+  const canDropFromSelection =
+    isHuman && isCurrentPlayer && !!gameState.selectedCard && canDiscardFromSource(gameState.selectedCard.source);
   const isDragActive = dragSession !== null;
   const canDropFromDrag =
     isDragActive &&

--- a/apps/web/src/components/player-area/DiscardPiles.tsx
+++ b/apps/web/src/components/player-area/DiscardPiles.tsx
@@ -204,7 +204,7 @@ function DiscardPile({
           />
         );
       })}
-      {isHuman && playerIndex === 0 ? <KeyHint code={DISCARD_KEYS[pileIndex]} /> : null}
+      <KeyHint code={DISCARD_KEYS[pileIndex]} playerIndex={playerIndex} />
     </div>
   );
 }

--- a/apps/web/src/components/player-area/HandSection.tsx
+++ b/apps/web/src/components/player-area/HandSection.tsx
@@ -6,6 +6,7 @@ import { KeyHint } from '@/components/KeyHint';
 import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
 import { useIsDragSource } from '@/contexts/useDrag';
 import { HAND_KEYS } from '@/game/keyboardActions';
+import { applyBoardIntent, resolvePileIntent } from '@/game/pileIntents';
 import { useDraggableCard } from '@/hooks/useDraggableCard';
 import { cn } from '@/lib/utils';
 import { HAND_Y_OFFSETS } from '@/utils/cardPositions';
@@ -38,18 +39,16 @@ export function HandSection({
   const handCardOnClick: MouseEventHandler = (e) => {
     e.stopPropagation();
 
-    if (isHuman && isCurrentPlayer) {
-      const index = parseInt(e.currentTarget.parentElement?.getAttribute('data-card-index') || '');
-      if (
-        gameState.selectedCard?.source === 'hand' &&
-        gameState.selectedCard.index === index &&
-        gameState.currentPlayerIndex === playerIndex
-      ) {
-        clearSelection();
-      } else {
-        selectCard('hand', index);
-      }
-    }
+    // The only DOM-derived part of the decision; everything after it is the
+    // shared, pure resolver. A missing or malformed attribute yields `NaN`,
+    // which resolves to an empty slot and so to no intent at all.
+    const index = parseInt(e.currentTarget.parentElement?.getAttribute('data-card-index') || '');
+
+    applyBoardIntent(resolvePileIntent({ kind: 'hand', playerIndex, index }, gameState), {
+      selectCard,
+      clearSelection,
+      discardCard,
+    });
   };
 
   return (

--- a/apps/web/src/components/player-area/HandSection.tsx
+++ b/apps/web/src/components/player-area/HandSection.tsx
@@ -58,19 +58,15 @@ export function HandSection({
       <div className={cn('hand-area', handOverlaps && 'overlap-hand')}>
         {player.hand.map((card, index) => (
           <div
-            // `relative` only while the hand is NOT overlapping. In overlap mode
-            // the cards are absolutely positioned against `.hand-area`, so making
-            // the holder a containing block would re-anchor them and break the
-            // fan. The key badge follows the same rule below.
-            className={cn(
-              'card-holder inline-flex flex-nowrap w-[calc(var(--hand-area-width)/5)] h-card',
-              !handOverlaps && 'relative',
-            )}
+            className="card-holder inline-flex flex-nowrap w-[calc(var(--hand-area-width)/5)] h-card"
             key={`hand-${index}`}
             data-card-index={index}
             style={{
               // @ts-expect-error custom var
               '--card-rotate': `${(index - Math.floor(5 / 2)) * 4}deg`,
+              // Declared here so `layout.css` can place the key badge on this
+              // slot's column without the component knowing the fan geometry.
+              '--hand-slot-index': index,
             }}
           >
             {isCardBeingAnimated(playerIndex, 'hand', index) || isCardBeingAnimated(playerIndex, 'deck', index) ? (
@@ -113,25 +109,7 @@ export function HandSection({
                 overlapIndex={handOverlaps ? index : undefined}
               />
             )}
-            {isHuman && playerIndex === 0 ? (
-              // Not overlapping: the holder is the containing block, so the badge
-              // centres itself under the slot. Overlapping: the holder is static
-              // and the badge anchors to `.hand-area`, so it gets the same column
-              // maths the card itself uses.
-              <KeyHint
-                code={HAND_KEYS[index]}
-                style={
-                  handOverlaps
-                    ? {
-                        left: `calc(${index} * (var(--card-width) - 10px))`,
-                        width: 'var(--card-width)',
-                        transform: 'none',
-                        textAlign: 'center',
-                      }
-                    : undefined
-                }
-              />
-            ) : null}
+            <KeyHint code={HAND_KEYS[index]} playerIndex={playerIndex} />
           </div>
         ))}
       </div>

--- a/apps/web/src/components/player-area/HandSection.tsx
+++ b/apps/web/src/components/player-area/HandSection.tsx
@@ -2,8 +2,10 @@ import type { Card as CardType, GameState, MoveResult, Player } from '@skipbo/ga
 import type { MouseEventHandler } from 'react';
 
 import { Card } from '@/components/Card';
+import { KeyHint } from '@/components/KeyHint';
 import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
 import { useIsDragSource } from '@/contexts/useDrag';
+import { HAND_KEYS } from '@/game/keyboardActions';
 import { useDraggableCard } from '@/hooks/useDraggableCard';
 import { cn } from '@/lib/utils';
 import { HAND_Y_OFFSETS } from '@/utils/cardPositions';
@@ -56,7 +58,14 @@ export function HandSection({
       <div className={cn('hand-area', handOverlaps && 'overlap-hand')}>
         {player.hand.map((card, index) => (
           <div
-            className="card-holder inline-flex flex-nowrap w-[calc(var(--hand-area-width)/5)] h-card"
+            // `relative` only while the hand is NOT overlapping. In overlap mode
+            // the cards are absolutely positioned against `.hand-area`, so making
+            // the holder a containing block would re-anchor them and break the
+            // fan. The key badge follows the same rule below.
+            className={cn(
+              'card-holder inline-flex flex-nowrap w-[calc(var(--hand-area-width)/5)] h-card',
+              !handOverlaps && 'relative',
+            )}
             key={`hand-${index}`}
             data-card-index={index}
             style={{
@@ -104,6 +113,25 @@ export function HandSection({
                 overlapIndex={handOverlaps ? index : undefined}
               />
             )}
+            {isHuman && playerIndex === 0 ? (
+              // Not overlapping: the holder is the containing block, so the badge
+              // centres itself under the slot. Overlapping: the holder is static
+              // and the badge anchors to `.hand-area`, so it gets the same column
+              // maths the card itself uses.
+              <KeyHint
+                code={HAND_KEYS[index]}
+                style={
+                  handOverlaps
+                    ? {
+                        left: `calc(${index} * (var(--card-width) - 10px))`,
+                        width: 'var(--card-width)',
+                        transform: 'none',
+                        textAlign: 'center',
+                      }
+                    : undefined
+                }
+              />
+            ) : null}
           </div>
         ))}
       </div>

--- a/apps/web/src/components/player-area/StockPile.tsx
+++ b/apps/web/src/components/player-area/StockPile.tsx
@@ -6,6 +6,7 @@ import { EmptyCard } from '@/components/EmptyCard.tsx';
 import { KeyHint } from '@/components/KeyHint';
 import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
 import { STOCK_KEY } from '@/game/keyboardActions';
+import { applyBoardIntent, resolvePileIntent } from '@/game/pileIntents';
 import { useIsDragSource } from '@/contexts/useDrag';
 import { useDraggableCard } from '@/hooks/useDraggableCard';
 import { cn } from '@/lib/utils';
@@ -49,13 +50,11 @@ export function StockPile({
   const stockPileOnClick: MouseEventHandler = (e) => {
     e.stopPropagation();
 
-    if (isHuman && isCurrentPlayer) {
-      if (gameState.selectedCard?.source === 'stock' && gameState.currentPlayerIndex === playerIndex) {
-        clearSelection();
-      } else {
-        selectCard('stock', player.stockPile.length - 1);
-      }
-    }
+    applyBoardIntent(resolvePileIntent({ kind: 'stock', playerIndex }, gameState), {
+      selectCard,
+      clearSelection,
+      discardCard,
+    });
   };
 
   return (

--- a/apps/web/src/components/player-area/StockPile.tsx
+++ b/apps/web/src/components/player-area/StockPile.tsx
@@ -107,8 +107,7 @@ export function StockPile({
               className="relative z-10"
             />
           )}
-          {/* Only the local seat is keyboard-driven, so only it gets badges. */}
-          {isHuman && playerIndex === 0 ? <KeyHint code={STOCK_KEY} /> : null}
+          <KeyHint code={STOCK_KEY} playerIndex={playerIndex} />
         </div>
       ) : (
         <EmptyCard />

--- a/apps/web/src/components/player-area/StockPile.tsx
+++ b/apps/web/src/components/player-area/StockPile.tsx
@@ -3,7 +3,9 @@ import type { CSSProperties, MouseEventHandler } from 'react';
 
 import { Card } from '@/components/Card';
 import { EmptyCard } from '@/components/EmptyCard.tsx';
+import { KeyHint } from '@/components/KeyHint';
 import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
+import { STOCK_KEY } from '@/game/keyboardActions';
 import { useIsDragSource } from '@/contexts/useDrag';
 import { useDraggableCard } from '@/hooks/useDraggableCard';
 import { cn } from '@/lib/utils';
@@ -105,6 +107,8 @@ export function StockPile({
               className="relative z-10"
             />
           )}
+          {/* Only the local seat is keyboard-driven, so only it gets badges. */}
+          {isHuman && playerIndex === 0 ? <KeyHint code={STOCK_KEY} /> : null}
         </div>
       ) : (
         <EmptyCard />

--- a/apps/web/src/contexts/BoardKeyboardContext.tsx
+++ b/apps/web/src/contexts/BoardKeyboardContext.tsx
@@ -1,16 +1,28 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FC, ReactNode } from 'react';
 
 import type { GameState, MoveResult } from '@skipbo/game-core';
 
 import { BoardKeyboardContext, type BoardKeyboardContextValue } from '@/contexts/useBoardKeyboard';
+import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
 import { useDrag } from '@/contexts/useDrag';
 import {
   BOUND_CODES,
+  FALLBACK_KEY_LABELS,
   resolveKeyboardIntent,
   shouldIgnoreKeyEvent,
   type KeyEventEnvironment,
 } from '@/game/keyboardActions';
+import {
+  ACTIVITY_REVEAL_MS,
+  AUTO_REVEAL_DELAY_MS,
+  AUTO_REVEAL_MS,
+  hasKeyboardPointer,
+  hasSeenKeyHintsThisSession,
+  markKeyHintsSeenThisSession,
+  resolveKeyLabels,
+  shouldAutoRevealKeyHints,
+} from '@/game/keyHints';
 
 export interface BoardKeyboardProviderProps {
   children: ReactNode;
@@ -73,6 +85,23 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
   // Space that discards something else entirely.
   const [armed, setArmed] = useState<{ pile: number; handIndex: number } | null>(null);
   const { session: dragSession } = useDrag();
+  const { activeAnimations } = useCardAnimation();
+
+  // Two independent reveals: `isAltHeld` while the recall gesture is down, and
+  // `isTimedVisible` for the auto-reveal and the post-key idle window. Keeping
+  // them apart means releasing Alt can't cut short a reveal a key press earned.
+  const [isAltHeld, setIsAltHeld] = useState(false);
+  const [isTimedVisible, setIsTimedVisible] = useState(false);
+  const [keyLabels, setKeyLabels] = useState<Record<string, string>>(FALLBACK_KEY_LABELS);
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const revealTemporarily = useCallback((durationMs: number) => {
+    setIsTimedVisible(true);
+    clearTimeout(hideTimer.current);
+    hideTimer.current = setTimeout(() => setIsTimedVisible(false), durationMs);
+  }, []);
+
+  useEffect(() => () => clearTimeout(hideTimer.current), []);
 
   const selectedCard = gameState.selectedCard;
   const isLocalTurn = gameState.currentPlayerIndex === 0 && !gameState.gameIsOver;
@@ -122,9 +151,20 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
         hasArmedDiscard: current.armedDiscardPile !== null,
       };
 
+      // Alt is the hold-to-recall gesture, so it never reaches the board.
+      if (event.key === 'Alt') {
+        setIsAltHeld(true);
+        return;
+      }
+
       if (shouldIgnoreKeyEvent(event, environment)) {
         return;
       }
+
+      // Any key that survives the guards — bound or not — means the player is
+      // reaching for the keyboard, so show them what the keys do. Someone
+      // pressing a key that does nothing is precisely who needs the badges.
+      revealTemporarily(ACTIVITY_REVEAL_MS);
 
       // Claim every bound code up front, whether or not it resolves to a legal
       // move. Otherwise Space scrolls the board away when there is nothing armed
@@ -172,11 +212,89 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
       }
     };
 
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [enabled]);
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (event.key === 'Alt') {
+        setIsAltHeld(false);
+      }
+    };
 
-  const value = useMemo<BoardKeyboardContextValue>(() => ({ armedDiscardPile }), [armedDiscardPile]);
+    // Alt-Tabbing away never delivers the keyup, which would strand the badges
+    // on until the next Alt press.
+    const onBlur = () => setIsAltHeld(false);
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      window.removeEventListener('blur', onBlur);
+    };
+  }, [enabled, revealTemporarily]);
+
+  // The one unprompted reveal, on the first turn the player can actually act on.
+  // The "already seen" flag is mirrored into state and only set once the reveal
+  // has actually started: deriving it straight from sessionStorage would flip
+  // `canAutoReveal` to false the moment the flag was written, and the effect
+  // cleanup would cancel the very timer that was about to show the badges.
+  const [hasSeenHints, setHasSeenHints] = useState(hasSeenKeyHintsThisSession);
+  const canAutoReveal = shouldAutoRevealKeyHints({
+    isEnabled: enabled,
+    hasSeenThisSession: hasSeenHints,
+    hasKeyboardPointer: hasKeyboardPointer(),
+    isLocalTurn,
+    isAnimating: activeAnimations.length > 0,
+  });
+
+  useEffect(() => {
+    if (!canAutoReveal) {
+      return undefined;
+    }
+
+    // Marking inside the timer means an attempt cancelled by a late animation
+    // doesn't burn the session's one unprompted reveal.
+    const timer = setTimeout(() => {
+      markKeyHintsSeenThisSession();
+      setHasSeenHints(true);
+      revealTemporarily(AUTO_REVEAL_MS);
+    }, AUTO_REVEAL_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [canAutoReveal, revealTemporarily]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void resolveKeyLabels().then((labels) => {
+      if (!cancelled) {
+        setKeyLabels(labels);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const areKeyHintsVisible = enabled && (isAltHeld || isTimedVisible);
+
+  // Drive visibility from a body attribute rather than per-badge props, the same
+  // way DragProvider lights up drop targets: one CSS toggle instead of a
+  // re-render of every pile on the board.
+  useEffect(() => {
+    if (!areKeyHintsVisible) {
+      return undefined;
+    }
+
+    document.body.setAttribute('data-key-hints', 'visible');
+    return () => document.body.removeAttribute('data-key-hints');
+  }, [areKeyHintsVisible]);
+
+  const value = useMemo<BoardKeyboardContextValue>(
+    () => ({ armedDiscardPile, keyLabels }),
+    [armedDiscardPile, keyLabels],
+  );
 
   return <BoardKeyboardContext.Provider value={value}>{children}</BoardKeyboardContext.Provider>;
 };

--- a/apps/web/src/contexts/BoardKeyboardContext.tsx
+++ b/apps/web/src/contexts/BoardKeyboardContext.tsx
@@ -6,10 +6,11 @@ import type { GameState, MoveResult } from '@skipbo/game-core';
 import { KeyboardShortcutsDialog } from '@/components/KeyboardShortcutsDialog';
 import { BoardKeyboardContext, type BoardKeyboardContextValue } from '@/contexts/useBoardKeyboard';
 import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
-import { useDrag } from '@/contexts/useDrag';
+import { DRAG_ACTIVE_ATTRIBUTE } from '@/contexts/useDrag';
 import {
   BOUND_CODES,
   FALLBACK_KEY_LABELS,
+  LOCAL_PLAYER_INDEX,
   resolveKeyboardIntent,
   shouldIgnoreKeyEvent,
   type KeyEventEnvironment,
@@ -85,7 +86,6 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
   // selection consumed, or end the turn, and a stale highlight would invite a
   // Space that discards something else entirely.
   const [armed, setArmed] = useState<{ pile: number; handIndex: number } | null>(null);
-  const { session: dragSession } = useDrag();
   const { activeAnimations } = useCardAnimation();
 
   // Two independent reveals: `isAltHeld` while the recall gesture is down, and
@@ -106,7 +106,7 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
   useEffect(() => () => clearTimeout(hideTimer.current), []);
 
   const selectedCard = gameState.selectedCard;
-  const isLocalTurn = gameState.currentPlayerIndex === 0 && !gameState.gameIsOver;
+  const isLocalTurn = gameState.currentPlayerIndex === LOCAL_PLAYER_INDEX && !gameState.gameIsOver;
   const armedDiscardPile =
     armed && isLocalTurn && selectedCard?.source === 'hand' && selectedCard.index === armed.handIndex
       ? armed.pile
@@ -115,26 +115,11 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
   // The listener reads the live board through a ref rather than closing over it,
   // so a rebind isn't needed on every state change — and, more importantly, so a
   // key pressed mid-move can never act on a stale board.
-  const latest = useRef({
-    gameState,
-    armedDiscardPile,
-    isDragActive: dragSession !== null,
-    selectCard,
-    playCard,
-    discardCard,
-    clearSelection,
-  });
+  const current = { gameState, armedDiscardPile, selectCard, playCard, discardCard, clearSelection };
+  const latest = useRef(current);
 
   useEffect(() => {
-    latest.current = {
-      gameState,
-      armedDiscardPile,
-      isDragActive: dragSession !== null,
-      selectCard,
-      playCard,
-      discardCard,
-      clearSelection,
-    };
+    latest.current = current;
   });
 
   useEffect(() => {
@@ -149,7 +134,11 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
         isTextEntry: isTextEntryElement(target),
         isActivatable: isActivatableElement(target),
         hasOpenOverlay: document.querySelector(OVERLAY_SELECTOR) !== null,
-        isDragActive: current.isDragActive,
+        // Read from the attribute DragProvider already publishes rather than
+        // subscribing to the drag context: the session object changes on every
+        // pointermove, which would re-render this provider ~60 times a second
+        // for a boolean that flips twice per drag.
+        isDragActive: document.body.hasAttribute(DRAG_ACTIVE_ATTRIBUTE),
         hasArmedDiscard: current.armedDiscardPile !== null,
       };
 
@@ -241,10 +230,13 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
   // `canAutoReveal` to false the moment the flag was written, and the effect
   // cleanup would cancel the very timer that was about to show the badges.
   const [hasSeenHints, setHasSeenHints] = useState(hasSeenKeyHintsThisSession);
+  // Lazy initialiser: the pointer kind cannot change for the life of the page,
+  // and matchMedia allocates a live MediaQueryList on every call.
+  const [isKeyboardPointer] = useState(hasKeyboardPointer);
   const canAutoReveal = shouldAutoRevealKeyHints({
     isEnabled: enabled,
     hasSeenThisSession: hasSeenHints,
-    hasKeyboardPointer: hasKeyboardPointer(),
+    hasKeyboardPointer: isKeyboardPointer,
     isLocalTurn,
     isAnimating: activeAnimations.length > 0,
   });

--- a/apps/web/src/contexts/BoardKeyboardContext.tsx
+++ b/apps/web/src/contexts/BoardKeyboardContext.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { FC, ReactNode } from 'react';
+
+import type { GameState, MoveResult } from '@skipbo/game-core';
+
+import { BoardKeyboardContext, type BoardKeyboardContextValue } from '@/contexts/useBoardKeyboard';
+import { useDrag } from '@/contexts/useDrag';
+import {
+  BOUND_CODES,
+  resolveKeyboardIntent,
+  shouldIgnoreKeyEvent,
+  type KeyEventEnvironment,
+} from '@/game/keyboardActions';
+
+export interface BoardKeyboardProviderProps {
+  children: ReactNode;
+  /** False while no game is in play (the online lobby, a fixture render). */
+  enabled?: boolean;
+  gameState: GameState;
+  selectCard: (source: 'hand' | 'stock' | 'discard', index: number, discardPileIndex?: number) => void;
+  playCard: (buildPileIndex: number) => Promise<MoveResult>;
+  discardCard: (discardPileIndex: number) => Promise<MoveResult>;
+  clearSelection: () => void;
+}
+
+const OVERLAY_SELECTOR =
+  '[role="dialog"][data-state="open"], [role="listbox"][data-state="open"], [role="menu"][data-state="open"]';
+
+// A key pressed with nothing focused targets `window` or `document`, neither of
+// which is an Element — narrow before asking either one about tags or roles.
+const asElement = (target: EventTarget | null): Element | null => (target instanceof Element ? target : null);
+
+const isTextEntryElement = (element: Element | null): boolean => {
+  if (!element) {
+    return false;
+  }
+
+  const tagName = element.tagName;
+
+  return (
+    tagName === 'INPUT' ||
+    tagName === 'TEXTAREA' ||
+    tagName === 'SELECT' ||
+    (element as HTMLElement).isContentEditable === true
+  );
+};
+
+const isActivatableElement = (element: Element | null): boolean =>
+  !!element && (element.tagName === 'BUTTON' || element.getAttribute('role') === 'button');
+
+/**
+ * Mounts the desktop keyboard layer over a board and publishes the armed-discard
+ * state to the piles that need to render it.
+ *
+ * Mounted once per screen rather than inside the board: `GameBoard` is rendered
+ * by `LocalGameBoard`, by `OnlineGameBoard` in the two-player case, and again as
+ * an inert placeholder during the online lobby — binding from in there would
+ * double-register or attach to stub callbacks.
+ */
+export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
+  children,
+  enabled = true,
+  gameState,
+  selectCard,
+  playCard,
+  discardCard,
+  clearSelection,
+}) => {
+  // The arm remembers which hand card it was made for. That turns "is this arm
+  // still valid?" into a derived question rather than an effect that races the
+  // render — the player may click another card with the mouse, have the
+  // selection consumed, or end the turn, and a stale highlight would invite a
+  // Space that discards something else entirely.
+  const [armed, setArmed] = useState<{ pile: number; handIndex: number } | null>(null);
+  const { session: dragSession } = useDrag();
+
+  const selectedCard = gameState.selectedCard;
+  const isLocalTurn = gameState.currentPlayerIndex === 0 && !gameState.gameIsOver;
+  const armedDiscardPile =
+    armed && isLocalTurn && selectedCard?.source === 'hand' && selectedCard.index === armed.handIndex
+      ? armed.pile
+      : null;
+
+  // The listener reads the live board through a ref rather than closing over it,
+  // so a rebind isn't needed on every state change — and, more importantly, so a
+  // key pressed mid-move can never act on a stale board.
+  const latest = useRef({
+    gameState,
+    armedDiscardPile,
+    isDragActive: dragSession !== null,
+    selectCard,
+    playCard,
+    discardCard,
+    clearSelection,
+  });
+
+  useEffect(() => {
+    latest.current = {
+      gameState,
+      armedDiscardPile,
+      isDragActive: dragSession !== null,
+      selectCard,
+      playCard,
+      discardCard,
+      clearSelection,
+    };
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const current = latest.current;
+      const target = asElement(event.target);
+      const environment: KeyEventEnvironment = {
+        isTextEntry: isTextEntryElement(target),
+        isActivatable: isActivatableElement(target),
+        hasOpenOverlay: document.querySelector(OVERLAY_SELECTOR) !== null,
+        isDragActive: current.isDragActive,
+        hasArmedDiscard: current.armedDiscardPile !== null,
+      };
+
+      if (shouldIgnoreKeyEvent(event, environment)) {
+        return;
+      }
+
+      // Claim every bound code up front, whether or not it resolves to a legal
+      // move. Otherwise Space scrolls the board away when there is nothing armed
+      // to confirm, which is exactly when a player is most likely to press it.
+      if (BOUND_CODES.has(event.code)) {
+        event.preventDefault();
+      }
+
+      const intent = resolveKeyboardIntent(event, current.gameState, current.armedDiscardPile);
+
+      if (!intent) {
+        return;
+      }
+
+      switch (intent.kind) {
+        case 'select':
+          setArmed(null);
+          current.selectCard(intent.source, intent.index, intent.discardPileIndex);
+          break;
+        case 'clearSelection':
+          setArmed(null);
+          current.clearSelection();
+          break;
+        case 'play':
+          setArmed(null);
+          void current.playCard(intent.buildPile);
+          break;
+        case 'armDiscard': {
+          // Pinning the hand index is what lets the arm be invalidated by
+          // derivation when the selection moves on.
+          const handIndex = current.gameState.selectedCard?.index;
+          setArmed(handIndex === undefined ? null : { pile: intent.discardPile, handIndex });
+          break;
+        }
+        case 'confirmDiscard':
+          setArmed(null);
+          void current.discardCard(intent.discardPile);
+          break;
+        case 'disarm':
+          setArmed(null);
+          break;
+        case 'help':
+          // Wired to the cheat sheet in a later change.
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [enabled]);
+
+  const value = useMemo<BoardKeyboardContextValue>(() => ({ armedDiscardPile }), [armedDiscardPile]);
+
+  return <BoardKeyboardContext.Provider value={value}>{children}</BoardKeyboardContext.Provider>;
+};

--- a/apps/web/src/contexts/BoardKeyboardContext.tsx
+++ b/apps/web/src/contexts/BoardKeyboardContext.tsx
@@ -3,6 +3,7 @@ import type { FC, ReactNode } from 'react';
 
 import type { GameState, MoveResult } from '@skipbo/game-core';
 
+import { KeyboardShortcutsDialog } from '@/components/KeyboardShortcutsDialog';
 import { BoardKeyboardContext, type BoardKeyboardContextValue } from '@/contexts/useBoardKeyboard';
 import { useCardAnimation } from '@/contexts/useCardAnimation.ts';
 import { useDrag } from '@/contexts/useDrag';
@@ -93,6 +94,7 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
   const [isAltHeld, setIsAltHeld] = useState(false);
   const [isTimedVisible, setIsTimedVisible] = useState(false);
   const [keyLabels, setKeyLabels] = useState<Record<string, string>>(FALLBACK_KEY_LABELS);
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const revealTemporarily = useCallback((durationMs: number) => {
@@ -207,7 +209,7 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
           setArmed(null);
           break;
         case 'help':
-          // Wired to the cheat sheet in a later change.
+          setIsHelpOpen(true);
           break;
       }
     };
@@ -296,5 +298,10 @@ export const BoardKeyboardProvider: FC<BoardKeyboardProviderProps> = ({
     [armedDiscardPile, keyLabels],
   );
 
-  return <BoardKeyboardContext.Provider value={value}>{children}</BoardKeyboardContext.Provider>;
+  return (
+    <BoardKeyboardContext.Provider value={value}>
+      {children}
+      <KeyboardShortcutsDialog keyLabels={keyLabels} onOpenChange={setIsHelpOpen} open={isHelpOpen} />
+    </BoardKeyboardContext.Provider>
+  );
 };

--- a/apps/web/src/contexts/DragContext.tsx
+++ b/apps/web/src/contexts/DragContext.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { FC, ReactNode } from 'react';
-import { DragContext, type DragContextValue, type DragSession } from '@/contexts/useDrag';
+import { DRAG_ACTIVE_ATTRIBUTE, DragContext, type DragContextValue, type DragSession } from '@/contexts/useDrag';
 
 interface DragProviderProps {
   children: ReactNode;
@@ -32,8 +32,8 @@ export const DragProvider: FC<DragProviderProps> = ({ children }) => {
   // while a drag is active.
   useEffect(() => {
     if (session) {
-      document.body.setAttribute('data-drag-active', 'true');
-      return () => document.body.removeAttribute('data-drag-active');
+      document.body.setAttribute(DRAG_ACTIVE_ATTRIBUTE, 'true');
+      return () => document.body.removeAttribute(DRAG_ACTIVE_ATTRIBUTE);
     }
     return undefined;
   }, [session]);

--- a/apps/web/src/contexts/__tests__/BoardKeyboardContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/BoardKeyboardContext.test.tsx
@@ -1,0 +1,212 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Card, GameConfig, GameState, MoveResult, Player } from '@skipbo/game-core';
+
+import { BoardKeyboardProvider } from '@/contexts/BoardKeyboardContext';
+import { useBoardKeyboard } from '@/contexts/useBoardKeyboard';
+
+const FIXTURE_CONFIG: GameConfig = {
+  DECK_SIZE: 162,
+  SKIP_BO_CARDS: 18,
+  CARD_COPIES_PER_RANK: 12,
+  HAND_SIZE: 5,
+  STOCK_SIZE: 30,
+  BUILD_PILES_COUNT: 4,
+  DISCARD_PILES_COUNT: 4,
+  CARD_VALUES_MIN: 1,
+  CARD_VALUES_MAX: 12,
+  CARD_VALUES_SKIP_BO: 0,
+};
+
+const card = (value: number, isSkipBo = false): Card => ({ value, isSkipBo });
+
+const createPlayer = (overrides: Partial<Player> = {}): Player => ({
+  isAI: false,
+  stockPile: [card(11), card(12)],
+  hand: [card(1), card(4), card(5), card(6), card(7)],
+  discardPiles: [[], [], [], []],
+  ...overrides,
+});
+
+const createGameState = (overrides: Partial<GameState> = {}): GameState => ({
+  deck: [],
+  buildPiles: [[], [], [], []],
+  completedBuildPiles: [],
+  players: [createPlayer(), createPlayer({ isAI: true })],
+  currentPlayerIndex: 0,
+  gameIsOver: false,
+  winnerIndex: null,
+  selectedCard: null,
+  message: { code: 'SELECT_CARD' },
+  config: FIXTURE_CONFIG,
+  ...overrides,
+});
+
+const createHandlers = () => ({
+  selectCard: vi.fn() as unknown as (
+    source: 'hand' | 'stock' | 'discard',
+    index: number,
+    discardPileIndex?: number,
+  ) => void,
+  playCard: vi.fn(async () => ({ success: true, message: 'ok' })) as unknown as (
+    buildPileIndex: number,
+  ) => Promise<MoveResult>,
+  discardCard: vi.fn(async () => ({ success: true, message: 'ok' })) as unknown as (
+    discardPileIndex: number,
+  ) => Promise<MoveResult>,
+  clearSelection: vi.fn() as unknown as () => void,
+});
+
+/** Surfaces the armed pile so tests can assert on it without a full board. */
+function ArmedProbe() {
+  const { armedDiscardPile } = useBoardKeyboard();
+  return <span data-testid="armed">{armedDiscardPile === null ? 'none' : String(armedDiscardPile)}</span>;
+}
+
+let handlers = createHandlers();
+
+const mount = (gameState: GameState, enabled = true) => {
+  handlers = createHandlers();
+
+  return render(
+    <BoardKeyboardProvider
+      enabled={enabled}
+      gameState={gameState}
+      selectCard={handlers.selectCard}
+      playCard={handlers.playCard}
+      discardCard={handlers.discardCard}
+      clearSelection={handlers.clearSelection}
+    >
+      <ArmedProbe />
+      <input data-testid="text-field" />
+      <button data-testid="a-button">bouton</button>
+    </BoardKeyboardProvider>,
+  );
+};
+
+const pressOnWindow = (code: string, init: Partial<KeyboardEventInit> = {}) =>
+  fireEvent.keyDown(window, { code, key: '', ...init });
+
+beforeEach(() => {
+  handlers = createHandlers();
+});
+
+describe('BoardKeyboardProvider', () => {
+  it('selects a hand card from its letter key', () => {
+    mount(createGameState());
+
+    pressOnWindow('KeyW');
+
+    expect(handlers.selectCard).toHaveBeenCalledWith('hand', 0, undefined);
+  });
+
+  it('plays the selection onto a build pile from its digit key', () => {
+    mount(createGameState({ selectedCard: { card: card(1), source: 'hand', index: 0 } }));
+
+    pressOnWindow('Digit2');
+
+    expect(handlers.playCard).toHaveBeenCalledWith(0);
+  });
+
+  it('arms a discard without committing it, then commits on Space', () => {
+    mount(createGameState({ selectedCard: { card: card(4), source: 'hand', index: 1 } }));
+
+    pressOnWindow('KeyO');
+
+    expect(handlers.discardCard).not.toHaveBeenCalled();
+    expect(screen.getByTestId('armed').textContent).toBe('2');
+
+    pressOnWindow('Space');
+
+    expect(handlers.discardCard).toHaveBeenCalledWith(2);
+    expect(screen.getByTestId('armed').textContent).toBe('none');
+  });
+
+  it('disarms on Escape without discarding or clearing the selection', () => {
+    mount(createGameState({ selectedCard: { card: card(4), source: 'hand', index: 1 } }));
+
+    pressOnWindow('KeyO');
+    pressOnWindow('Escape');
+
+    expect(screen.getByTestId('armed').textContent).toBe('none');
+    expect(handlers.discardCard).not.toHaveBeenCalled();
+    expect(handlers.clearSelection).not.toHaveBeenCalled();
+  });
+
+  it('clears the selection on a second Escape', () => {
+    mount(createGameState({ selectedCard: { card: card(4), source: 'hand', index: 1 } }));
+
+    pressOnWindow('Escape');
+
+    expect(handlers.clearSelection).toHaveBeenCalled();
+  });
+
+  it('drops a stale arm when the selection changes underneath it', () => {
+    const { rerender } = mount(createGameState({ selectedCard: { card: card(4), source: 'hand', index: 1 } }));
+
+    pressOnWindow('KeyO');
+    expect(screen.getByTestId('armed').textContent).toBe('2');
+
+    // The player reaches for the mouse and picks up their stock card instead.
+    rerender(
+      <BoardKeyboardProvider
+        gameState={createGameState({ selectedCard: { card: card(12), source: 'stock', index: 1 } })}
+        selectCard={handlers.selectCard}
+        playCard={handlers.playCard}
+        discardCard={handlers.discardCard}
+        clearSelection={handlers.clearSelection}
+      >
+        <ArmedProbe />
+      </BoardKeyboardProvider>,
+    );
+
+    expect(screen.getByTestId('armed').textContent).toBe('none');
+  });
+
+  it('ignores keys typed into a text field', () => {
+    mount(createGameState());
+
+    fireEvent.keyDown(screen.getByTestId('text-field'), { code: 'KeyW', key: 'w' });
+
+    expect(handlers.selectCard).not.toHaveBeenCalled();
+  });
+
+  it('leaves Space to a focused button but still claims letters', () => {
+    mount(createGameState());
+    const button = screen.getByTestId('a-button');
+
+    fireEvent.keyDown(button, { code: 'Space', key: ' ' });
+    expect(handlers.discardCard).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(button, { code: 'KeyW', key: 'w' });
+    expect(handlers.selectCard).toHaveBeenCalledWith('hand', 0, undefined);
+  });
+
+  it('ignores modified presses so browser shortcuts survive', () => {
+    mount(createGameState());
+
+    pressOnWindow('Digit2', { metaKey: true });
+    pressOnWindow('KeyW', { ctrlKey: true });
+
+    expect(handlers.playCard).not.toHaveBeenCalled();
+    expect(handlers.selectCard).not.toHaveBeenCalled();
+  });
+
+  it('does nothing at all while disabled', () => {
+    mount(createGameState(), false);
+
+    pressOnWindow('KeyW');
+
+    expect(handlers.selectCard).not.toHaveBeenCalled();
+  });
+
+  it('unbinds the listener on unmount', () => {
+    const { unmount } = mount(createGameState());
+
+    unmount();
+    pressOnWindow('KeyW');
+
+    expect(handlers.selectCard).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/contexts/__tests__/BoardKeyboardContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/BoardKeyboardContext.test.tsx
@@ -2,48 +2,25 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Card, GameConfig, GameState, MoveResult, Player } from '@skipbo/game-core';
+import { initialGameState, type Card, type GameState, type MoveResult } from '@skipbo/game-core';
 
 import { BoardKeyboardProvider } from '@/contexts/BoardKeyboardContext';
 import { CardAnimationProvider } from '@/contexts/CardAnimationContext';
 import { useBoardKeyboard } from '@/contexts/useBoardKeyboard';
 
-const FIXTURE_CONFIG: GameConfig = {
-  DECK_SIZE: 162,
-  SKIP_BO_CARDS: 18,
-  CARD_COPIES_PER_RANK: 12,
-  HAND_SIZE: 5,
-  STOCK_SIZE: 30,
-  BUILD_PILES_COUNT: 4,
-  DISCARD_PILES_COUNT: 4,
-  CARD_VALUES_MIN: 1,
-  CARD_VALUES_MAX: 12,
-  CARD_VALUES_SKIP_BO: 0,
-};
-
 const card = (value: number, isSkipBo = false): Card => ({ value, isSkipBo });
 
-const createPlayer = (overrides: Partial<Player> = {}): Player => ({
-  isAI: false,
-  stockPile: [card(11), card(12)],
-  hand: [card(1), card(4), card(5), card(6), card(7)],
-  discardPiles: [[], [], [], []],
-  ...overrides,
-});
-
-const createGameState = (overrides: Partial<GameState> = {}): GameState => ({
-  deck: [],
-  buildPiles: [[], [], [], []],
-  completedBuildPiles: [],
-  players: [createPlayer(), createPlayer({ isAI: true })],
-  currentPlayerIndex: 0,
-  gameIsOver: false,
-  winnerIndex: null,
-  selectedCard: null,
-  message: { code: 'SELECT_CARD' },
-  config: FIXTURE_CONFIG,
-  ...overrides,
-});
+/** A board on the local player's turn, with a known hand and empty piles. */
+const createGameState = (overrides: Partial<GameState> = {}): GameState => {
+  const state = initialGameState();
+  state.currentPlayerIndex = 0;
+  state.buildPiles = [[], [], [], []];
+  state.selectedCard = null;
+  state.players[0].stockPile = [card(11), card(12)];
+  state.players[0].hand = [card(1), card(4), card(5), card(6), card(7)];
+  state.players[0].discardPiles = [[], [], [], []];
+  return { ...state, ...overrides };
+};
 
 const createHandlers = () => ({
   selectCard: vi.fn() as unknown as (

--- a/apps/web/src/contexts/__tests__/BoardKeyboardContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/BoardKeyboardContext.test.tsx
@@ -1,12 +1,13 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { initialGameState, type Card, type GameState, type MoveResult } from '@skipbo/game-core';
 
 import { BoardKeyboardProvider } from '@/contexts/BoardKeyboardContext';
 import { CardAnimationProvider } from '@/contexts/CardAnimationContext';
 import { useBoardKeyboard } from '@/contexts/useBoardKeyboard';
+import { ACTIVITY_REVEAL_MS, AUTO_REVEAL_DELAY_MS, AUTO_REVEAL_MS, markKeyHintsSeenThisSession } from '@/game/keyHints';
 
 const card = (value: number, isSkipBo = false): Card => ({ value, isSkipBo });
 
@@ -84,8 +85,19 @@ const mount = (gameState: GameState, enabled = true) => {
 const pressOnWindow = (code: string, init: Partial<KeyboardEventInit> = {}) =>
   fireEvent.keyDown(window, { code, key: '', ...init });
 
+const hintsAreVisible = () => document.body.getAttribute('data-key-hints') === 'visible';
+
 beforeEach(() => {
   handlers = createHandlers();
+  sessionStorage.clear();
+  // A desktop pointer, so the unprompted reveal is allowed to fire.
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  document.body.removeAttribute('data-key-hints');
 });
 
 describe('BoardKeyboardProvider', () => {
@@ -196,5 +208,123 @@ describe('BoardKeyboardProvider', () => {
     pressOnWindow('KeyW');
 
     expect(handlers.selectCard).not.toHaveBeenCalled();
+  });
+
+  it('opens the cheat sheet on ?, listing every binding', () => {
+    mount(createGameState());
+
+    fireEvent.keyDown(window, { code: 'Slash', key: '?' });
+
+    const sheet = screen.getByTestId('keyboard-shortcuts-dialog');
+    // 4 build + 1 talon + 5 hand + 4 discard, plus Space, Enter, Escape and Alt.
+    expect(sheet.querySelectorAll('kbd')).toHaveLength(18);
+    expect(screen.getByText('Raccourcis clavier')).toBeTruthy();
+  });
+
+  it('does not act on the board while the cheat sheet is open', () => {
+    mount(createGameState());
+
+    fireEvent.keyDown(window, { code: 'Slash', key: '?' });
+    pressOnWindow('KeyW');
+
+    expect(handlers.selectCard).not.toHaveBeenCalled();
+  });
+});
+
+describe('BoardKeyboardProvider — hint reveal', () => {
+  it('reveals the badges unprompted on the first settled turn, then hides them', () => {
+    vi.useFakeTimers();
+    mount(createGameState());
+
+    expect(hintsAreVisible()).toBe(false);
+
+    // A short delay lets the first interactive frame settle before fading in.
+    act(() => void vi.advanceTimersByTime(AUTO_REVEAL_DELAY_MS));
+    expect(hintsAreVisible()).toBe(true);
+
+    act(() => void vi.advanceTimersByTime(AUTO_REVEAL_MS));
+    expect(hintsAreVisible()).toBe(false);
+  });
+
+  it('fires the unprompted reveal only once per session', () => {
+    markKeyHintsSeenThisSession();
+    vi.useFakeTimers();
+    mount(createGameState());
+
+    act(() => void vi.advanceTimersByTime(AUTO_REVEAL_DELAY_MS + AUTO_REVEAL_MS));
+
+    expect(hintsAreVisible()).toBe(false);
+  });
+
+  it('leaves the badges down on a touch-primary device', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }));
+    vi.useFakeTimers();
+    mount(createGameState());
+
+    act(() => void vi.advanceTimersByTime(AUTO_REVEAL_DELAY_MS));
+
+    expect(hintsAreVisible()).toBe(false);
+  });
+
+  it('waits for the local turn before revealing', () => {
+    vi.useFakeTimers();
+    mount(createGameState({ currentPlayerIndex: 1 }));
+
+    act(() => void vi.advanceTimersByTime(AUTO_REVEAL_DELAY_MS));
+
+    expect(hintsAreVisible()).toBe(false);
+  });
+
+  it('brings the badges back on any key press, then hides them again when idle', () => {
+    markKeyHintsSeenThisSession();
+    vi.useFakeTimers();
+    mount(createGameState());
+
+    // An unbound key still counts — pressing one is exactly the signal that the
+    // player wants the keyboard and does not know the map.
+    act(() => pressOnWindow('KeyK'));
+    expect(hintsAreVisible()).toBe(true);
+
+    act(() => void vi.advanceTimersByTime(ACTIVITY_REVEAL_MS));
+    expect(hintsAreVisible()).toBe(false);
+  });
+
+  it('holds the badges up for as long as Alt is down, without acting on the board', () => {
+    markKeyHintsSeenThisSession();
+    mount(createGameState());
+
+    act(() => void fireEvent.keyDown(window, { code: 'AltLeft', key: 'Alt' }));
+    expect(hintsAreVisible()).toBe(true);
+    expect(handlers.selectCard).not.toHaveBeenCalled();
+
+    // Releasing some other key mid-hold must not drop the badges.
+    act(() => void fireEvent.keyUp(window, { code: 'KeyW', key: 'w' }));
+    expect(hintsAreVisible()).toBe(true);
+
+    act(() => void fireEvent.keyUp(window, { code: 'AltLeft', key: 'Alt' }));
+    expect(hintsAreVisible()).toBe(false);
+  });
+
+  it('releases the Alt hold when the window loses focus', () => {
+    // Alt-Tabbing away never delivers the keyup, which would otherwise strand
+    // the badges on until the next Alt press.
+    markKeyHintsSeenThisSession();
+    mount(createGameState());
+
+    act(() => void fireEvent.keyDown(window, { code: 'AltLeft', key: 'Alt' }));
+    expect(hintsAreVisible()).toBe(true);
+
+    act(() => void fireEvent.blur(window));
+    expect(hintsAreVisible()).toBe(false);
+  });
+
+  it('keeps the badges down entirely while disabled', () => {
+    vi.useFakeTimers();
+    mount(createGameState(), false);
+
+    act(() => void vi.advanceTimersByTime(AUTO_REVEAL_DELAY_MS));
+    act(() => void fireEvent.keyDown(window, { code: 'AltLeft', key: 'Alt' }));
+
+    expect(hintsAreVisible()).toBe(false);
   });
 });

--- a/apps/web/src/contexts/__tests__/BoardKeyboardContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/BoardKeyboardContext.test.tsx
@@ -1,9 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Card, GameConfig, GameState, MoveResult, Player } from '@skipbo/game-core';
 
 import { BoardKeyboardProvider } from '@/contexts/BoardKeyboardContext';
+import { CardAnimationProvider } from '@/contexts/CardAnimationContext';
 import { useBoardKeyboard } from '@/contexts/useBoardKeyboard';
 
 const FIXTURE_CONFIG: GameConfig = {
@@ -66,10 +68,13 @@ function ArmedProbe() {
 
 let handlers = createHandlers();
 
-const mount = (gameState: GameState, enabled = true) => {
-  handlers = createHandlers();
-
-  return render(
+/**
+ * The provider reads the animation queue to decide when the board is settled
+ * enough for the unprompted hint reveal, so it needs a CardAnimationProvider
+ * above it — as it always has in the app (both are mounted under Root).
+ */
+const tree = (gameState: GameState, enabled: boolean, children: ReactNode) => (
+  <CardAnimationProvider>
     <BoardKeyboardProvider
       enabled={enabled}
       gameState={gameState}
@@ -78,10 +83,24 @@ const mount = (gameState: GameState, enabled = true) => {
       discardCard={handlers.discardCard}
       clearSelection={handlers.clearSelection}
     >
-      <ArmedProbe />
-      <input data-testid="text-field" />
-      <button data-testid="a-button">bouton</button>
-    </BoardKeyboardProvider>,
+      {children}
+    </BoardKeyboardProvider>
+  </CardAnimationProvider>
+);
+
+const mount = (gameState: GameState, enabled = true) => {
+  handlers = createHandlers();
+
+  return render(
+    tree(
+      gameState,
+      enabled,
+      <>
+        <ArmedProbe />
+        <input data-testid="text-field" />
+        <button data-testid="a-button">bouton</button>
+      </>,
+    ),
   );
 };
 
@@ -150,15 +169,7 @@ describe('BoardKeyboardProvider', () => {
 
     // The player reaches for the mouse and picks up their stock card instead.
     rerender(
-      <BoardKeyboardProvider
-        gameState={createGameState({ selectedCard: { card: card(12), source: 'stock', index: 1 } })}
-        selectCard={handlers.selectCard}
-        playCard={handlers.playCard}
-        discardCard={handlers.discardCard}
-        clearSelection={handlers.clearSelection}
-      >
-        <ArmedProbe />
-      </BoardKeyboardProvider>,
+      tree(createGameState({ selectedCard: { card: card(12), source: 'stock', index: 1 } }), true, <ArmedProbe />),
     );
 
     expect(screen.getByTestId('armed').textContent).toBe('none');

--- a/apps/web/src/contexts/useBoardKeyboard.ts
+++ b/apps/web/src/contexts/useBoardKeyboard.ts
@@ -1,8 +1,12 @@
 import { createContext, useContext } from 'react';
 
+import { FALLBACK_KEY_LABELS } from '@/game/keyboardActions';
+
 export interface BoardKeyboardContextValue {
   /** Discard pile awaiting a Space confirmation, or `null`. */
   armedDiscardPile: number | null;
+  /** Printed key labels for the player's actual layout, keyed by `code`. */
+  keyLabels: Record<string, string>;
 }
 
 // A no-op default keeps the hook usable in fixtures and unit tests that render a
@@ -11,6 +15,7 @@ export interface BoardKeyboardContextValue {
 // did before the feature existed.
 const NOOP_BOARD_KEYBOARD_CONTEXT: BoardKeyboardContextValue = {
   armedDiscardPile: null,
+  keyLabels: FALLBACK_KEY_LABELS,
 };
 
 export const BoardKeyboardContext = createContext<BoardKeyboardContextValue>(NOOP_BOARD_KEYBOARD_CONTEXT);

--- a/apps/web/src/contexts/useBoardKeyboard.ts
+++ b/apps/web/src/contexts/useBoardKeyboard.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 
-import { FALLBACK_KEY_LABELS } from '@/game/keyboardActions';
+import { FALLBACK_KEY_LABELS, LOCAL_PLAYER_INDEX } from '@/game/keyboardActions';
 
 export interface BoardKeyboardContextValue {
   /** Discard pile awaiting a Space confirmation, or `null`. */
@@ -25,7 +25,6 @@ export const useBoardKeyboard = (): BoardKeyboardContextValue => useContext(Boar
 /** True when this discard pile is the one waiting on a Space confirmation. */
 export const useIsDiscardPileArmed = (pileIndex: number, playerIndex: number): boolean => {
   const { armedDiscardPile } = useBoardKeyboard();
-  // The keyboard only ever drives the local seat, which both boards re-centre
-  // to index 0 — an opponent's pile at the same index must not light up.
-  return playerIndex === 0 && armedDiscardPile === pileIndex;
+  // An opponent's pile at the same index must not light up.
+  return playerIndex === LOCAL_PLAYER_INDEX && armedDiscardPile === pileIndex;
 };

--- a/apps/web/src/contexts/useBoardKeyboard.ts
+++ b/apps/web/src/contexts/useBoardKeyboard.ts
@@ -1,0 +1,26 @@
+import { createContext, useContext } from 'react';
+
+export interface BoardKeyboardContextValue {
+  /** Discard pile awaiting a Space confirmation, or `null`. */
+  armedDiscardPile: number | null;
+}
+
+// A no-op default keeps the hook usable in fixtures and unit tests that render a
+// board without the provider. Like drag, the keyboard layer is additive — with
+// no provider there is simply nothing armed, and every consumer renders as it
+// did before the feature existed.
+const NOOP_BOARD_KEYBOARD_CONTEXT: BoardKeyboardContextValue = {
+  armedDiscardPile: null,
+};
+
+export const BoardKeyboardContext = createContext<BoardKeyboardContextValue>(NOOP_BOARD_KEYBOARD_CONTEXT);
+
+export const useBoardKeyboard = (): BoardKeyboardContextValue => useContext(BoardKeyboardContext);
+
+/** True when this discard pile is the one waiting on a Space confirmation. */
+export const useIsDiscardPileArmed = (pileIndex: number, playerIndex: number): boolean => {
+  const { armedDiscardPile } = useBoardKeyboard();
+  // The keyboard only ever drives the local seat, which both boards re-centre
+  // to index 0 — an opponent's pile at the same index must not light up.
+  return playerIndex === 0 && armedDiscardPile === pileIndex;
+};

--- a/apps/web/src/contexts/useDrag.ts
+++ b/apps/web/src/contexts/useDrag.ts
@@ -17,6 +17,13 @@ export interface DragSession {
   hovered: DragTargetId | null;
 }
 
+/**
+ * Body attribute set for the duration of a drag. CSS uses it to light up drop
+ * targets globally; non-React readers use it to answer "is a drag running?"
+ * without subscribing to the session, which changes on every pointermove.
+ */
+export const DRAG_ACTIVE_ATTRIBUTE = 'data-drag-active';
+
 export interface DragContextValue {
   session: DragSession | null;
   beginDrag: (init: Omit<DragSession, 'hovered'> & { hovered?: DragTargetId | null }) => void;

--- a/apps/web/src/game/__tests__/keyHints.test.ts
+++ b/apps/web/src/game/__tests__/keyHints.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FALLBACK_KEY_LABELS } from '@/game/keyboardActions';
+import {
+  hasKeyboardPointer,
+  hasSeenKeyHintsThisSession,
+  markKeyHintsSeenThisSession,
+  resolveKeyLabels,
+  shouldAutoRevealKeyHints,
+  type AutoRevealInput,
+} from '@/game/keyHints';
+
+const ready: AutoRevealInput = {
+  isEnabled: true,
+  hasSeenThisSession: false,
+  hasKeyboardPointer: true,
+  isLocalTurn: true,
+  isAnimating: false,
+};
+
+describe('shouldAutoRevealKeyHints', () => {
+  it('fires on the first settled local turn', () => {
+    expect(shouldAutoRevealKeyHints(ready)).toBe(true);
+  });
+
+  it('stays down once it has already fired this session', () => {
+    expect(shouldAutoRevealKeyHints({ ...ready, hasSeenThisSession: true })).toBe(false);
+  });
+
+  it('stays down while the keyboard layer is disabled', () => {
+    expect(shouldAutoRevealKeyHints({ ...ready, isEnabled: false })).toBe(false);
+  });
+
+  it('stays down on touch-primary devices', () => {
+    expect(shouldAutoRevealKeyHints({ ...ready, hasKeyboardPointer: false })).toBe(false);
+  });
+
+  it('waits for the local turn rather than showing during the opponent move', () => {
+    expect(shouldAutoRevealKeyHints({ ...ready, isLocalTurn: false })).toBe(false);
+  });
+
+  it('waits for the deal to finish so it does not flash over flying cards', () => {
+    expect(shouldAutoRevealKeyHints({ ...ready, isAnimating: true })).toBe(false);
+  });
+});
+
+describe('session flag', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('starts unset and records once marked', () => {
+    expect(hasSeenKeyHintsThisSession()).toBe(false);
+
+    markKeyHintsSeenThisSession();
+
+    expect(hasSeenKeyHintsThisSession()).toBe(true);
+  });
+
+  it('treats a throwing sessionStorage as "not seen" rather than crashing', () => {
+    // Safari in private mode, and any browser with storage blocked. Swapping the
+    // global out beats spying: the binding may be a jsdom Storage proxy or the
+    // MemoryStorage polyfill from vitest.setup, and a spy does not stick to both.
+    const throwing = {
+      getItem: () => {
+        throw new Error('denied');
+      },
+      setItem: () => {
+        throw new Error('denied');
+      },
+    };
+    vi.stubGlobal('sessionStorage', throwing);
+
+    expect(() => markKeyHintsSeenThisSession()).not.toThrow();
+    expect(hasSeenKeyHintsThisSession()).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('hasKeyboardPointer', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('is true for a fine, hovering pointer', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));
+
+    expect(hasKeyboardPointer()).toBe(true);
+  });
+
+  it('is false for a coarse pointer', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }));
+
+    expect(hasKeyboardPointer()).toBe(false);
+  });
+});
+
+describe('resolveKeyLabels', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, 'keyboard');
+  });
+
+  it('falls back to QWERTY names where the layout API is missing', async () => {
+    await expect(resolveKeyLabels()).resolves.toEqual(FALLBACK_KEY_LABELS);
+  });
+
+  it('uses the real printed labels where the layout API exists', async () => {
+    // An AZERTY layout: the same physical keys, different legends.
+    const layout = new Map([
+      ['KeyQ', 'a'],
+      ['KeyW', 'z'],
+    ]);
+    Reflect.set(navigator, 'keyboard', { getLayoutMap: () => Promise.resolve(layout) });
+
+    const labels = await resolveKeyLabels();
+
+    expect(labels.KeyQ).toBe('a');
+    expect(labels.KeyW).toBe('z');
+    // Codes the layout map doesn't report keep their fallback.
+    expect(labels.Digit2).toBe('2');
+    expect(labels.KeyE).toBe('e');
+  });
+
+  it('falls back when the layout API rejects', async () => {
+    Reflect.set(navigator, 'keyboard', { getLayoutMap: () => Promise.reject(new Error('nope')) });
+
+    await expect(resolveKeyLabels()).resolves.toEqual(FALLBACK_KEY_LABELS);
+  });
+});

--- a/apps/web/src/game/__tests__/keyHints.test.ts
+++ b/apps/web/src/game/__tests__/keyHints.test.ts
@@ -94,6 +94,12 @@ describe('hasKeyboardPointer', () => {
 
     expect(hasKeyboardPointer()).toBe(false);
   });
+
+  it('is false where matchMedia does not exist, rather than throwing', () => {
+    vi.stubGlobal('matchMedia', undefined);
+
+    expect(hasKeyboardPointer()).toBe(false);
+  });
 });
 
 describe('resolveKeyLabels', () => {

--- a/apps/web/src/game/__tests__/keyboardActions.test.ts
+++ b/apps/web/src/game/__tests__/keyboardActions.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from 'vitest';
+
+import { initialGameState, type Card, type GameState } from '@skipbo/game-core';
+
+import { BOUND_CODES, resolveKeyboardIntent, type KeyboardIntent } from '@/game/keyboardActions';
+
+const card = (value: number, isSkipBo = false): Card => ({ value, isSkipBo });
+
+/**
+ * A board on the local player's turn: four empty build piles, a known hand, one
+ * stocked discard pile. Individual tests mutate from here.
+ */
+const boardOnLocalTurn = (): GameState => {
+  const state = initialGameState();
+  state.currentPlayerIndex = 0;
+  state.gameIsOver = false;
+  state.buildPiles = [[], [], [], []];
+  state.selectedCard = null;
+  state.players[0].hand = [card(1), card(7), null, card(3), card(12)];
+  state.players[0].stockPile = [card(4), card(9)];
+  state.players[0].discardPiles = [[card(6)], [], [], []];
+  return state;
+};
+
+const press = (code: string, key = ''): { code: string; key: string } => ({ code, key });
+
+const resolve = (state: GameState, code: string, armed: number | null = null): KeyboardIntent | null =>
+  resolveKeyboardIntent(press(code), state, armed);
+
+describe('resolveKeyboardIntent — selection', () => {
+  it('selects the stock top with q', () => {
+    const state = boardOnLocalTurn();
+
+    expect(resolve(state, 'KeyQ')).toEqual({ kind: 'select', source: 'stock', index: 1 });
+  });
+
+  it('ignores q on an empty stock', () => {
+    const state = boardOnLocalTurn();
+    state.players[0].stockPile = [];
+
+    expect(resolve(state, 'KeyQ')).toBeNull();
+  });
+
+  it('maps w e r t y onto hand slots 0-4', () => {
+    const state = boardOnLocalTurn();
+
+    state.players[0].hand = [card(1), card(7), card(2), card(3), card(12)];
+
+    expect(resolve(state, 'KeyW')).toEqual({ kind: 'select', source: 'hand', index: 0 });
+    expect(resolve(state, 'KeyE')).toEqual({ kind: 'select', source: 'hand', index: 1 });
+    expect(resolve(state, 'KeyR')).toEqual({ kind: 'select', source: 'hand', index: 2 });
+    expect(resolve(state, 'KeyT')).toEqual({ kind: 'select', source: 'hand', index: 3 });
+    expect(resolve(state, 'KeyY')).toEqual({ kind: 'select', source: 'hand', index: 4 });
+  });
+
+  it('ignores a hand key pointing at a null hole', () => {
+    const state = boardOnLocalTurn();
+
+    // Slot 2 is empty; hands keep their length and hold `null` rather than splicing.
+    expect(resolve(state, 'KeyR')).toBeNull();
+  });
+
+  it('selects the top card of a stocked discard pile', () => {
+    const state = boardOnLocalTurn();
+
+    expect(resolve(state, 'KeyU')).toEqual({
+      kind: 'select',
+      source: 'discard',
+      index: 0,
+      discardPileIndex: 0,
+    });
+  });
+
+  it('ignores a discard key on an empty pile when nothing is selected', () => {
+    const state = boardOnLocalTurn();
+
+    expect(resolve(state, 'KeyI')).toBeNull();
+  });
+
+  it('deselects when the already-selected source is pressed again', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(1), source: 'hand', index: 0 };
+
+    expect(resolve(state, 'KeyW')).toEqual({ kind: 'clearSelection' });
+  });
+
+  it('moves the selection when a different hand key is pressed', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(1), source: 'hand', index: 0 };
+
+    expect(resolve(state, 'KeyE')).toEqual({ kind: 'select', source: 'hand', index: 1 });
+  });
+});
+
+describe('resolveKeyboardIntent — build plays', () => {
+  it('plays a legal card immediately, with no confirmation step', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(1), source: 'hand', index: 0 };
+
+    expect(resolve(state, 'Digit2')).toEqual({ kind: 'play', buildPile: 0 });
+  });
+
+  it('maps 2 3 4 5 onto build piles 0-3', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(1), source: 'hand', index: 0 };
+
+    expect(resolve(state, 'Digit3')).toEqual({ kind: 'play', buildPile: 1 });
+    expect(resolve(state, 'Digit4')).toEqual({ kind: 'play', buildPile: 2 });
+    expect(resolve(state, 'Digit5')).toEqual({ kind: 'play', buildPile: 3 });
+  });
+
+  it('ignores a build key when the card is illegal on that pile', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(7), source: 'hand', index: 1 };
+
+    // An empty build pile only accepts a 1 or a Skip-Bo.
+    expect(resolve(state, 'Digit2')).toBeNull();
+  });
+
+  it('plays a Skip-Bo wildcard onto any pile', () => {
+    const state = boardOnLocalTurn();
+    state.players[0].hand = [card(0, true), null, null, null, null];
+    state.selectedCard = { card: card(0, true), source: 'hand', index: 0 };
+
+    expect(resolve(state, 'Digit4')).toEqual({ kind: 'play', buildPile: 2 });
+  });
+
+  it('ignores a build key with nothing selected', () => {
+    const state = boardOnLocalTurn();
+
+    expect(resolve(state, 'Digit2')).toBeNull();
+  });
+});
+
+describe('resolveKeyboardIntent — discard confirmation', () => {
+  it('arms rather than commits when a hand card meets a discard pile', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(7), source: 'hand', index: 1 };
+
+    expect(resolve(state, 'KeyO')).toEqual({ kind: 'armDiscard', discardPile: 2 });
+  });
+
+  it('arms an empty discard pile — an empty pile is still a legal target', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(7), source: 'hand', index: 1 };
+
+    expect(resolve(state, 'KeyI')).toEqual({ kind: 'armDiscard', discardPile: 1 });
+  });
+
+  it('commits the armed pile on Space', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(7), source: 'hand', index: 1 };
+
+    expect(resolve(state, 'Space', 2)).toEqual({ kind: 'confirmDiscard', discardPile: 2 });
+  });
+
+  it('accepts Enter as a confirmation alias', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(7), source: 'hand', index: 1 };
+
+    expect(resolve(state, 'Enter', 0)).toEqual({ kind: 'confirmDiscard', discardPile: 0 });
+  });
+
+  it('ignores Space with nothing armed', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(7), source: 'hand', index: 1 };
+
+    expect(resolve(state, 'Space')).toBeNull();
+  });
+
+  it('refuses a stale arm whose selection is no longer a hand card', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(9), source: 'stock', index: 1 };
+
+    expect(resolve(state, 'Space', 2)).toBeNull();
+  });
+
+  it('refuses a stale arm whose selection was cleared', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = null;
+
+    expect(resolve(state, 'Space', 2)).toBeNull();
+  });
+
+  it('re-arms when a different discard key is pressed', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(7), source: 'hand', index: 1 };
+
+    expect(resolve(state, 'KeyP', 2)).toEqual({ kind: 'armDiscard', discardPile: 3 });
+  });
+});
+
+describe('resolveKeyboardIntent — cancellation', () => {
+  it('disarms first, keeping the selection intact', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(7), source: 'hand', index: 1 };
+
+    expect(resolve(state, 'Escape', 2)).toEqual({ kind: 'disarm' });
+  });
+
+  it('clears the selection when nothing is armed', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(7), source: 'hand', index: 1 };
+
+    expect(resolve(state, 'Escape')).toEqual({ kind: 'clearSelection' });
+  });
+
+  it('is inert with nothing selected and nothing armed', () => {
+    const state = boardOnLocalTurn();
+
+    expect(resolve(state, 'Escape')).toBeNull();
+  });
+});
+
+describe('resolveKeyboardIntent — gating', () => {
+  it('ignores every board key on the opponent turn', () => {
+    const state = boardOnLocalTurn();
+    state.currentPlayerIndex = 1;
+    state.selectedCard = { card: card(1), source: 'hand', index: 0 };
+
+    for (const code of ['KeyQ', 'KeyW', 'KeyU', 'Digit2', 'Space', 'Escape']) {
+      expect(resolve(state, code, 0)).toBeNull();
+    }
+  });
+
+  it('ignores every board key once the game is over', () => {
+    const state = boardOnLocalTurn();
+    state.gameIsOver = true;
+    state.selectedCard = { card: card(1), source: 'hand', index: 0 };
+
+    for (const code of ['KeyQ', 'KeyW', 'KeyU', 'Digit2', 'Space', 'Escape']) {
+      expect(resolve(state, code, 0)).toBeNull();
+    }
+  });
+
+  it('ignores unbound keys, including the deliberately empty 1', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(1), source: 'hand', index: 0 };
+
+    for (const code of ['Digit1', 'Digit6', 'KeyA', 'KeyZ', 'Tab', 'ArrowLeft']) {
+      expect(resolve(state, code)).toBeNull();
+    }
+  });
+
+  it('opens the cheat sheet from ? even on the opponent turn', () => {
+    const state = boardOnLocalTurn();
+    state.currentPlayerIndex = 1;
+
+    expect(resolveKeyboardIntent(press('Slash', '?'), state, null)).toEqual({ kind: 'help' });
+  });
+
+  it('resolves ? by character, so shifted layouts still reach the sheet', () => {
+    const state = boardOnLocalTurn();
+
+    // AZERTY puts `?` on Comma; the code differs, the character does not.
+    expect(resolveKeyboardIntent(press('Comma', '?'), state, null)).toEqual({ kind: 'help' });
+  });
+});
+
+describe('BOUND_CODES', () => {
+  it('covers every code the board claims, so the hook knows what to preventDefault', () => {
+    expect(BOUND_CODES).toEqual(
+      new Set([
+        'KeyQ',
+        'KeyW',
+        'KeyE',
+        'KeyR',
+        'KeyT',
+        'KeyY',
+        'KeyU',
+        'KeyI',
+        'KeyO',
+        'KeyP',
+        'Digit2',
+        'Digit3',
+        'Digit4',
+        'Digit5',
+        'Space',
+        'Enter',
+        'Escape',
+      ]),
+    );
+  });
+
+  it('does not claim Digit1', () => {
+    expect(BOUND_CODES.has('Digit1')).toBe(false);
+  });
+});

--- a/apps/web/src/game/__tests__/keyboardActions.test.ts
+++ b/apps/web/src/game/__tests__/keyboardActions.test.ts
@@ -84,6 +84,51 @@ describe('resolveKeyboardIntent — selection', () => {
     expect(resolve(state, 'KeyW')).toEqual({ kind: 'clearSelection' });
   });
 
+  it('deselects the stock when q is pressed twice', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(9), source: 'stock', index: 1 };
+
+    expect(resolve(state, 'KeyQ')).toEqual({ kind: 'clearSelection' });
+  });
+
+  it('deselects a discard pile when its own key is pressed again', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(6), source: 'discard', index: 0, discardPileIndex: 0 };
+
+    expect(resolve(state, 'KeyU')).toEqual({ kind: 'clearSelection' });
+  });
+
+  it('moves the selection to another discard pile rather than deselecting', () => {
+    const state = boardOnLocalTurn();
+    state.players[0].discardPiles = [[card(6)], [card(2)], [], []];
+    state.selectedCard = { card: card(6), source: 'discard', index: 0, discardPileIndex: 0 };
+
+    expect(resolve(state, 'KeyI')).toEqual({
+      kind: 'select',
+      source: 'discard',
+      index: 0,
+      discardPileIndex: 1,
+    });
+  });
+
+  it('ignores a discard key pointing past the last pile', () => {
+    const state = boardOnLocalTurn();
+    // A board configured with fewer discard piles than there are keys.
+    state.players[0].discardPiles = [[card(6)], []];
+
+    expect(resolve(state, 'KeyO')).toBeNull();
+    expect(resolve(state, 'KeyP')).toBeNull();
+  });
+
+  it('ignores a build key pointing past the last pile', () => {
+    const state = boardOnLocalTurn();
+    state.buildPiles = [[], []];
+    state.selectedCard = { card: card(1), source: 'hand', index: 0 };
+
+    expect(resolve(state, 'Digit4')).toBeNull();
+    expect(resolve(state, 'Digit5')).toBeNull();
+  });
+
   it('moves the selection when a different hand key is pressed', () => {
     const state = boardOnLocalTurn();
     state.selectedCard = { card: card(1), source: 'hand', index: 0 };

--- a/apps/web/src/game/__tests__/keyboardGuards.test.ts
+++ b/apps/web/src/game/__tests__/keyboardGuards.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldIgnoreKeyEvent, type KeyEventEnvironment, type KeyEventFlags } from '@/game/keyboardActions';
+
+const event = (overrides: Partial<KeyEventFlags> = {}): KeyEventFlags => ({
+  code: 'KeyW',
+  repeat: false,
+  ctrlKey: false,
+  metaKey: false,
+  altKey: false,
+  defaultPrevented: false,
+  ...overrides,
+});
+
+const environment = (overrides: Partial<KeyEventEnvironment> = {}): KeyEventEnvironment => ({
+  isTextEntry: false,
+  isActivatable: false,
+  hasOpenOverlay: false,
+  isDragActive: false,
+  hasArmedDiscard: false,
+  ...overrides,
+});
+
+describe('shouldIgnoreKeyEvent', () => {
+  it('lets an ordinary board key through', () => {
+    expect(shouldIgnoreKeyEvent(event(), environment())).toBe(false);
+  });
+
+  it('ignores a press another handler already claimed', () => {
+    expect(shouldIgnoreKeyEvent(event({ defaultPrevented: true }), environment())).toBe(true);
+  });
+
+  it('ignores auto-repeat, so a held key cannot spam moves', () => {
+    expect(shouldIgnoreKeyEvent(event({ repeat: true }), environment())).toBe(true);
+  });
+
+  it.each(['ctrlKey', 'metaKey', 'altKey'] as const)('leaves %s combinations to the browser', (modifier) => {
+    expect(shouldIgnoreKeyEvent(event({ [modifier]: true }), environment())).toBe(true);
+  });
+
+  it('ignores keys typed into a text field', () => {
+    // The lobby room-code input: `u` must type a `u`, not select a discard pile.
+    expect(shouldIgnoreKeyEvent(event({ code: 'KeyU' }), environment({ isTextEntry: true }))).toBe(true);
+  });
+
+  it('ignores keys while a dialog, listbox or menu is open', () => {
+    expect(shouldIgnoreKeyEvent(event(), environment({ hasOpenOverlay: true }))).toBe(true);
+  });
+
+  it('ignores keys during a pointer drag, which owns Escape itself', () => {
+    expect(shouldIgnoreKeyEvent(event({ code: 'Escape' }), environment({ isDragActive: true }))).toBe(true);
+  });
+
+  it('yields Space and Enter to a focused button so it is not activated twice', () => {
+    expect(shouldIgnoreKeyEvent(event({ code: 'Space' }), environment({ isActivatable: true }))).toBe(true);
+    expect(shouldIgnoreKeyEvent(event({ code: 'Enter' }), environment({ isActivatable: true }))).toBe(true);
+  });
+
+  it('claims Space back from a focused card once a discard is armed', () => {
+    // Mouse-click a card (which focuses it), press a discard key, press Space:
+    // the confirmation the player is being prompted for must not be eaten by
+    // the card that happens to still hold focus.
+    expect(
+      shouldIgnoreKeyEvent(event({ code: 'Space' }), environment({ isActivatable: true, hasArmedDiscard: true })),
+    ).toBe(false);
+  });
+
+  it('still defers to the other guards while a discard is armed', () => {
+    expect(
+      shouldIgnoreKeyEvent(event({ code: 'Space' }), environment({ hasArmedDiscard: true, hasOpenOverlay: true })),
+    ).toBe(true);
+    expect(
+      shouldIgnoreKeyEvent(event({ code: 'Space' }), environment({ hasArmedDiscard: true, isTextEntry: true })),
+    ).toBe(true);
+  });
+
+  it('still claims letters and digits while a card or pile has focus', () => {
+    // Having clicked a card is no reason to lose the shortcuts.
+    expect(shouldIgnoreKeyEvent(event({ code: 'KeyW' }), environment({ isActivatable: true }))).toBe(false);
+    expect(shouldIgnoreKeyEvent(event({ code: 'Digit2' }), environment({ isActivatable: true }))).toBe(false);
+    expect(shouldIgnoreKeyEvent(event({ code: 'Escape' }), environment({ isActivatable: true }))).toBe(false);
+  });
+});

--- a/apps/web/src/game/__tests__/pileIntents.test.ts
+++ b/apps/web/src/game/__tests__/pileIntents.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { initialGameState, type Card, type GameState } from '@skipbo/game-core';
+
+import { applyBoardIntent, canDiscardFromSource, resolvePileIntent } from '@/game/pileIntents';
+
+const card = (value: number, isSkipBo = false): Card => ({ value, isSkipBo });
+
+/**
+ * A board on the local human's turn: a known hand with a `null` hole, a stocked
+ * pile, one non-empty discard pile. Individual tests mutate from here.
+ */
+const boardOnLocalTurn = (): GameState => {
+  const state = initialGameState();
+  state.currentPlayerIndex = 0;
+  state.gameIsOver = false;
+  state.buildPiles = [[], [], [], []];
+  state.selectedCard = null;
+  state.players[0].isAI = false;
+  state.players[0].hand = [card(1), card(7), null, card(3), card(12)];
+  state.players[0].stockPile = [card(4), card(9)];
+  state.players[0].discardPiles = [[card(6)], [], [], []];
+  return state;
+};
+
+const selectHand = (state: GameState, index: number): void => {
+  state.selectedCard = { card: state.players[0].hand[index]!, source: 'hand', index };
+};
+
+describe('resolvePileIntent — turn and seat gating', () => {
+  it('is inert on a seat that is not the current player', () => {
+    const state = boardOnLocalTurn();
+    state.currentPlayerIndex = 1;
+
+    expect(resolvePileIntent({ kind: 'stock', playerIndex: 0 }, state)).toBeNull();
+    expect(resolvePileIntent({ kind: 'hand', playerIndex: 0, index: 0 }, state)).toBeNull();
+    expect(resolvePileIntent({ kind: 'discard', playerIndex: 0, index: 0 }, state)).toBeNull();
+  });
+
+  it('is inert on an AI seat even on that seat’s turn', () => {
+    const state = boardOnLocalTurn();
+    state.currentPlayerIndex = 1;
+    state.players[1].isAI = true;
+    state.players[1].stockPile = [card(4)];
+
+    expect(resolvePileIntent({ kind: 'stock', playerIndex: 1 }, state)).toBeNull();
+  });
+
+  it('is inert on a seat index that does not exist', () => {
+    const state = boardOnLocalTurn();
+    state.currentPlayerIndex = 9;
+
+    expect(resolvePileIntent({ kind: 'stock', playerIndex: 9 }, state)).toBeNull();
+  });
+});
+
+describe('resolvePileIntent — stock', () => {
+  it('selects the stock top', () => {
+    expect(resolvePileIntent({ kind: 'stock', playerIndex: 0 }, boardOnLocalTurn())).toEqual({
+      kind: 'select',
+      source: 'stock',
+      index: 1,
+    });
+  });
+
+  it('is inert when the stock is empty (rule 3)', () => {
+    const state = boardOnLocalTurn();
+    state.players[0].stockPile = [];
+
+    expect(resolvePileIntent({ kind: 'stock', playerIndex: 0 }, state)).toBeNull();
+  });
+
+  it('deselects the stock when it is already the selected source (rule 2)', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(9), source: 'stock', index: 1 };
+
+    expect(resolvePileIntent({ kind: 'stock', playerIndex: 0 }, state)).toEqual({ kind: 'clearSelection' });
+  });
+
+  it('switches selection to the stock when another source is selected', () => {
+    const state = boardOnLocalTurn();
+    selectHand(state, 0);
+
+    expect(resolvePileIntent({ kind: 'stock', playerIndex: 0 }, state)).toEqual({
+      kind: 'select',
+      source: 'stock',
+      index: 1,
+    });
+  });
+});
+
+describe('resolvePileIntent — hand', () => {
+  it('selects a filled hand slot', () => {
+    expect(resolvePileIntent({ kind: 'hand', playerIndex: 0, index: 3 }, boardOnLocalTurn())).toEqual({
+      kind: 'select',
+      source: 'hand',
+      index: 3,
+    });
+  });
+
+  it('is inert on a null hole — hands keep their length rather than splicing (rule 3)', () => {
+    expect(resolvePileIntent({ kind: 'hand', playerIndex: 0, index: 2 }, boardOnLocalTurn())).toBeNull();
+  });
+
+  it('is inert on an out-of-range or unparsed index', () => {
+    const state = boardOnLocalTurn();
+
+    expect(resolvePileIntent({ kind: 'hand', playerIndex: 0, index: 99 }, state)).toBeNull();
+    // What a missing `data-card-index` attribute parses to in the click path.
+    expect(resolvePileIntent({ kind: 'hand', playerIndex: 0, index: Number.NaN }, state)).toBeNull();
+  });
+
+  it('deselects the hand card that is already selected (rule 2)', () => {
+    const state = boardOnLocalTurn();
+    selectHand(state, 1);
+
+    expect(resolvePileIntent({ kind: 'hand', playerIndex: 0, index: 1 }, state)).toEqual({ kind: 'clearSelection' });
+  });
+
+  it('moves the selection to a different hand card rather than deselecting', () => {
+    const state = boardOnLocalTurn();
+    selectHand(state, 1);
+
+    expect(resolvePileIntent({ kind: 'hand', playerIndex: 0, index: 0 }, state)).toEqual({
+      kind: 'select',
+      source: 'hand',
+      index: 0,
+    });
+  });
+});
+
+describe('resolvePileIntent — discard', () => {
+  it('is a discard target while a hand card is selected (rule 1)', () => {
+    const state = boardOnLocalTurn();
+    selectHand(state, 0);
+
+    expect(resolvePileIntent({ kind: 'discard', playerIndex: 0, index: 2 }, state)).toEqual({
+      kind: 'discard',
+      discardPile: 2,
+    });
+  });
+
+  it('accepts a hand card onto an empty pile — emptiness only blocks it as a source', () => {
+    const state = boardOnLocalTurn();
+    selectHand(state, 0);
+
+    expect(state.players[0].discardPiles[1]).toHaveLength(0);
+    expect(resolvePileIntent({ kind: 'discard', playerIndex: 0, index: 1 }, state)).toEqual({
+      kind: 'discard',
+      discardPile: 1,
+    });
+  });
+
+  it('is a card source when nothing is selected (rule 1)', () => {
+    expect(resolvePileIntent({ kind: 'discard', playerIndex: 0, index: 0 }, boardOnLocalTurn())).toEqual({
+      kind: 'select',
+      source: 'discard',
+      index: 0,
+      discardPileIndex: 0,
+    });
+  });
+
+  it('selects the top card of a deeper pile', () => {
+    const state = boardOnLocalTurn();
+    state.players[0].discardPiles[0] = [card(6), card(2), card(11)];
+
+    expect(resolvePileIntent({ kind: 'discard', playerIndex: 0, index: 0 }, state)).toEqual({
+      kind: 'select',
+      source: 'discard',
+      index: 2,
+      discardPileIndex: 0,
+    });
+  });
+
+  it('is a card source, not a discard target, when a stock card is selected (rule 1)', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(9), source: 'stock', index: 1 };
+
+    expect(resolvePileIntent({ kind: 'discard', playerIndex: 0, index: 0 }, state)).toEqual({
+      kind: 'select',
+      source: 'discard',
+      index: 0,
+      discardPileIndex: 0,
+    });
+  });
+
+  it('is inert as a source when the pile is empty (rule 3)', () => {
+    expect(resolvePileIntent({ kind: 'discard', playerIndex: 0, index: 1 }, boardOnLocalTurn())).toBeNull();
+  });
+
+  it('is inert on a pile index that does not exist', () => {
+    expect(resolvePileIntent({ kind: 'discard', playerIndex: 0, index: 9 }, boardOnLocalTurn())).toBeNull();
+  });
+
+  it('deselects the discard pile that is already the selected source (rule 2)', () => {
+    const state = boardOnLocalTurn();
+    state.selectedCard = { card: card(6), source: 'discard', index: 0, discardPileIndex: 0 };
+
+    expect(resolvePileIntent({ kind: 'discard', playerIndex: 0, index: 0 }, state)).toEqual({
+      kind: 'clearSelection',
+    });
+  });
+
+  it('moves the selection to another discard pile rather than deselecting', () => {
+    const state = boardOnLocalTurn();
+    state.players[0].discardPiles[3] = [card(8)];
+    state.selectedCard = { card: card(6), source: 'discard', index: 0, discardPileIndex: 0 };
+
+    expect(resolvePileIntent({ kind: 'discard', playerIndex: 0, index: 3 }, state)).toEqual({
+      kind: 'select',
+      source: 'discard',
+      index: 0,
+      discardPileIndex: 3,
+    });
+  });
+});
+
+describe('resolvePileIntent — selection-first invariant', () => {
+  it('never plays a card: pressing a pile only ever selects, deselects or discards', () => {
+    const state = boardOnLocalTurn();
+    const targets = [
+      { kind: 'stock' as const, playerIndex: 0 },
+      ...[0, 1, 2, 3, 4].map((index) => ({ kind: 'hand' as const, playerIndex: 0, index })),
+      ...[0, 1, 2, 3].map((index) => ({ kind: 'discard' as const, playerIndex: 0, index })),
+    ];
+    const selections = [null, { card: card(1), source: 'hand' as const, index: 0 }];
+
+    for (const selectedCard of selections) {
+      state.selectedCard = selectedCard;
+
+      for (const target of targets) {
+        const intent = resolvePileIntent(target, state);
+
+        expect(intent === null || ['select', 'clearSelection', 'discard'].includes(intent.kind)).toBe(true);
+      }
+    }
+  });
+});
+
+describe('canDiscardFromSource', () => {
+  it('allows the hand and nothing else', () => {
+    expect(canDiscardFromSource('hand')).toBe(true);
+    expect(canDiscardFromSource('stock')).toBe(false);
+    expect(canDiscardFromSource('discard')).toBe(false);
+  });
+});
+
+describe('applyBoardIntent', () => {
+  const handlers = () => ({
+    selectCard: vi.fn(),
+    clearSelection: vi.fn(),
+    discardCard: vi.fn().mockResolvedValue({ success: true, message: '' }),
+  });
+
+  it('does nothing for an inert press', () => {
+    const h = handlers();
+    applyBoardIntent(null, h);
+
+    expect(h.selectCard).not.toHaveBeenCalled();
+    expect(h.clearSelection).not.toHaveBeenCalled();
+    expect(h.discardCard).not.toHaveBeenCalled();
+  });
+
+  it('forwards a discard-pile selection with its pile index', () => {
+    const h = handlers();
+    applyBoardIntent({ kind: 'select', source: 'discard', index: 2, discardPileIndex: 3 }, h);
+
+    expect(h.selectCard).toHaveBeenCalledWith('discard', 2, 3);
+  });
+
+  it('forwards a hand selection without a pile index', () => {
+    const h = handlers();
+    applyBoardIntent({ kind: 'select', source: 'hand', index: 1 }, h);
+
+    expect(h.selectCard).toHaveBeenCalledWith('hand', 1, undefined);
+  });
+
+  it('clears the selection', () => {
+    const h = handlers();
+    applyBoardIntent({ kind: 'clearSelection' }, h);
+
+    expect(h.clearSelection).toHaveBeenCalledOnce();
+  });
+
+  it('discards onto the resolved pile', () => {
+    const h = handlers();
+    applyBoardIntent({ kind: 'discard', discardPile: 2 }, h);
+
+    expect(h.discardCard).toHaveBeenCalledWith(2);
+  });
+});

--- a/apps/web/src/game/keyHints.ts
+++ b/apps/web/src/game/keyHints.ts
@@ -1,0 +1,119 @@
+import { FALLBACK_KEY_LABELS } from '@/game/keyboardActions';
+
+/**
+ * Policy for the key-hint badges under each pile.
+ *
+ * Two independent reveals, deliberately kept separate:
+ *
+ * - **Auto-reveal** — unprompted, once per session, on the first turn the player
+ *   can actually act on. It is the only thing that ever appears without being
+ *   asked for, and the only way someone who has never pressed a key finds out
+ *   the shortcuts exist.
+ * - **Activity reveal** — any key press, or holding Alt, brings the badges back
+ *   for as long as the player keeps going. Pressing a key is a declaration that
+ *   they want the keyboard, so it is always answered.
+ *
+ * That split is what lets the auto-reveal be short and one-shot: forgetting the
+ * map costs one keystroke, not a hunt through a menu.
+ */
+
+/** Session-scoped, so the hint returns on the next launch but not next game. */
+const HINT_SHOWN_KEY = 'skipbo_keyboard_hint_shown';
+
+/** How long the unprompted reveal stays up. */
+export const AUTO_REVEAL_MS = 4000;
+
+/** Idle delay after the last key press before the badges fade again. */
+export const ACTIVITY_REVEAL_MS = 3000;
+
+/**
+ * Lets the first interactive frame settle before fading the badges in, so the
+ * reveal doesn't collide with the tail of the opening deal animation.
+ */
+export const AUTO_REVEAL_DELAY_MS = 300;
+
+export const hasSeenKeyHintsThisSession = (): boolean => {
+  try {
+    return sessionStorage.getItem(HINT_SHOWN_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+export const markKeyHintsSeenThisSession = (): void => {
+  try {
+    sessionStorage.setItem(HINT_SHOWN_KEY, 'true');
+  } catch {
+    /* ignore */
+  }
+};
+
+export interface AutoRevealInput {
+  /** The keyboard layer is live (a real game, not the lobby). */
+  isEnabled: boolean;
+  /** The unprompted reveal already fired this session. */
+  hasSeenThisSession: boolean;
+  /** A physical keyboard is plausibly present. */
+  hasKeyboardPointer: boolean;
+  /** It is the local player's turn. */
+  isLocalTurn: boolean;
+  /** Cards are still in flight. */
+  isAnimating: boolean;
+}
+
+/**
+ * Whether to fire the unprompted reveal right now. Pure so the conditions can be
+ * tested without faking a board, a clock and a media query at once.
+ */
+export function shouldAutoRevealKeyHints({
+  isEnabled,
+  hasSeenThisSession,
+  hasKeyboardPointer,
+  isLocalTurn,
+  isAnimating,
+}: AutoRevealInput): boolean {
+  return isEnabled && !hasSeenThisSession && hasKeyboardPointer && isLocalTurn && !isAnimating;
+}
+
+/**
+ * There is no API for "is a keyboard attached", so this is a proxy: a fine
+ * pointer with hover means a mouse or trackpad, which in practice means a
+ * desktop. It misses an iPad with a Magic Keyboard, whose primary pointer is
+ * still coarse — those players reach the hints through Alt or `?` instead.
+ */
+export const hasKeyboardPointer = (): boolean => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+
+  return window.matchMedia('(pointer: fine) and (hover: hover)').matches;
+};
+
+interface KeyboardLayoutCapableNavigator extends Navigator {
+  keyboard?: { getLayoutMap?: () => Promise<Map<string, string>> };
+}
+
+/**
+ * Badge labels for the bound keys. The bindings are positional (`KeyboardEvent.
+ * code`), so on a non-QWERTY layout the printed letters differ from the code
+ * names — an AZERTY player presses the keys labelled `a z e r t y u i o p`. The
+ * KeyboardLayoutMap API reports the real labels where it exists (Chromium only);
+ * elsewhere the QWERTY names are the honest best guess.
+ */
+export const resolveKeyLabels = async (): Promise<Record<string, string>> => {
+  const getLayoutMap = (navigator as KeyboardLayoutCapableNavigator).keyboard?.getLayoutMap;
+
+  if (typeof getLayoutMap !== 'function') {
+    return FALLBACK_KEY_LABELS;
+  }
+
+  try {
+    const layoutMap = await getLayoutMap.call((navigator as KeyboardLayoutCapableNavigator).keyboard);
+
+    return Object.fromEntries(
+      Object.entries(FALLBACK_KEY_LABELS).map(([code, fallback]) => [code, layoutMap.get(code) ?? fallback]),
+    );
+  } catch {
+    return FALLBACK_KEY_LABELS;
+  }
+};

--- a/apps/web/src/game/keyboardActions.ts
+++ b/apps/web/src/game/keyboardActions.ts
@@ -1,0 +1,205 @@
+import { canPlayCard, type GameState } from '@skipbo/game-core';
+
+/**
+ * Desktop keyboard layer. The physical key rows mirror the board rows: the digit
+ * row drives the construction piles (rendered above), the top letter row drives
+ * the local player's own zone (rendered below).
+ *
+ *         2   3   4   5           construction piles 1-4
+ *     q   w e r t y   u i o p     talon | main 1-5 | défausses 1-4
+ *
+ * Bindings are keyed on `KeyboardEvent.code`, never on `key`. The mapping is
+ * positional by design, and `code` is what preserves that shape on non-QWERTY
+ * layouts — AZERTY's top row occupies the same ten physical keys, so the finger
+ * pattern survives even though the printed labels differ. `key` would break it
+ * twice over: AZERTY digits need Shift, and its letters sit elsewhere.
+ */
+export const STOCK_KEY = 'KeyQ';
+export const HAND_KEYS = ['KeyW', 'KeyE', 'KeyR', 'KeyT', 'KeyY'] as const;
+export const DISCARD_KEYS = ['KeyU', 'KeyI', 'KeyO', 'KeyP'] as const;
+export const BUILD_KEYS = ['Digit2', 'Digit3', 'Digit4', 'Digit5'] as const;
+
+/** Every code the board layer claims. Used to decide whether to preventDefault. */
+export const BOUND_CODES: ReadonlySet<string> = new Set<string>([
+  STOCK_KEY,
+  ...HAND_KEYS,
+  ...DISCARD_KEYS,
+  ...BUILD_KEYS,
+  'Space',
+  'Enter',
+  'Escape',
+]);
+
+/**
+ * QWERTY labels for the badges. Overridden at runtime by the real layout via
+ * `navigator.keyboard.getLayoutMap()` where that API exists (Chromium only), so
+ * an AZERTY player sees `a z e r t y u i o p` rather than a confident lie.
+ */
+export const FALLBACK_KEY_LABELS: Readonly<Record<string, string>> = {
+  KeyQ: 'q',
+  KeyW: 'w',
+  KeyE: 'e',
+  KeyR: 'r',
+  KeyT: 't',
+  KeyY: 'y',
+  KeyU: 'u',
+  KeyI: 'i',
+  KeyO: 'o',
+  KeyP: 'p',
+  Digit2: '2',
+  Digit3: '3',
+  Digit4: '4',
+  Digit5: '5',
+};
+
+export type KeyboardIntent =
+  | { kind: 'select'; source: 'hand' | 'stock' | 'discard'; index: number; discardPileIndex?: number }
+  | { kind: 'clearSelection' }
+  | { kind: 'play'; buildPile: number }
+  | { kind: 'armDiscard'; discardPile: number }
+  | { kind: 'confirmDiscard'; discardPile: number }
+  | { kind: 'disarm' }
+  | { kind: 'help' };
+
+export interface KeyboardEventLike {
+  /** Physical key identity — what every board binding matches on. */
+  code: string;
+  /** Layout-dependent character. Only consulted for `?`, which has no stable code. */
+  key: string;
+}
+
+/**
+ * The seat the keyboard drives. Both boards re-centre the local human to index 0
+ * — `GameBoard` renders `players[0]` as the bottom area, and `OnlineGameBoard`
+ * renders `players[0]` locally with every other seat remote — so the keyboard
+ * never needs to know which mode it is in.
+ */
+const LOCAL_PLAYER_INDEX = 0;
+
+/**
+ * Maps a key press onto a board intent, or `null` when the press is not
+ * actionable (wrong turn, empty slot, illegal target, unbound key).
+ *
+ * Pure: no React, no DOM, no side effects. Every legality question is answered
+ * here so the hook stays a thin listener, and so this can be exhaustively tested
+ * without rendering a board.
+ *
+ * @param armedDiscardPile Pile index awaiting a Space confirmation, or `null`.
+ */
+export function resolveKeyboardIntent(
+  event: KeyboardEventLike,
+  gameState: GameState,
+  armedDiscardPile: number | null,
+): KeyboardIntent | null {
+  const { code, key } = event;
+
+  // The cheat sheet is reachable at any time — including on the opponent's turn,
+  // which is exactly when a player has the spare attention to go looking for it.
+  if (key === '?') {
+    return { kind: 'help' };
+  }
+
+  const player = gameState.players[LOCAL_PLAYER_INDEX];
+  const isLocalTurn = gameState.currentPlayerIndex === LOCAL_PLAYER_INDEX && !gameState.gameIsOver;
+
+  if (!player || !isLocalTurn) {
+    return null;
+  }
+
+  const { selectedCard } = gameState;
+
+  if (code === 'Escape') {
+    if (armedDiscardPile !== null) {
+      return { kind: 'disarm' };
+    }
+
+    return selectedCard ? { kind: 'clearSelection' } : null;
+  }
+
+  if (code === 'Space' || code === 'Enter') {
+    // A stale arm — the selection moved on, or was cleared, since the pile was
+    // armed — must not commit a discard the player is no longer looking at.
+    if (armedDiscardPile !== null && selectedCard?.source === 'hand') {
+      return { kind: 'confirmDiscard', discardPile: armedDiscardPile };
+    }
+
+    return null;
+  }
+
+  if (code === STOCK_KEY) {
+    const topIndex = player.stockPile.length - 1;
+
+    if (topIndex < 0) {
+      return null;
+    }
+
+    // Mirrors the click behaviour in StockPile: pressing the pile you already
+    // have selected deselects it.
+    if (selectedCard?.source === 'stock') {
+      return { kind: 'clearSelection' };
+    }
+
+    return { kind: 'select', source: 'stock', index: topIndex };
+  }
+
+  const handIndex = HAND_KEYS.indexOf(code as (typeof HAND_KEYS)[number]);
+
+  if (handIndex >= 0) {
+    // Hands are fixed-length with `null` holes, so an in-range index is not
+    // proof of a card.
+    if (handIndex >= player.hand.length || !player.hand[handIndex]) {
+      return null;
+    }
+
+    if (selectedCard?.source === 'hand' && selectedCard.index === handIndex) {
+      return { kind: 'clearSelection' };
+    }
+
+    return { kind: 'select', source: 'hand', index: handIndex };
+  }
+
+  const discardIndex = DISCARD_KEYS.indexOf(code as (typeof DISCARD_KEYS)[number]);
+
+  if (discardIndex >= 0) {
+    if (discardIndex >= player.discardPiles.length) {
+      return null;
+    }
+
+    // Contextual, exactly as the pile behaves under the mouse: with a hand card
+    // in hand it is a discard target, otherwise it is a card source.
+    if (selectedCard?.source === 'hand') {
+      return { kind: 'armDiscard', discardPile: discardIndex };
+    }
+
+    const pile = player.discardPiles[discardIndex];
+
+    if (pile.length === 0) {
+      return null;
+    }
+
+    if (selectedCard?.source === 'discard' && selectedCard.discardPileIndex === discardIndex) {
+      return { kind: 'clearSelection' };
+    }
+
+    return { kind: 'select', source: 'discard', index: pile.length - 1, discardPileIndex: discardIndex };
+  }
+
+  const buildIndex = BUILD_KEYS.indexOf(code as (typeof BUILD_KEYS)[number]);
+
+  if (buildIndex >= 0) {
+    if (buildIndex >= gameState.buildPiles.length || !selectedCard) {
+      return null;
+    }
+
+    // Build plays commit immediately — they are recoverable and the legal piles
+    // are already lit up by `can-drop`. Only discards, which are irreversible
+    // and end the turn, take the Space confirmation.
+    if (!canPlayCard(selectedCard.card, buildIndex, gameState)) {
+      return null;
+    }
+
+    return { kind: 'play', buildPile: buildIndex };
+  }
+
+  return null;
+}

--- a/apps/web/src/game/keyboardActions.ts
+++ b/apps/web/src/game/keyboardActions.ts
@@ -1,5 +1,7 @@
 import { canPlayCard, type GameState } from '@skipbo/game-core';
 
+import { resolvePileIntent, type BoardIntent } from '@/game/pileIntents';
+
 /**
  * Desktop keyboard layer. The physical key rows mirror the board rows: the digit
  * row drives the construction piles (rendered above), the top letter row drives
@@ -111,14 +113,28 @@ export function shouldIgnoreKeyEvent(event: KeyEventFlags, environment: KeyEvent
   return environment.isActivatable && (event.code === 'Space' || event.code === 'Enter');
 }
 
+/**
+ * Pile presses reuse the board-wide {@link BoardIntent} outcomes; the rest are
+ * keyboard-only. `discard` is deliberately excluded — a click discards on the
+ * spot, but the keyboard arms first and commits on Space (see
+ * {@link toKeyboardIntent}).
+ */
 export type KeyboardIntent =
-  | { kind: 'select'; source: 'hand' | 'stock' | 'discard'; index: number; discardPileIndex?: number }
-  | { kind: 'clearSelection' }
+  | Exclude<BoardIntent, { kind: 'discard' }>
   | { kind: 'play'; buildPile: number }
   | { kind: 'armDiscard'; discardPile: number }
   | { kind: 'confirmDiscard'; discardPile: number }
   | { kind: 'disarm' }
   | { kind: 'help' };
+
+/**
+ * The keyboard's only departure from the click behaviour: an immediate discard
+ * becomes an armed one. A discard is irreversible and ends the turn, and a
+ * mistyped letter is far easier than a mis-aimed click, so it waits for a Space
+ * confirmation. Every other pile outcome passes through untouched.
+ */
+const toKeyboardIntent = (intent: BoardIntent | null): KeyboardIntent | null =>
+  intent?.kind === 'discard' ? { kind: 'armDiscard', discardPile: intent.discardPile } : intent;
 
 export interface KeyboardEventLike {
   /** Physical key identity — what every board binding matches on. */
@@ -177,62 +193,26 @@ export function resolveKeyboardIntent(
     return null;
   }
 
+  // Every pile binding below defers to `resolvePileIntent`, so a key press and a
+  // click on the same pile can no longer disagree.
   if (code === STOCK_KEY) {
-    const topIndex = player.stockPile.length - 1;
-
-    if (topIndex < 0) {
-      return null;
-    }
-
-    // Mirrors the click behaviour in StockPile: pressing the pile you already
-    // have selected deselects it.
-    if (selectedCard?.source === 'stock') {
-      return { kind: 'clearSelection' };
-    }
-
-    return { kind: 'select', source: 'stock', index: topIndex };
+    return toKeyboardIntent(resolvePileIntent({ kind: 'stock', playerIndex: LOCAL_PLAYER_INDEX }, gameState));
   }
 
   const handIndex = HAND_KEYS.indexOf(code);
 
   if (handIndex >= 0) {
-    // Hands are fixed-length with `null` holes, so an in-range index is not
-    // proof of a card.
-    if (handIndex >= player.hand.length || !player.hand[handIndex]) {
-      return null;
-    }
-
-    if (selectedCard?.source === 'hand' && selectedCard.index === handIndex) {
-      return { kind: 'clearSelection' };
-    }
-
-    return { kind: 'select', source: 'hand', index: handIndex };
+    return toKeyboardIntent(
+      resolvePileIntent({ kind: 'hand', playerIndex: LOCAL_PLAYER_INDEX, index: handIndex }, gameState),
+    );
   }
 
   const discardIndex = DISCARD_KEYS.indexOf(code);
 
   if (discardIndex >= 0) {
-    if (discardIndex >= player.discardPiles.length) {
-      return null;
-    }
-
-    // Contextual, exactly as the pile behaves under the mouse: with a hand card
-    // in hand it is a discard target, otherwise it is a card source.
-    if (selectedCard?.source === 'hand') {
-      return { kind: 'armDiscard', discardPile: discardIndex };
-    }
-
-    const pile = player.discardPiles[discardIndex];
-
-    if (pile.length === 0) {
-      return null;
-    }
-
-    if (selectedCard?.source === 'discard' && selectedCard.discardPileIndex === discardIndex) {
-      return { kind: 'clearSelection' };
-    }
-
-    return { kind: 'select', source: 'discard', index: pile.length - 1, discardPileIndex: discardIndex };
+    return toKeyboardIntent(
+      resolvePileIntent({ kind: 'discard', playerIndex: LOCAL_PLAYER_INDEX, index: discardIndex }, gameState),
+    );
   }
 
   const buildIndex = BUILD_KEYS.indexOf(code);

--- a/apps/web/src/game/keyboardActions.ts
+++ b/apps/web/src/game/keyboardActions.ts
@@ -52,6 +52,72 @@ export const FALLBACK_KEY_LABELS: Readonly<Record<string, string>> = {
   Digit5: '5',
 };
 
+/** What the DOM looked like when the key was pressed, reduced to decisions. */
+export interface KeyEventEnvironment {
+  /** Focus sits in an input, textarea, select or contenteditable. */
+  isTextEntry: boolean;
+  /** Focus sits on something Enter/Space would activate (a button or role=button). */
+  isActivatable: boolean;
+  /** A modal dialog, listbox or menu is open. */
+  hasOpenOverlay: boolean;
+  /** A pointer drag is in progress. */
+  isDragActive: boolean;
+  /** A discard is armed and waiting on its Space confirmation. */
+  hasArmedDiscard: boolean;
+}
+
+export interface KeyEventFlags {
+  code: string;
+  repeat: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  defaultPrevented: boolean;
+}
+
+/**
+ * Whether a key press should never reach the board. Split out from the listener
+ * so every guard is directly testable — these are the cases that make a global
+ * key handler misbehave, and each one is a real path in this app.
+ */
+export function shouldIgnoreKeyEvent(event: KeyEventFlags, environment: KeyEventEnvironment): boolean {
+  if (event.defaultPrevented || event.repeat) {
+    return true;
+  }
+
+  // Alt is reserved as the hold-to-reveal gesture for the hint badges, and the
+  // other modifiers belong to the browser (Cmd-1 switches tabs).
+  if (event.ctrlKey || event.metaKey || event.altKey) {
+    return true;
+  }
+
+  // The lobby has a room-code field: `u` must type a `u` there.
+  if (environment.isTextEntry || environment.hasOpenOverlay) {
+    return true;
+  }
+
+  // `useDraggableCard` owns Escape for the duration of a drag.
+  if (environment.isDragActive) {
+    return true;
+  }
+
+  // Cards and piles carry their own Enter/Space handlers for keyboard-only
+  // navigation. When one of them has focus it activates itself, so the board
+  // layer must not also fire — but letters and digits still belong to us, since
+  // having clicked a card is no reason to lose the shortcuts.
+  //
+  // The exception is an armed discard. Clicking a card focuses it (every card is
+  // tabIndex=0), so in a mixed mouse-then-keyboard flow — click a card, press a
+  // discard key, press Space — the focused card would otherwise eat the
+  // confirmation the player is being prompted for. A pending confirmation is
+  // unambiguous, so it outranks the focused element.
+  if (environment.hasArmedDiscard) {
+    return false;
+  }
+
+  return environment.isActivatable && (event.code === 'Space' || event.code === 'Enter');
+}
+
 export type KeyboardIntent =
   | { kind: 'select'; source: 'hand' | 'stock' | 'discard'; index: number; discardPileIndex?: number }
   | { kind: 'clearSelection' }

--- a/apps/web/src/game/keyboardActions.ts
+++ b/apps/web/src/game/keyboardActions.ts
@@ -15,42 +15,35 @@ import { canPlayCard, type GameState } from '@skipbo/game-core';
  * twice over: AZERTY digits need Shift, and its letters sit elsewhere.
  */
 export const STOCK_KEY = 'KeyQ';
-export const HAND_KEYS = ['KeyW', 'KeyE', 'KeyR', 'KeyT', 'KeyY'] as const;
-export const DISCARD_KEYS = ['KeyU', 'KeyI', 'KeyO', 'KeyP'] as const;
-export const BUILD_KEYS = ['Digit2', 'Digit3', 'Digit4', 'Digit5'] as const;
+export const HAND_KEYS: readonly string[] = ['KeyW', 'KeyE', 'KeyR', 'KeyT', 'KeyY'];
+export const DISCARD_KEYS: readonly string[] = ['KeyU', 'KeyI', 'KeyO', 'KeyP'];
+export const BUILD_KEYS: readonly string[] = ['Digit2', 'Digit3', 'Digit4', 'Digit5'];
+
+/** Every pile binding, in board order. The single list new bindings are added to. */
+const BOARD_CODES: readonly string[] = [STOCK_KEY, ...HAND_KEYS, ...DISCARD_KEYS, ...BUILD_KEYS];
 
 /** Every code the board layer claims. Used to decide whether to preventDefault. */
-export const BOUND_CODES: ReadonlySet<string> = new Set<string>([
-  STOCK_KEY,
-  ...HAND_KEYS,
-  ...DISCARD_KEYS,
-  ...BUILD_KEYS,
-  'Space',
-  'Enter',
-  'Escape',
-]);
+export const BOUND_CODES: ReadonlySet<string> = new Set<string>([...BOARD_CODES, 'Space', 'Enter', 'Escape']);
 
 /**
- * QWERTY labels for the badges. Overridden at runtime by the real layout via
+ * QWERTY labels for the badges, derived from the codes themselves so a new
+ * binding is labelled automatically rather than needing a second list kept in
+ * sync. Overridden at runtime by the real layout via
  * `navigator.keyboard.getLayoutMap()` where that API exists (Chromium only), so
  * an AZERTY player sees `a z e r t y u i o p` rather than a confident lie.
  */
-export const FALLBACK_KEY_LABELS: Readonly<Record<string, string>> = {
-  KeyQ: 'q',
-  KeyW: 'w',
-  KeyE: 'e',
-  KeyR: 'r',
-  KeyT: 't',
-  KeyY: 'y',
-  KeyU: 'u',
-  KeyI: 'i',
-  KeyO: 'o',
-  KeyP: 'p',
-  Digit2: '2',
-  Digit3: '3',
-  Digit4: '4',
-  Digit5: '5',
-};
+export const FALLBACK_KEY_LABELS: Readonly<Record<string, string>> = Object.fromEntries(
+  BOARD_CODES.map((code) => [code, code.replace(/^(?:Key|Digit)/, '').toLowerCase()]),
+);
+
+/**
+ * The seat the keyboard drives, and the only one whose piles carry hint badges.
+ * Both boards re-centre the local human here — `GameBoard` renders `players[0]`
+ * as the bottom area, and `OnlineGameBoard` renders `players[0]` locally with
+ * every other seat remote — so nothing downstream needs to know which mode it is
+ * in.
+ */
+export const LOCAL_PLAYER_INDEX = 0;
 
 /** What the DOM looked like when the key was pressed, reduced to decisions. */
 export interface KeyEventEnvironment {
@@ -135,14 +128,6 @@ export interface KeyboardEventLike {
 }
 
 /**
- * The seat the keyboard drives. Both boards re-centre the local human to index 0
- * — `GameBoard` renders `players[0]` as the bottom area, and `OnlineGameBoard`
- * renders `players[0]` locally with every other seat remote — so the keyboard
- * never needs to know which mode it is in.
- */
-const LOCAL_PLAYER_INDEX = 0;
-
-/**
  * Maps a key press onto a board intent, or `null` when the press is not
  * actionable (wrong turn, empty slot, illegal target, unbound key).
  *
@@ -208,7 +193,7 @@ export function resolveKeyboardIntent(
     return { kind: 'select', source: 'stock', index: topIndex };
   }
 
-  const handIndex = HAND_KEYS.indexOf(code as (typeof HAND_KEYS)[number]);
+  const handIndex = HAND_KEYS.indexOf(code);
 
   if (handIndex >= 0) {
     // Hands are fixed-length with `null` holes, so an in-range index is not
@@ -224,7 +209,7 @@ export function resolveKeyboardIntent(
     return { kind: 'select', source: 'hand', index: handIndex };
   }
 
-  const discardIndex = DISCARD_KEYS.indexOf(code as (typeof DISCARD_KEYS)[number]);
+  const discardIndex = DISCARD_KEYS.indexOf(code);
 
   if (discardIndex >= 0) {
     if (discardIndex >= player.discardPiles.length) {
@@ -250,7 +235,7 @@ export function resolveKeyboardIntent(
     return { kind: 'select', source: 'discard', index: pile.length - 1, discardPileIndex: discardIndex };
   }
 
-  const buildIndex = BUILD_KEYS.indexOf(code as (typeof BUILD_KEYS)[number]);
+  const buildIndex = BUILD_KEYS.indexOf(code);
 
   if (buildIndex >= 0) {
     if (buildIndex >= gameState.buildPiles.length || !selectedCard) {

--- a/apps/web/src/game/pileIntents.ts
+++ b/apps/web/src/game/pileIntents.ts
@@ -1,0 +1,157 @@
+import type { GameState, MoveResult, SelectedCard } from '@skipbo/game-core';
+
+/**
+ * The single statement of "what does pressing a pile do".
+ *
+ * Every input method the board offers — click, Enter/Space on a focused pile,
+ * the keyboard shortcut layer — asks the same three questions of the same game
+ * state, and used to answer them separately. The click handlers in
+ * `player-area/` and `resolveKeyboardIntent` had drifted into two copies of one
+ * rule set, each with comments claiming to mirror the other; the rules now live
+ * here and the input layers only translate their own events into a
+ * {@link PilePressTarget} and their own side effects out of a {@link BoardIntent}.
+ *
+ * Pure: no React, no DOM, no dispatch. Everything here is answerable from the
+ * game state alone, which is what keeps it exhaustively testable without a
+ * rendered board.
+ */
+
+/** Where a card is taken from. Derived from the canonical selection so it cannot drift. */
+export type CardSource = SelectedCard['source'];
+
+/** A pile the player pressed, whatever the input method was. */
+export type PilePressTarget =
+  | { kind: 'stock'; playerIndex: number }
+  | { kind: 'hand'; playerIndex: number; index: number }
+  /** `index` is the discard pile, not a card within it. */
+  | { kind: 'discard'; playerIndex: number; index: number };
+
+/**
+ * What that press means. Deliberately smaller than the keyboard's intent union:
+ * these are only the outcomes a *pile press* can have. Build plays, Escape and
+ * the cheat sheet are keyboard-only concerns and stay in `keyboardActions`.
+ */
+export type BoardIntent =
+  | { kind: 'select'; source: CardSource; index: number; discardPileIndex?: number }
+  | { kind: 'clearSelection' }
+  | { kind: 'discard'; discardPile: number };
+
+/**
+ * Whether a card taken from `source` may be discarded. Also answers which
+ * discard piles light up as valid drop targets mid-drag, which is the same
+ * question asked before the card is selected — hence a predicate rather than a
+ * second reading of `selectedCard`.
+ */
+export const canDiscardFromSource = (source: CardSource): boolean => source === 'hand';
+
+/**
+ * Resolves a pile press against the current state, or `null` when the press is
+ * inert (not the player's pile, not their turn, an empty slot, an AI seat).
+ *
+ * The three rules, stated once:
+ *
+ * 1. A discard pile is a *discard target* while a hand card is selected, and a
+ *    *card source* otherwise.
+ * 2. Pressing the source that is already selected deselects it.
+ * 3. An empty slot is inert as a source.
+ *
+ * Rule 1 is what preserves the "selection first, then play or discard"
+ * invariant: this never plays a card, it only ever selects, deselects, or
+ * discards an already-selected one.
+ */
+export function resolvePileIntent(target: PilePressTarget, gameState: GameState): BoardIntent | null {
+  const player = gameState.players[target.playerIndex];
+
+  // An AI seat's piles are rendered but never interactive, and a pile only
+  // responds on its owner's turn. Callers may gate further — the keyboard also
+  // refuses once the game is over — but never less.
+  if (!player || player.isAI || gameState.currentPlayerIndex !== target.playerIndex) {
+    return null;
+  }
+
+  const { selectedCard } = gameState;
+
+  switch (target.kind) {
+    case 'stock': {
+      const topIndex = player.stockPile.length - 1;
+
+      if (topIndex < 0) {
+        return null;
+      }
+
+      // The stock has one pressable card, so its source alone identifies it.
+      if (selectedCard?.source === 'stock') {
+        return { kind: 'clearSelection' };
+      }
+
+      return { kind: 'select', source: 'stock', index: topIndex };
+    }
+
+    case 'hand': {
+      // Hands are fixed-length arrays with `null` holes, so an in-range index
+      // is not proof of a card.
+      if (!player.hand[target.index]) {
+        return null;
+      }
+
+      if (selectedCard?.source === 'hand' && selectedCard.index === target.index) {
+        return { kind: 'clearSelection' };
+      }
+
+      return { kind: 'select', source: 'hand', index: target.index };
+    }
+
+    case 'discard': {
+      const pile = player.discardPiles[target.index];
+
+      if (!pile) {
+        return null;
+      }
+
+      // Rule 1. Checked before the emptiness guard below: an empty pile is a
+      // perfectly good discard target, it is only useless as a source.
+      if (selectedCard && canDiscardFromSource(selectedCard.source)) {
+        return { kind: 'discard', discardPile: target.index };
+      }
+
+      if (pile.length === 0) {
+        return null;
+      }
+
+      if (selectedCard?.source === 'discard' && selectedCard.discardPileIndex === target.index) {
+        return { kind: 'clearSelection' };
+      }
+
+      return { kind: 'select', source: 'discard', index: pile.length - 1, discardPileIndex: target.index };
+    }
+  }
+}
+
+/** The side effects a resolved intent needs. Supplied by whichever hook owns the game. */
+export interface BoardIntentHandlers {
+  selectCard: (source: CardSource, index: number, discardPileIndex?: number) => void;
+  clearSelection: () => void;
+  discardCard: (discardPileIndex: number) => Promise<MoveResult>;
+}
+
+/**
+ * Performs a resolved intent. Takes `null` so callers can pipe
+ * `resolvePileIntent` straight in without repeating the inert-press guard.
+ */
+export function applyBoardIntent(intent: BoardIntent | null, handlers: BoardIntentHandlers): void {
+  if (!intent) {
+    return;
+  }
+
+  switch (intent.kind) {
+    case 'select':
+      handlers.selectCard(intent.source, intent.index, intent.discardPileIndex);
+      return;
+    case 'clearSelection':
+      handlers.clearSelection();
+      return;
+    case 'discard':
+      void handlers.discardCard(intent.discardPile);
+      return;
+  }
+}

--- a/apps/web/src/hooks/useDraggableCard.ts
+++ b/apps/web/src/hooks/useDraggableCard.ts
@@ -3,6 +3,7 @@ import type { PointerEvent as ReactPointerEvent } from 'react';
 import type { Card, GameState, MoveResult } from '@skipbo/game-core';
 import { canPlayCard } from '@skipbo/game-core';
 import { useDrag, type DragSource, type DragTargetId } from '@/contexts/useDrag';
+import { canDiscardFromSource } from '@/game/pileIntents';
 import { setDragCommitOverride } from '@/services/dragCommitOverride';
 
 const DRAG_THRESHOLD_PX = 5;
@@ -24,7 +25,9 @@ const computeValidTargets = (card: Card, source: DragSource, gameState: GameStat
     if (canPlayCard(card, i, gameState)) validBuildPiles.add(i);
   }
   const validDiscardPiles = new Set<number>();
-  if (source.kind === 'hand') {
+  // Same rule the click and keyboard paths resolve through — a discard pile
+  // accepts a hand card and nothing else.
+  if (canDiscardFromSource(source.kind)) {
     for (let i = 0; i < gameState.config.DISCARD_PILES_COUNT; i++) {
       validDiscardPiles.add(i);
     }

--- a/apps/web/src/styles/drag.css
+++ b/apps/web/src/styles/drag.css
@@ -45,34 +45,40 @@
     @apply translate-y-0;
   }
 
-  /* Keyboard: a discard pile armed by u/i/o/p and awaiting its Space
-     confirmation. Louder than can-drop on purpose — a discard is irreversible
-     and ends the turn — and labelled with the key that commits it, so the
-     pending state explains itself without a legend. */
+  /* The two "committed target" states share one treatment — a solid ring and a
+     lift — and differ only in their label:
+
+       .is-drag-over  the pile the dragged card is currently over
+       .is-armed      a discard pile picked by u/i/o/p, awaiting its Space
+                      confirmation. It also pulses, because unlike a drag it
+                      persists with no pointer holding it there. */
+  &.is-drag-over,
   &.is-armed {
     @apply -translate-y-1 shadow-can-drop;
 
     &::after {
-      @apply content-['Espace'] absolute -top-4.5 left-1/2 -translate-x-1/2 z-20 text-xs font-bold uppercase tracking-wide text-drop-indicator;
-    }
-
-    &::before {
-      @apply content-[''] absolute z-10 opacity-100 -inset-1 animate-pulse border-solid border-2 border-drop-indicator;
-      border-radius: calc(var(--card-radius) + 4px);
-    }
-  }
-
-  /* Stronger highlight on the target the dragged card is currently over. */
-  &.is-drag-over {
-    @apply -translate-y-1 shadow-can-drop;
-
-    &::after {
-      @apply content-['↓'] absolute -top-6.25 left-1/2 text-lg -translate-x-1/2 font-bold z-20 animate-bounce text-drop-indicator;
+      @apply absolute left-1/2 -translate-x-1/2 z-20 font-bold text-drop-indicator;
     }
 
     &::before {
       @apply content-[''] absolute z-10 opacity-100 -inset-1 border-solid border-2 border-drop-indicator;
       border-radius: calc(var(--card-radius) + 4px);
+    }
+  }
+
+  &.is-drag-over::after {
+    @apply content-['↓'] -top-6.25 text-lg animate-bounce;
+  }
+
+  /* Labelled with the key that commits it, so the pending state explains itself
+     without a legend. */
+  &.is-armed {
+    &::after {
+      @apply content-['Espace'] -top-4.5 text-xs uppercase tracking-wide;
+    }
+
+    &::before {
+      @apply animate-pulse;
     }
   }
 }

--- a/apps/web/src/styles/drag.css
+++ b/apps/web/src/styles/drag.css
@@ -35,9 +35,13 @@
      drag reads as the "Vide" card itself bouncing. Keep the dashed border
      pulse, drop the translate — for both an EmptyCard that is itself the
      drop-indicator, and any drop-indicator parent (e.g. build-pile,
-     discard-pile-stack) whose only visible content is an EmptyCard. */
+     discard-pile-stack) whose only visible content is an EmptyCard.
+
+     That last case is spelled as "has a placeholder and no real card" rather
+     than `:only-child`: piles also carry a keyboard hint badge, which is a
+     child but not visible content. */
   body[data-drag-active='true'] &.can-drop.empty-card,
-  body[data-drag-active='true'] &.can-drop:has(> .empty-card:only-child) {
+  body[data-drag-active='true'] &.can-drop:has(> .empty-card):not(:has(> .card:not(.empty-card))) {
     @apply translate-y-0;
   }
 

--- a/apps/web/src/styles/drag.css
+++ b/apps/web/src/styles/drag.css
@@ -41,6 +41,23 @@
     @apply translate-y-0;
   }
 
+  /* Keyboard: a discard pile armed by u/i/o/p and awaiting its Space
+     confirmation. Louder than can-drop on purpose — a discard is irreversible
+     and ends the turn — and labelled with the key that commits it, so the
+     pending state explains itself without a legend. */
+  &.is-armed {
+    @apply -translate-y-1 shadow-can-drop;
+
+    &::after {
+      @apply content-['Espace'] absolute -top-4.5 left-1/2 -translate-x-1/2 z-20 text-xs font-bold uppercase tracking-wide text-drop-indicator;
+    }
+
+    &::before {
+      @apply content-[''] absolute z-10 opacity-100 -inset-1 animate-pulse border-solid border-2 border-drop-indicator;
+      border-radius: calc(var(--card-radius) + 4px);
+    }
+  }
+
   /* Stronger highlight on the target the dragged card is currently over. */
   &.is-drag-over {
     @apply -translate-y-1 shadow-can-drop;

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -30,6 +30,12 @@
 
     &:not(.overlap-hand) {
       @apply flex justify-center gap-2.5;
+
+      /* Flat hand: the holder is a plain flex item, so it can be the badge's
+         containing block and the badge just centres itself under the slot. */
+      .card-holder {
+        @apply relative;
+      }
     }
 
     &.overlap-hand {

--- a/apps/web/src/styles/utilities.css
+++ b/apps/web/src/styles/utilities.css
@@ -43,6 +43,12 @@
   }
 }
 
+/* Keycap in the shortcuts cheat sheet. */
+@utility shortcut-key {
+  @apply inline-flex min-w-7 items-center justify-center rounded-md border border-border/70 bg-secondary px-1.5 py-0.5;
+  @apply font-mono text-xs font-semibold uppercase text-secondary-foreground shadow-sm;
+}
+
 @utility vertical-text {
   /* Lock the perpendicular extent so themes can change font-size / font-family
      without shifting cards next to vertical labels. Width is fixed; the box is

--- a/apps/web/src/styles/utilities.css
+++ b/apps/web/src/styles/utilities.css
@@ -19,6 +19,30 @@
   @apply text-sm text-muted-foreground;
 }
 
+/*
+  Keyboard shortcut badge under a pile.
+
+  Deliberately absolute and always mounted: at rest it is transparent and takes
+  no layout, so the board is pixel-identical with the hints down and the
+  committed visual baselines never have to account for it. Visibility is driven
+  by a body attribute the BoardKeyboardProvider toggles, the same way
+  `data-drag-active` lights up drop targets.
+
+  It borrows the version badge's recipe (`text-xs`, muted foreground, tabular
+  figures) rather than its `.app-version-badge` class: 15 of 17 themes leave that
+  class to those utilities, but minecraft and glass restyle it into a chunky
+  footer chip that would be wrong repeated thirteen times across the board. A
+  theme that wants its own treatment can target `.key-hint-badge` directly.
+*/
+@utility key-hint-badge {
+  @apply pointer-events-none absolute left-1/2 -bottom-4 z-30 -translate-x-1/2 text-xs font-semibold uppercase tabular-nums text-muted-foreground/80;
+  @apply opacity-0 transition-opacity duration-200 ease-out motion-reduce:transition-none;
+
+  body[data-key-hints='visible'] & {
+    @apply opacity-100;
+  }
+}
+
 @utility vertical-text {
   /* Lock the perpendicular extent so themes can change font-size / font-family
      without shifting cards next to vertical labels. Width is fixed; the box is

--- a/apps/web/src/styles/utilities.css
+++ b/apps/web/src/styles/utilities.css
@@ -41,6 +41,19 @@
   body[data-key-hints='visible'] & {
     @apply opacity-100;
   }
+
+  /* Fanned hand: the holder must stay static, because the cards inside it are
+     absolutely positioned against `.hand-area` (see layout.css). The badge
+     therefore anchors to `.hand-area` too, and is placed on its slot's column
+     from the index the holder declares — the component never states the fan
+     geometry itself.
+
+     This lives here rather than in layout.css because that file is `@layer
+     base`, and the utilities layer's own `left-1/2` would win over it. */
+  .overlap-hand & {
+    @apply w-card translate-x-0 text-center;
+    left: calc(var(--hand-slot-index) * (var(--card-width) - 10px));
+  }
 }
 
 /* Keycap in the shortcuts cheat sheet. */

--- a/apps/web/src/themes/README.md
+++ b/apps/web/src/themes/README.md
@@ -366,6 +366,15 @@ Tokens read by global code in `styles/*.css` are **universal**. Themes override 
 | `--victory-burst-distance-scale`                        | number      | `0.88` (desktop), `0.72` (mobile)                     | burst geometry                                                 |
 | `--victory-shine-opacity` / `--victory-flyby-opacity`   | number      | `0`                                                   | optional victory layers                                        |
 
+### Keyboard-layer classes
+
+Two utilities in `styles/utilities.css` that themes may restyle but never have to:
+
+| Class             | Where                                | Notes                                                                                                                                                                                                                                                                                                                                                                               |
+| ----------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.key-hint-badge` | under each of the local seat's piles | Borrows the version badge's recipe (`text-xs`, `text-muted-foreground/80`, tabular figures) rather than its `.app-version-badge` class — minecraft and glass restyle that one into a footer chip, which is wrong repeated across the board. Absolute and `opacity-0` at rest; `body[data-key-hints='visible']` fades it in. Must never take layout, or every visual baseline moves. |
+| `.shortcut-key`   | keycaps in the `?` cheat sheet       | `bg-secondary` / `text-secondary-foreground`, so it follows the theme without per-theme work.                                                                                                                                                                                                                                                                                       |
+
 ### Theme-internal tokens (private to one theme)
 
 Each theme can declare additional tokens that are only read inside its own block. Keep a meaningful prefix.
@@ -421,6 +430,7 @@ These all have shown up in past incidents or get debated in review. Skip them.
 - `background:` shorthand on body or anywhere that needs a stable `background-color` (see §4.1).
 - Splitting a theme into multiple sibling `.theme-<name> selector { ... }` rules instead of one nested block (see §3.4).
 - Space-separated multi-layer gradients (see §4.3).
+- Structural selectors (`:only-child`, `:last-child`, `:nth-last-child(… of …)`) that identify a pile's cards by "not the empty placeholder". Say `.card` explicitly. Pile containers hold non-card children too — the keyboard hint badge is one — and a looser set silently hands "topmost card" to one of them. This broke Metro's discard collapse when the badges landed.
 
 ## 11. Readability contract
 

--- a/apps/web/src/themes/metro.css
+++ b/apps/web/src/themes/metro.css
@@ -274,8 +274,11 @@
        the défausses sit between the pioche and the main. */
     @apply isolate;
 
-    /* The topmost real card (numbered or Skip-Bo) wins z-order. */
-    .card:not(.empty-card):nth-last-child(1 of :not(.empty-card)) {
+    /* The topmost real card (numbered or Skip-Bo) wins z-order.
+       The `of` set is scoped to `.card` rather than every non-empty-card child:
+       a pile may also hold non-card children (the keyboard hint badge), and a
+       looser set would hand "topmost" to one of those. */
+    .card:not(.empty-card):nth-last-child(1 of .card:not(.empty-card)) {
       @apply z-11!;
     }
 
@@ -311,7 +314,7 @@
        (card-corner-number is bumped to `visible` from card.css). Skip-Bo
        cards are intentionally excluded so their top sliver remains
        visible when stacked between or beneath numbered cards. */
-    .card.normal-card:not(:nth-last-child(1 of :not(.empty-card))) {
+    .card.normal-card:not(:nth-last-child(1 of .card:not(.empty-card))) {
       @apply pointer-events-none z-10!;
       clip-path: inset(0 calc(100% - var(--metro-corner-tile)) calc(100% - var(--metro-corner-tile)) 0);
 

--- a/apps/web/tests/ui/keyboard-shortcuts.spec.ts
+++ b/apps/web/tests/ui/keyboard-shortcuts.spec.ts
@@ -172,6 +172,35 @@ test.describe('@desktop keyboard shortcuts', () => {
     await expect(hintsUp).toHaveCount(0);
   });
 
+  test('opens the cheat sheet with ?, on either turn', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    await page.keyboard.press('?');
+
+    const sheet = page.getByTestId('keyboard-shortcuts-dialog');
+    await expect(sheet).toBeVisible();
+    await expect(sheet.getByRole('heading', { name: 'Raccourcis clavier' })).toBeVisible();
+
+    // Every binding is listed: 4 build + 1 talon + 5 hand + 4 discard, plus
+    // Space, Enter, Escape and Alt.
+    await expect(sheet.locator('kbd')).toHaveCount(18);
+
+    await page.keyboard.press('Escape');
+    await expect(sheet).toHaveCount(0);
+  });
+
+  test('does not let the board act while the cheat sheet is open', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    await page.keyboard.press('?');
+    await expect(page.getByTestId('keyboard-shortcuts-dialog')).toBeVisible();
+
+    await page.keyboard.press('w');
+    expect(await selectedCardCount(page)).toBe(0);
+  });
+
   test('leaves the board alone while the New Game dialog is open', async ({ page }) => {
     await gotoApp(page);
     await waitForHumanTurn(page);

--- a/apps/web/tests/ui/keyboard-shortcuts.spec.ts
+++ b/apps/web/tests/ui/keyboard-shortcuts.spec.ts
@@ -128,6 +128,50 @@ test.describe('@desktop keyboard shortcuts', () => {
     await expect(humanDiscardPile(page, 0).locator('.card:not(.empty-card)')).toHaveCount(1);
   });
 
+  test('reveals the key badges once unprompted, then puts them away', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    const hintsUp = page.locator('body[data-key-hints="visible"]');
+
+    // The one unprompted reveal, on the first turn the player can act on.
+    await expect(hintsUp).toBeVisible();
+
+    // Every bound key is labelled: talon, five hand slots, four discards,
+    // four build piles.
+    await expect(page.locator('.key-hint-badge')).toHaveCount(14);
+    await expect(humanArea(page).locator('[data-key-hint="KeyQ"]')).toHaveText(/q/i);
+    await expect(page.locator('[data-key-hint="Digit2"]')).toHaveText('2');
+
+    // The opponent's piles are not keyboard-driven, so they carry no badges.
+    await expect(page.getByTestId('ai-player-area').locator('.key-hint-badge')).toHaveCount(0);
+
+    // It drops on its own and leaves the board as it found it.
+    await expect(hintsUp).toHaveCount(0, { timeout: 10_000 });
+  });
+
+  test('brings the badges back on a key press, including an unbound one', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    const hintsUp = page.locator('body[data-key-hints="visible"]');
+    await expect(hintsUp).toHaveCount(0, { timeout: 10_000 });
+
+    // `k` does nothing on the board — which is exactly the player who needs to
+    // be told what the keys are.
+    await page.keyboard.press('k');
+    await expect(hintsUp).toBeVisible();
+    await expect(hintsUp).toHaveCount(0, { timeout: 10_000 });
+
+    // Holding Alt recalls them for as long as it is down, and acts on nothing.
+    await page.keyboard.down('Alt');
+    await expect(hintsUp).toBeVisible();
+    expect(await selectedCardCount(page)).toBe(0);
+
+    await page.keyboard.up('Alt');
+    await expect(hintsUp).toHaveCount(0);
+  });
+
   test('leaves the board alone while the New Game dialog is open', async ({ page }) => {
     await gotoApp(page);
     await waitForHumanTurn(page);

--- a/apps/web/tests/ui/keyboard-shortcuts.spec.ts
+++ b/apps/web/tests/ui/keyboard-shortcuts.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { gotoApp } from './helpers';
+
+/**
+ * The desktop keyboard layer, driven end to end against a real local game.
+ *
+ * Fixtures are deliberately not used: `FixtureApp` wires the board to no-op
+ * callbacks and mounts no keyboard provider, so a fixture would assert nothing.
+ *
+ *         2   3   4   5           construction piles 1-4
+ *     q   w e r t y   u i o p     talon | main 1-5 | défausses 1-4
+ */
+
+const humanArea = (page: Page) => page.getByTestId('human-player-area');
+
+const humanHandCard = (page: Page, index: number) =>
+  humanArea(page).locator(`[data-card-index="${index}"] .card`).first();
+
+const humanDiscardPile = (page: Page, index: number) => humanArea(page).locator(`[data-pile-index="${index}"]`);
+
+const selectedCardCount = (page: Page) => humanArea(page).locator('.card.selected').count();
+
+/** The board settles into the human's turn after the opening deal animates in. */
+const waitForHumanTurn = async (page: Page) => {
+  await expect(humanArea(page)).toHaveAttribute('data-player-state', 'active');
+  await page.waitForFunction(() => document.querySelectorAll('.animated-card').length === 0);
+};
+
+test.describe('@desktop keyboard shortcuts', () => {
+  test('selects a hand card with its letter key and clears it with Escape', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    await page.keyboard.press('w');
+    await expect(humanHandCard(page, 0)).toHaveClass(/selected/);
+
+    await page.keyboard.press('Escape');
+    expect(await selectedCardCount(page)).toBe(0);
+  });
+
+  test('moves the selection between hand slots', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    await page.keyboard.press('e');
+    await expect(humanHandCard(page, 1)).toHaveClass(/selected/);
+
+    await page.keyboard.press('y');
+    await expect(humanHandCard(page, 4)).toHaveClass(/selected/);
+    await expect(humanHandCard(page, 1)).not.toHaveClass(/selected/);
+
+    // Pressing the selected card's own key deselects it, as clicking it does.
+    await page.keyboard.press('y');
+    expect(await selectedCardCount(page)).toBe(0);
+  });
+
+  test('plays onto a build pile immediately, with no confirmation', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    // Skip-Bo wildcards are legal on every build pile, which makes the play
+    // deterministic without depending on the shuffle.
+    await page.getByTestId('debug-fill-hand-skipbo-button').click();
+
+    await page.keyboard.press('w');
+    await expect(humanHandCard(page, 0)).toHaveClass(/selected/);
+
+    await page.keyboard.press('3');
+
+    await expect(page.locator('[data-build-pile="1"] .card')).toBeVisible();
+    expect(await selectedCardCount(page)).toBe(0);
+  });
+
+  test('arms a discard and waits for Space rather than committing', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    await page.keyboard.press('w');
+    await page.keyboard.press('u');
+
+    // Armed, not discarded: the pile is highlighted and still empty.
+    await expect(humanDiscardPile(page, 0)).toHaveAttribute('data-armed', 'true');
+    await expect(humanDiscardPile(page, 0).locator('.card:not(.empty-card)')).toHaveCount(0);
+    await expect(humanHandCard(page, 0)).toHaveClass(/selected/);
+  });
+
+  test('Escape disarms the pile but keeps the card selected', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    await page.keyboard.press('w');
+    await page.keyboard.press('u');
+    await expect(humanDiscardPile(page, 0)).toHaveAttribute('data-armed', 'true');
+
+    await page.keyboard.press('Escape');
+
+    await expect(humanDiscardPile(page, 0)).not.toHaveAttribute('data-armed', 'true');
+    await expect(humanHandCard(page, 0)).toHaveClass(/selected/);
+  });
+
+  test('Space commits the armed discard and ends the turn', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    await page.keyboard.press('w');
+    await page.keyboard.press('u');
+    await page.keyboard.press('Space');
+
+    await expect(humanDiscardPile(page, 0).locator('.card:not(.empty-card)')).toHaveCount(1);
+    // Discarding ends the turn, so the board hands over to the AI.
+    await expect(humanArea(page)).not.toHaveAttribute('data-player-state', 'active');
+  });
+
+  test('confirms even when a mouse click left a card holding focus', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    // Clicking focuses the card (every card is tabIndex=0); the pending
+    // confirmation must still reach the keyboard layer rather than re-toggling
+    // the focused card.
+    await humanHandCard(page, 0).click();
+    await expect(humanHandCard(page, 0)).toHaveClass(/selected/);
+
+    await page.keyboard.press('u');
+    await page.keyboard.press('Space');
+
+    await expect(humanDiscardPile(page, 0).locator('.card:not(.empty-card)')).toHaveCount(1);
+  });
+
+  test('leaves the board alone while the New Game dialog is open', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    await page.getByTestId('new-game-trigger').click();
+    await expect(page.getByTestId('new-game-dialog')).toBeVisible();
+
+    // Board keys typed over an open dialog must not reach the board behind it.
+    await page.keyboard.press('w');
+    await page.keyboard.press('e');
+    expect(await selectedCardCount(page)).toBe(0);
+  });
+
+  test('lets board letters be typed into the room-code field', async ({ page }) => {
+    await gotoApp(page);
+    await waitForHumanTurn(page);
+
+    await page.getByTestId('new-game-trigger').click();
+    await page.getByTestId('new-game-mode-join-online').click();
+
+    const roomCodeField = page.getByTestId('new-game-room-code-input');
+    await roomCodeField.click();
+    await page.keyboard.type('wue');
+
+    // `w`, `u` and `e` are board bindings; inside a text field they are text.
+    await expect(roomCodeField).toHaveValue('WUE');
+    expect(await selectedCardCount(page)).toBe(0);
+  });
+});

--- a/apps/web/tests/ui/online-multiplayer.spec.ts
+++ b/apps/web/tests/ui/online-multiplayer.spec.ts
@@ -41,6 +41,47 @@ test.describe('Online multiplayer', () => {
     await page.getByRole('button', { name: 'Je suis prêt' }).click();
   };
 
+  /**
+   * Creates a room and returns its code, read from the host's own lobby rather
+   * than from `relay.rooms` — these specs run in parallel against one relay, so
+   * "the most recently created room" can belong to a different test.
+   */
+  const createRoom = async (hostPage: Page): Promise<string> => {
+    await openApp(hostPage);
+    await hostPage.getByTestId('new-game-trigger').click();
+    await hostPage.getByTestId('new-game-mode-create-online').click();
+    await hostPage.getByTestId('new-game-create-online').click();
+    await expect(hostPage.getByRole('heading', { name: "Salle d'attente" })).toBeVisible();
+
+    const roomCode = (await hostPage.getByTestId('lobby-room-code').innerText()).trim();
+    expect(roomCode).not.toBe('');
+    return roomCode;
+  };
+
+  const joinRoom = async (guestPage: Page, roomCode: string) => {
+    await openApp(guestPage);
+    await guestPage.getByTestId('new-game-trigger').click();
+    await guestPage.getByTestId('new-game-mode-join-online').click();
+    await guestPage.getByTestId('new-game-room-code-input').fill(roomCode);
+    await guestPage.getByTestId('new-game-join-online').click();
+  };
+
+  /**
+   * Lobby to first move. The mock relay does not shuffle seats, so the host
+   * always plays first once this resolves.
+   */
+  const startTwoSeatGame = async (hostPage: Page, guestPage: Page): Promise<string> => {
+    const roomCode = await createRoom(hostPage);
+    await joinRoom(guestPage, roomCode);
+
+    await readyUp(guestPage, GUEST_NAME);
+    await readyUp(hostPage, HOST_NAME);
+    await hostPage.getByRole('button', { name: 'Démarrer la partie' }).click();
+    await expect(hostPage.getByTestId('game-message')).toHaveText("C'est votre tour");
+
+    return roomCode;
+  };
+
   /** Selects the first hand card and discards it onto the first discard pile. */
   const discardFirstHandCard = async (page: Page): Promise<string> => {
     const localArea = page.getByTestId('human-player-area');
@@ -67,8 +108,9 @@ test.describe('Online multiplayer', () => {
 
       const hostLobby = hostPage.getByRole('dialog', { name: "Salle d'attente" });
       await expect(hostLobby).toBeVisible();
-      const roomCode = [...relay.rooms.keys()].at(-1)!;
-      await expect(hostLobby.getByText(roomCode, { exact: true })).toBeVisible();
+      const roomCode = (await hostLobby.getByTestId('lobby-room-code').innerText()).trim();
+      // The relay really did create this room — the code on screen is not a stub.
+      expect(relay.rooms.has(roomCode)).toBe(true);
 
       // --- Guest joins with the room code ---------------------------------
       await openApp(guestPage);
@@ -127,23 +169,7 @@ test.describe('Online multiplayer', () => {
     const guestPage = await guestContext.newPage();
 
     try {
-      await openApp(hostPage);
-      await hostPage.getByTestId('new-game-trigger').click();
-      await hostPage.getByTestId('new-game-mode-create-online').click();
-      await hostPage.getByTestId('new-game-create-online').click();
-      await expect(hostPage.getByRole('heading', { name: "Salle d'attente" })).toBeVisible();
-      const roomCode = [...relay.rooms.keys()].at(-1)!;
-
-      await openApp(guestPage);
-      await guestPage.getByTestId('new-game-trigger').click();
-      await guestPage.getByTestId('new-game-mode-join-online').click();
-      await guestPage.getByTestId('new-game-room-code-input').fill(roomCode);
-      await guestPage.getByTestId('new-game-join-online').click();
-
-      await readyUp(guestPage, GUEST_NAME);
-      await readyUp(hostPage, HOST_NAME);
-      await hostPage.getByRole('button', { name: 'Démarrer la partie' }).click();
-      await expect(hostPage.getByTestId('game-message')).toHaveText("C'est votre tour");
+      await startTwoSeatGame(hostPage, guestPage);
 
       const hostArea = hostPage.getByTestId('human-player-area');
       const cardValue = (await hostArea.getByLabel('Hand card 1').locator('.card-number').innerText()).trim();
@@ -175,23 +201,7 @@ test.describe('Online multiplayer', () => {
     const firstGuestPage = await guestContext.newPage();
 
     try {
-      await openApp(hostPage);
-      await hostPage.getByTestId('new-game-trigger').click();
-      await hostPage.getByTestId('new-game-mode-create-online').click();
-      await hostPage.getByTestId('new-game-create-online').click();
-      await expect(hostPage.getByRole('heading', { name: "Salle d'attente" })).toBeVisible();
-      const roomCode = [...relay.rooms.keys()].at(-1)!;
-
-      await openApp(firstGuestPage);
-      await firstGuestPage.getByTestId('new-game-trigger').click();
-      await firstGuestPage.getByTestId('new-game-mode-join-online').click();
-      await firstGuestPage.getByTestId('new-game-room-code-input').fill(roomCode);
-      await firstGuestPage.getByTestId('new-game-join-online').click();
-
-      await readyUp(firstGuestPage, GUEST_NAME);
-      await readyUp(hostPage, HOST_NAME);
-      await hostPage.getByRole('button', { name: 'Démarrer la partie' }).click();
-      await expect(hostPage.getByTestId('game-message')).toHaveText("C'est votre tour");
+      const roomCode = await startTwoSeatGame(hostPage, firstGuestPage);
 
       // A latecomer is rejected because the room is no longer WAITING.
       await openApp(page);

--- a/apps/web/tests/ui/online-multiplayer.spec.ts
+++ b/apps/web/tests/ui/online-multiplayer.spec.ts
@@ -120,6 +120,54 @@ test.describe('Online multiplayer', () => {
     }
   });
 
+  test('@desktop the keyboard drives a move that reaches the other seat', async ({ browser }) => {
+    const hostContext = await browser.newContext();
+    const guestContext = await browser.newContext();
+    const hostPage = await hostContext.newPage();
+    const guestPage = await guestContext.newPage();
+
+    try {
+      await openApp(hostPage);
+      await hostPage.getByTestId('new-game-trigger').click();
+      await hostPage.getByTestId('new-game-mode-create-online').click();
+      await hostPage.getByTestId('new-game-create-online').click();
+      await expect(hostPage.getByRole('heading', { name: "Salle d'attente" })).toBeVisible();
+      const roomCode = [...relay.rooms.keys()].at(-1)!;
+
+      await openApp(guestPage);
+      await guestPage.getByTestId('new-game-trigger').click();
+      await guestPage.getByTestId('new-game-mode-join-online').click();
+      await guestPage.getByTestId('new-game-room-code-input').fill(roomCode);
+      await guestPage.getByTestId('new-game-join-online').click();
+
+      await readyUp(guestPage, GUEST_NAME);
+      await readyUp(hostPage, HOST_NAME);
+      await hostPage.getByRole('button', { name: 'Démarrer la partie' }).click();
+      await expect(hostPage.getByTestId('game-message')).toHaveText("C'est votre tour");
+
+      const hostArea = hostPage.getByTestId('human-player-area');
+      const cardValue = (await hostArea.getByLabel('Hand card 1').locator('.card-number').innerText()).trim();
+
+      // Select with `w`, arm défausse 1 with `u`, confirm with Space.
+      await hostPage.keyboard.press('w');
+      await expect(hostPage.getByTestId('game-message')).toHaveText('Sélectionnez une destination');
+
+      await hostPage.keyboard.press('u');
+      await expect(hostArea.locator('[data-pile-index="0"]')).toHaveAttribute('data-armed', 'true');
+
+      await hostPage.keyboard.press('Space');
+
+      // The keyboard move goes through the host runtime and lands on the guest.
+      await expect(hostPage.getByTestId('game-message')).toHaveText(new RegExp(`Tour de ${GUEST_NAME}`));
+      await expect(
+        guestPage.locator('[data-testid="ai-player-area"] .discard-pile-stack[data-pile-index="0"] .card-number'),
+      ).toHaveText(cardValue);
+    } finally {
+      await hostContext.close();
+      await guestContext.close();
+    }
+  });
+
   test('@desktop guest cannot join a started game', async ({ browser, page }) => {
     const hostContext = await browser.newContext();
     const guestContext = await browser.newContext();

--- a/docs/runbooks/change-checklists.md
+++ b/docs/runbooks/change-checklists.md
@@ -43,7 +43,8 @@
 - Refresh visual baselines with `pnpm test:visual:update` when the visual change is intentional.
 - Update [../architecture/runtime-invariants.md](../architecture/runtime-invariants.md) if player-order or animation ownership assumptions changed.
 - Adding a child to a pile container (`.discard-pile-stack`, `.build-pile`) can retarget structural CSS that identifies the pile's cards — scope those selectors to `.card` and run the full `pnpm test:visual`, not just theme-contract.
-- New board input paths belong in the pure resolvers (`src/game/keyboardActions.ts` for keyboard) so they clear `codecov/patch` without a render test, and must go through the existing `selectCard` → `playCard`/`discardCard` callbacks rather than dispatching directly.
+- New board input paths belong in the pure resolvers (`src/game/pileIntents.ts` for what a pile press means, `src/game/keyboardActions.ts` for the key-to-pile mapping) so they clear `codecov/patch` without a render test, and must go through the existing `selectCard` → `playCard`/`discardCard` callbacks rather than dispatching directly.
+- Changing what pressing a pile does means changing `resolvePileIntent` only. A new input method translates its event into a `PilePressTarget` and performs the returned `BoardIntent`; it must not restate the select / deselect / discard rules — restating them per input method is exactly how the click and keyboard paths drifted before.
 
 ## Realtime Protocol Checklist
 

--- a/docs/runbooks/change-checklists.md
+++ b/docs/runbooks/change-checklists.md
@@ -42,6 +42,8 @@
 - Run the desktop theme-contract suite for shared board or fixture-visible layout changes.
 - Refresh visual baselines with `pnpm test:visual:update` when the visual change is intentional.
 - Update [../architecture/runtime-invariants.md](../architecture/runtime-invariants.md) if player-order or animation ownership assumptions changed.
+- Adding a child to a pile container (`.discard-pile-stack`, `.build-pile`) can retarget structural CSS that identifies the pile's cards — scope those selectors to `.card` and run the full `pnpm test:visual`, not just theme-contract.
+- New board input paths belong in the pure resolvers (`src/game/keyboardActions.ts` for keyboard) so they clear `codecov/patch` without a render test, and must go through the existing `selectCard` → `playCard`/`discardCard` callbacks rather than dispatching directly.
 
 ## Realtime Protocol Checklist
 


### PR DESCRIPTION
Adds a desktop keyboard layer. The bindings are **positional** — the digit row drives the construction piles, the top letter row the local player's own zone, mirroring how the board is laid out on screen.

```
        2   3   4   5           construction piles 1-4
    q   w e r t y   u i o p     talon | main 1-5 | défausses 1-4

Space / Enter  confirm an armed discard
Esc            cancel
Alt (held)     show the key badges
?              cheat sheet
```

Build plays commit on the keypress — they're recoverable and the legal piles are already lit. Discards, which are irreversible and end the turn, arm the pile and wait for `Space`. Works in local and online games.

## Hint badges

Two independent reveals. The unprompted one fires **once per session** on the first settled turn and fades after 4s — the only thing that ever appears unasked, and the only way a player who has never pressed a key learns the layer exists. Any keypress (bound or not) or a held `Alt` brings them back, so forgetting the map costs one keystroke rather than a hunt through a menu.

Session-scoped in `sessionStorage` rather than a module variable, because the app reloads itself to apply PWA updates — a module variable would resurrect the hint mid-game.

## Notes for review

**Bindings key on `event.code`, never `event.key`.** The layout is positional by design, and `code` is what preserves the finger pattern on AZERTY, where digits need Shift and letters sit elsewhere. `?` is the one exception (no stable code across layouts). Badge labels come from `navigator.keyboard.getLayoutMap()` where it exists, so an AZERTY player sees their own legends rather than a confident lie.

**Mounted per screen, not inside the board.** `GameBoard` is also rendered by `OnlineGameBoard` and again as an inert lobby placeholder with stub callbacks, so binding from in there would double-register. Online it is gated on `hasGameView`, not `roomStatus` — the online hook returns a seat-capacity placeholder until the first view arrives.

**Two structural CSS selectors changed.** `metro.css` and `drag.css` identified "the pile's cards" as "children that aren't the empty placeholder", which silently captured the new badge — Metro handed "topmost card" to it and collapsed the real one to its corner tile. Both now name `.card` explicitly. The trap is recorded in `AGENTS.md`, the UI checklist and the theme anti-patterns.

**Zero visual baseline changes.** The badges are absolutely positioned and transparent at rest, so the board is pixel-identical with hints down.

## Also fixed in passing

The three online multiplayer tests each read the room code as "the last key in `relay.rooms`", but they run in parallel against one relay — a test could join another test's room. Each now reads the code from its own host's lobby.

## Validation

- 535 unit tests (game-core, skipbo-runtime, web)
- 203 E2E incl. a new `keyboard-shortcuts.spec.ts` and a two-browser test driving a keyboard discard through the host runtime to the other seat
- 203 visual regression, both projects, no baseline changes
- `pnpm lint`, `pnpm typecheck`, `pnpm format`

## Open questions

- The `?` sheet has no visible affordance — discovery runs badges → Alt → `?`. Happy to add a small toolbar button if preferred.
- Every keypress re-shows the badges, so for a fast player they stay lit through most of a turn. One-line change to "first keypress of each turn" if that reads as clutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)