### PR TITLE
fix(web): relay end-game stats before closing the room

### DIFF
--- a/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
+++ b/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
@@ -1839,7 +1839,7 @@ describe('useOnlineSkipBoGame', () => {
     /** Drive a host session up to a finished game (via the debug win action). */
     const renderFinishedHostGame = async () => {
       const session = createHostSession();
-      const { result } = renderHook(() => useOnlineSkipBoGame(session));
+      const { result, unmount } = renderHook(() => useOnlineSkipBoGame(session));
 
       await act(async () => {
         vi.runOnlyPendingTimers();
@@ -1858,12 +1858,20 @@ describe('useOnlineSkipBoGame', () => {
         await Promise.resolve();
       });
 
+      // A move that does not end the game: authority is pushed with no endGame
+      // in sight, so the deferral only kicks in on the winning move below.
+      await act(async () => {
+        result.current.debugFillBuildPile(0);
+        await Promise.resolve();
+      });
+      expect(parseSent(socket).some((m) => m.type === 'endGame')).toBe(false);
+
       await act(async () => {
         result.current.debugWin();
         await Promise.resolve();
       });
 
-      return { result, socket };
+      return { result, socket, unmount };
     };
 
     it('holds endGame back until the record has been relayed', async () => {
@@ -1906,6 +1914,18 @@ describe('useOnlineSkipBoGame', () => {
       });
 
       expect(parseSent(socket).filter((m) => m.type === 'endGame')).toHaveLength(1);
+    });
+
+    it('cancels the pending grace timer when the screen unmounts', async () => {
+      const { socket, unmount } = await renderFinishedHostGame();
+
+      unmount();
+      await act(async () => {
+        vi.advanceTimersByTime(END_GAME_STATS_GRACE_MS + 50);
+      });
+
+      // The socket is gone with the screen; the timer must not outlive it.
+      expect(parseSent(socket).some((m) => m.type === 'endGame')).toBe(false);
     });
   });
 

--- a/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
+++ b/apps/web/src/hooks/__tests__/useOnlineSkipBoGame.test.tsx
@@ -5,7 +5,7 @@ import { gameReducer, initialGameState, type Card, type GameState } from '@skipb
 import type { CreateRoomResponse, LobbySeatInfo, RoomSummary, ServerMessage } from '@klbsjpolp/realtime-core';
 import { serializeClientGameView, type ClientGameView } from '@skipbo/skipbo-runtime';
 
-import { inferOpponentTransition, useOnlineSkipBoGame } from '@/hooks/useOnlineSkipBoGame';
+import { END_GAME_STATS_GRACE_MS, inferOpponentTransition, useOnlineSkipBoGame } from '@/hooks/useOnlineSkipBoGame';
 import { WEBSOCKET_PING_INTERVAL_MS } from '@/config/timing';
 import type { GameStatsRecord } from '@/monitoring/gameStats';
 
@@ -1834,6 +1834,78 @@ describe('useOnlineSkipBoGame', () => {
       });
 
       expect(result.current.receivedGameStats).toBeNull();
+    });
+
+    /** Drive a host session up to a finished game (via the debug win action). */
+    const renderFinishedHostGame = async () => {
+      const session = createHostSession();
+      const { result } = renderHook(() => useOnlineSkipBoGame(session));
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+      });
+
+      const socket = MockWebSocket.instances[0];
+      await act(async () => {
+        socket.open();
+        socket.emitMessage({ type: 'presence', room: waitingRoomSummary([0, 1], 1) });
+        socket.emitMessage({
+          type: 'gameStarted',
+          activeSeatIndices: [0, 1],
+          currentSeatIndex: 0,
+          gameConfig: { stockSize: 10 },
+        });
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        result.current.debugWin();
+        await Promise.resolve();
+      });
+
+      return { result, socket };
+    };
+
+    it('holds endGame back until the record has been relayed', async () => {
+      const { result, socket } = await renderFinishedHostGame();
+
+      // A finished room rejects relays, so endGame must not go out yet.
+      expect(parseSent(socket).some((m) => m.type === 'endGame')).toBe(false);
+
+      act(() => {
+        result.current.broadcastGameStats(statsRecord);
+      });
+
+      const sent = parseSent(socket);
+      const statsIndex = sent.findIndex((m) => m.type === 'relay' && m.kind === 'event');
+      const endGameIndex = sent.findIndex((m) => m.type === 'endGame');
+      expect(statsIndex).toBeGreaterThanOrEqual(0);
+      expect(endGameIndex).toBeGreaterThan(statsIndex);
+    });
+
+    it('sends endGame anyway when no record arrives within the grace delay', async () => {
+      const { socket } = await renderFinishedHostGame();
+
+      expect(parseSent(socket).some((m) => m.type === 'endGame')).toBe(false);
+
+      await act(async () => {
+        vi.advanceTimersByTime(END_GAME_STATS_GRACE_MS + 50);
+      });
+
+      expect(parseSent(socket).filter((m) => m.type === 'endGame')).toHaveLength(1);
+    });
+
+    it('sends endGame exactly once even if the record arrives after the grace delay', async () => {
+      const { result, socket } = await renderFinishedHostGame();
+
+      await act(async () => {
+        vi.advanceTimersByTime(END_GAME_STATS_GRACE_MS + 50);
+      });
+      act(() => {
+        result.current.broadcastGameStats(statsRecord);
+      });
+
+      expect(parseSent(socket).filter((m) => m.type === 'endGame')).toHaveLength(1);
     });
   });
 

