### PR TITLE
ci: let the review workflow post its review comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      # write, not read: the review is delivered as a PR comment, which the
+      # action cannot post with a read-only pull-requests scope.
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
This was sitting as an uncommitted edit in my working tree, so it's committed here deliberately rather than left to drift.

`claude-code-review.yml` runs `/code-review` and delivers the result as a PR comment, but the job only held `pull-requests: read` — it could never post what it produced.

**On widening the scope:** the trigger is `pull_request`, not `pull_request_target`. Fork PRs therefore get a read-only token and no access to secrets no matter what this block declares, so the `write` grant only ever applies to same-repo branches. Everything else in the block is untouched, and `contents` stays `read`.

Added an inline comment so the next reader doesn't have to reconstruct why it's `write`.

---

Two related notes from the same sweep, neither of which needed a commit:

- A stray `--git-common-dir/` directory was sitting untracked in the repo root, containing only `info/exclude` with the single line `.claude/worktrees/`. Some tool's `$(git rev-parse --git-common-dir)` substitution failed and left the literal flag as a path. Removed locally. I grepped `.husky`, `.github`, `.claude`, and `.codex` — the generator isn't in this repo, so there's no in-repo fix to make. Worth knowing it may come back.
- `investigations/` is excluded via `.git/info/exclude` rather than `.gitignore`. I'd initially flagged that as an oversight; it isn't — it sits under a "Local investigation notes" comment with your other machine-local entries, so it's deliberate and I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)