--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { canPlayCard, type GameAction, type MoveResult } from '@skipbo/game-core';
 
@@ -33,6 +33,13 @@ import { useOnlineConnection } from '@/hooks/useOnlineSkipBoGame/useOnlineConnec
 
 export { inferOpponentTransition, type OpponentTransition };
 
+/**
+ * How long the host waits for its own end-of-game stats record before sending
+ * `endGame` anyway. The record normally arrives on the very next render; this
+ * is only the safety net that guarantees the room reaches FINISHED.
+ */
+export const END_GAME_STATS_GRACE_MS = 3000;
+
 export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
   const [view, setView] = useState<ClientGameView | null>(null);
   // Latest room/lobby summary. During WAITING there is no game view yet, so the
@@ -56,6 +63,12 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
   const activeSeatIndicesRef = useRef<number[]>([]);
   const roomMetaRef = useRef<HostRoomMeta | null>(null);
   const lastBroadcastTurnRef = useRef<number | null>(null);
+  // Host only: the `endGame` message held back until the end-of-game stats have
+  // been relayed (a finished room rejects relays), plus the fallback timer that
+  // sends it anyway if the record never materializes.
+  const pendingEndGameRef = useRef<{ winnerSeatIndex: number | null } | null>(null);
+  const endGameTimeoutRef = useRef<number | null>(null);
+  const endGameSentRef = useRef(false);
   // Duration (ms) of the local play/discard animation that the user just
   // started. When that action ends the turn, the next player's draw animation
   // is held back by this much so the acting player sees the same sequence
@@ -106,16 +119,44 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     [sendRaw],
   );
 
+  // Send the deferred `endGame` (see `pushAuthority`), at most once per game.
+  const flushEndGame = useCallback((): void => {
+    const pending = pendingEndGameRef.current;
+    if (!pending) return;
+    pendingEndGameRef.current = null;
+    if (endGameTimeoutRef.current !== null) {
+      window.clearTimeout(endGameTimeoutRef.current);
+      endGameTimeoutRef.current = null;
+    }
+    endGameSentRef.current = true;
+    sendRaw({ type: 'endGame', winnerSeatIndex: pending.winnerSeatIndex });
+  }, [sendRaw]);
+
+  useEffect(
+    () => () => {
+      if (endGameTimeoutRef.current !== null) {
+        window.clearTimeout(endGameTimeoutRef.current);
+        endGameTimeoutRef.current = null;
+      }
+    },
+    [],
+  );
+
   // The host computes end-of-game stats from its own state — no network delay,
   // no risk of missing an intermediate view — so it is the only trustworthy
   // source. Broadcast the finalized record to every other seat (defaults to
   // all other seats) so guests display and persist the same numbers instead of
   // reconstructing an approximation from asynchronously-delivered views.
+  //
+  // This must reach the guests *before* the room turns FINISHED: the relay
+  // server rejects every relay in a finished room (409), so the deferred
+  // `endGame` is only released once the record is on the wire.
   const broadcastGameStats = useCallback(
     (record: GameStatsRecord): void => {
       sendRelay('event', { gameStats: record });
+      flushEndGame();
     },
-    [sendRelay],
+    [flushEndGame, sendRelay],
   );
 
   // ---------------------------------------------------------------------------
@@ -280,10 +321,22 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     };
     sendRaw({ type: 'snapshot', payload: snapshot });
 
-    if (host.gameIsOver) {
-      sendRaw({ type: 'endGame', winnerSeatIndex: host.winnerSeatIndex() });
+    if (host.gameIsOver && !endGameSentRef.current && pendingEndGameRef.current === null) {
+      // Hold `endGame` back until the stats record has been relayed: the server
+      // marks the room FINISHED on `endGame` and then rejects every relay, so
+      // sending it here would strand the guests without the final statistics.
+      // The record is produced one render later (the recorder observes the view
+      // we just ingested), hence the deferral rather than an ordering swap.
+      // The timer is the safety net for a game that ends without a record
+      // (e.g. the recorder never opened one after a host reconnect) — the room
+      // must always reach FINISHED.
+      pendingEndGameRef.current = { winnerSeatIndex: host.winnerSeatIndex() };
+      endGameTimeoutRef.current = window.setTimeout(() => {
+        endGameTimeoutRef.current = null;
+        flushEndGame();
+      }, END_GAME_STATS_GRACE_MS);
     }
-  }, [sendRaw, sendRelay, session]);
+  }, [flushEndGame, sendRaw, sendRelay, session]);
 
   const applyHostAction = useCallback(
     (action: GameAction): void => {

--- a/apps/web/tests/mock-relay/mockRelayServer.ts
+++ b/apps/web/tests/mock-relay/mockRelayServer.ts
@@ -296,6 +296,14 @@ export const startMockRelayServer = async (options: MockRelayServerOptions = {})
         }
         case 'relay': {
           const kind: RelayKind = message.kind;
+          if (room.status !== 'ACTIVE') {
+            // Faithful to the real relay: a room that is not ACTIVE (notably a
+            // FINISHED one) rejects every relay, so anything the host still
+            // wants to hand out — e.g. the end-of-game stats record — has to
+            // go out before `endGame`.
+            send(socket, { type: 'actionRejected', code: 'invalid_state', reason: 'La partie n’est pas active.' });
+            return;
+          }
           if (kind === 'move' && seatIndex !== room.currentSeatIndex) {
             send(socket, { type: 'actionRejected', code: 'not_your_turn', reason: 'Ce n’est pas votre tour.' });
             return;

--- a/apps/web/tests/ui/online-multiplayer.spec.ts
+++ b/apps/web/tests/ui/online-multiplayer.spec.ts
@@ -156,6 +156,23 @@ test.describe('Online multiplayer', () => {
       await hostPage.getByTestId('debug-win-button').click();
       await expect(hostPage.getByTestId('game-message')).toHaveText('Vous avez gagné !');
       await expect(guestPage.getByTestId('game-message')).toHaveText(`${HOST_NAME} a gagné.`);
+
+      // --- Both seats see the host's statistics for the finished game -------
+      // The record is computed by the host and relayed; the guest must get it
+      // before the room turns FINISHED (a finished room rejects every relay).
+      for (const page of [hostPage, guestPage]) {
+        await page.getByTestId('game-stats-button').click();
+        const dialog = page.getByTestId('game-stats-dialog');
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByTestId('game-stats-players').locator('tbody tr')).toHaveCount(2);
+        await expect(dialog).toContainText(HOST_NAME);
+        await expect(dialog).toContainText(GUEST_NAME);
+      }
+
+      // Same numbers on both seats: turns are what the host counted.
+      const readTurns = (page: Page) =>
+        page.getByTestId('game-stats-players').locator('tbody tr td:nth-child(2)').allInnerTexts();
+      expect(await readTurns(guestPage)).toEqual(await readTurns(hostPage));
     } finally {
       await hostContext.close();
       await guestContext.close();

--- a/docs/architecture/online-multiplayer.md
+++ b/docs/architecture/online-multiplayer.md
@@ -49,6 +49,7 @@ decision is recorded in [decision-log.md](decision-log.md).
 - On `startGame` the server shuffles the connected seats into `activeSeatIndices`, sets the first turn, and broadcasts `gameStarted`. The host then builds the game and pushes the first views.
 - Turn order follows the locked active-seat list; the host advances it with `setTurn`.
 - The host disconnecting during `ACTIVE` pauses the game under the disconnect grace; on return it rebuilds from its `snapshotRestore` blob and re-pushes views. A guest reconnecting requests a resync from the host.
+- **`endGame` closes the relay.** The server flips the room to `FINISHED` and rejects every subsequent relay (409), so anything the host still owes the guests must be on the wire first. The host therefore holds `endGame` back until it has relayed the end-of-game statistics record (`END_GAME_STATS_GRACE_MS` is the fallback that sends it anyway, so the room always reaches `FINISHED`).
 
 ## Redaction Model
 


### PR DESCRIPTION
## Problème

En ligne, seuls certains sièges voyaient les statistiques de fin de partie — en pratique, personne d'autre que l'hôte.

L'hôte calcule le bilan et le diffuse déjà (`broadcastGameStats` → `relay { kind: 'event', payload: { gameStats } }`), mais il envoie `endGame` **avant** que le record ne soit prêt (celui-ci est produit au rendu suivant, quand le recorder observe la vue finale). Or le serveur relais rejette tout `relay` dès que la salle est `FINISHED` :

```ts
// realtime-infra — roomService.ts
if (room.status === 'FINISHED') {
  throw new ClientError('Room is finished', 409);
}
```

La diffusion partait donc dans une salle déjà close et n'atteignait jamais les invités. Le mock relay, lui, acceptait les relais après `FINISHED`, d'où l'absence de détection en test.

## Correctif

- `useOnlineSkipBoGame` : `endGame` est retenu jusqu'à ce que le record de stats ait été relayé. `END_GAME_STATS_GRACE_MS` (3 s) est le filet de sécurité qui l'envoie quand même, pour qu'une partie sans record (reconnexion de l'hôte, par ex.) atteigne toujours `FINISHED`. Envoi garanti unique.
- `mockRelayServer` : rejette les relais hors `ACTIVE`, fidèlement au vrai serveur — c'est ce qui rend le scénario testable.
- E2E `online-multiplayer` : les deux sièges ouvrent le dialogue de statistiques en fin de partie et comparent les nombres de tours.
- 3 tests unitaires sur l'ordre `stats → endGame` (report, fallback, envoi unique).
- Note d'architecture dans `docs/architecture/online-multiplayer.md`.

## Validation

- `playwright test tests/ui/online-multiplayer.spec.ts --project=chromium-desktop` — 3/3
- `pnpm test` — 624 tests, tous verts
- `pnpm typecheck` — propre
- Régression vérifiée : en réintroduisant l'ancien ordre d'envoi, le test E2E échoue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)