### PR TITLE
refactor(web): extract the deferred endGame signal

### DIFF
--- a/apps/web/src/hooks/useOnlineSkipBoGame.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame.ts
@@ -25,6 +25,11 @@ import {
 } from '@/hooks/useOnlineSkipBoGame/helpers';
 import { deriveLobbyState } from '@/hooks/useOnlineSkipBoGame/lobbyState';
 import { createViewEchoTracker } from '@/hooks/useOnlineSkipBoGame/viewEchoes';
+import {
+  createEndGameSignal,
+  END_GAME_STATS_GRACE_MS,
+  type EndGameSignal,
+} from '@/hooks/useOnlineSkipBoGame/endGameSignal';
 import { useDebugActions } from '@/game/debugActions';
 import { preparePlayCardIntent, prepareDiscardCardIntent } from '@/game/moveIntents';
 import { startDiscardCardAnimation, startPlayCardAnimation } from '@/game/moveAnimations';
@@ -32,13 +37,7 @@ import { type ConnectionStatus, type HostSnapshotPayload } from '@/hooks/useOnli
 import { useOnlineConnection } from '@/hooks/useOnlineSkipBoGame/useOnlineConnection';
 
 export { inferOpponentTransition, type OpponentTransition };
-
-/**
- * How long the host waits for its own end-of-game stats record before sending
- * `endGame` anyway. The record normally arrives on the very next render; this
- * is only the safety net that guarantees the room reaches FINISHED.
- */
-export const END_GAME_STATS_GRACE_MS = 3000;
+export { END_GAME_STATS_GRACE_MS };
 
 export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
   const [view, setView] = useState<ClientGameView | null>(null);
@@ -64,11 +63,8 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
   const roomMetaRef = useRef<HostRoomMeta | null>(null);
   const lastBroadcastTurnRef = useRef<number | null>(null);
   // Host only: the `endGame` message held back until the end-of-game stats have
-  // been relayed (a finished room rejects relays), plus the fallback timer that
-  // sends it anyway if the record never materializes.
-  const pendingEndGameRef = useRef<{ winnerSeatIndex: number | null } | null>(null);
-  const endGameTimeoutRef = useRef<number | null>(null);
-  const endGameSentRef = useRef(false);
+  // been relayed (a finished room rejects relays). See endGameSignal.ts.
+  const endGameSignalRef = useRef<EndGameSignal | null>(null);
   // Duration (ms) of the local play/discard animation that the user just
   // started. When that action ends the turn, the next player's draw animation
   // is held back by this much so the acting player sees the same sequence
@@ -119,28 +115,20 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     [sendRaw],
   );
 
-  // Send the deferred `endGame` (see `pushAuthority`), at most once per game.
-  const flushEndGame = useCallback((): void => {
-    const pending = pendingEndGameRef.current;
-    if (!pending) return;
-    pendingEndGameRef.current = null;
-    if (endGameTimeoutRef.current !== null) {
-      window.clearTimeout(endGameTimeoutRef.current);
-      endGameTimeoutRef.current = null;
-    }
-    endGameSentRef.current = true;
-    sendRaw({ type: 'endGame', winnerSeatIndex: pending.winnerSeatIndex });
+  // Created lazily so it can close over `sendRaw`; one signal per hook instance.
+  const getEndGameSignal = useCallback((): EndGameSignal => {
+    endGameSignalRef.current ??= createEndGameSignal({
+      send: (winnerSeatIndex) => sendRaw({ type: 'endGame', winnerSeatIndex }),
+    });
+    return endGameSignalRef.current;
   }, [sendRaw]);
 
-  useEffect(
-    () => () => {
-      if (endGameTimeoutRef.current !== null) {
-        window.clearTimeout(endGameTimeoutRef.current);
-        endGameTimeoutRef.current = null;
-      }
-    },
-    [],
-  );
+  // Send the deferred `endGame` (see `pushAuthority`), at most once per game.
+  const flushEndGame = useCallback((): void => {
+    getEndGameSignal().flush();
+  }, [getEndGameSignal]);
+
+  useEffect(() => () => endGameSignalRef.current?.dispose(), []);
 
   // The host computes end-of-game stats from its own state — no network delay,
   // no risk of missing an intermediate view — so it is the only trustworthy
@@ -321,22 +309,16 @@ export function useOnlineSkipBoGame(session: CreateRoomResponse | null) {
     };
     sendRaw({ type: 'snapshot', payload: snapshot });
 
-    if (host.gameIsOver && !endGameSentRef.current && pendingEndGameRef.current === null) {
+    if (host.gameIsOver) {
       // Hold `endGame` back until the stats record has been relayed: the server
       // marks the room FINISHED on `endGame` and then rejects every relay, so
       // sending it here would strand the guests without the final statistics.
       // The record is produced one render later (the recorder observes the view
       // we just ingested), hence the deferral rather than an ordering swap.
-      // The timer is the safety net for a game that ends without a record
-      // (e.g. the recorder never opened one after a host reconnect) — the room
-      // must always reach FINISHED.
-      pendingEndGameRef.current = { winnerSeatIndex: host.winnerSeatIndex() };
-      endGameTimeoutRef.current = window.setTimeout(() => {
-        endGameTimeoutRef.current = null;
-        flushEndGame();
-      }, END_GAME_STATS_GRACE_MS);
+      // `arm` is idempotent, so pushing authority again while finished is safe.
+      getEndGameSignal().arm(host.winnerSeatIndex());
     }
-  }, [flushEndGame, sendRaw, sendRelay, session]);
+  }, [getEndGameSignal, sendRaw, sendRelay, session]);
 
   const applyHostAction = useCallback(
     (action: GameAction): void => {

--- a/apps/web/src/hooks/useOnlineSkipBoGame/__tests__/endGameSignal.test.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame/__tests__/endGameSignal.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createEndGameSignal, END_GAME_STATS_GRACE_MS } from '@/hooks/useOnlineSkipBoGame/endGameSignal';
+
+describe('createEndGameSignal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const setup = (graceMs?: number) => {
+    const send = vi.fn();
+    return { send, signal: createEndGameSignal({ send, graceMs }) };
+  };
+
+  it('does not send on arm — the stats record still has to go out first', () => {
+    const { send, signal } = setup();
+
+    signal.arm(2);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(signal.isArmed()).toBe(true);
+    expect(signal.isSent()).toBe(false);
+  });
+
+  it('sends the armed winner on flush and cancels the fallback timer', () => {
+    const { send, signal } = setup();
+
+    signal.arm(2);
+    signal.flush();
+
+    expect(send).toHaveBeenCalledExactlyOnceWith(2);
+    expect(signal.isArmed()).toBe(false);
+    expect(signal.isSent()).toBe(true);
+
+    // The timer must not fire a second endGame after an early flush.
+    vi.advanceTimersByTime(END_GAME_STATS_GRACE_MS * 2);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends anyway when the record never arrives within the grace delay', () => {
+    const { send, signal } = setup();
+
+    signal.arm(null);
+    vi.advanceTimersByTime(END_GAME_STATS_GRACE_MS - 1);
+    expect(send).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledExactlyOnceWith(null);
+    expect(signal.isSent()).toBe(true);
+  });
+
+  it('ignores a flush triggered by a record arriving after the timer fired', () => {
+    const { send, signal } = setup();
+
+    signal.arm(1);
+    vi.advanceTimersByTime(END_GAME_STATS_GRACE_MS);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    signal.flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to re-arm once sent, so a finished game signals exactly once', () => {
+    const { send, signal } = setup();
+
+    signal.arm(0);
+    signal.flush();
+
+    // pushAuthority keeps running while the room sits finished.
+    signal.arm(0);
+    signal.arm(0);
+    vi.advanceTimersByTime(END_GAME_STATS_GRACE_MS * 2);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(signal.isArmed()).toBe(false);
+  });
+
+  it('keeps the first winner when arm is called repeatedly before a flush', () => {
+    const { send, signal } = setup();
+
+    signal.arm(3);
+    signal.arm(1);
+    signal.flush();
+
+    expect(send).toHaveBeenCalledExactlyOnceWith(3);
+  });
+
+  it('is a no-op to flush when nothing was ever armed', () => {
+    const { send, signal } = setup();
+
+    signal.flush();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(signal.isSent()).toBe(false);
+  });
+
+  it('dispose cancels the fallback without sending', () => {
+    const { send, signal } = setup();
+
+    signal.arm(2);
+    signal.dispose();
+    vi.advanceTimersByTime(END_GAME_STATS_GRACE_MS * 2);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('honours a custom grace delay', () => {
+    const { send, signal } = setup(50);
+
+    signal.arm(0);
+    vi.advanceTimersByTime(49);
+    expect(send).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/useOnlineSkipBoGame/endGameSignal.ts
+++ b/apps/web/src/hooks/useOnlineSkipBoGame/endGameSignal.ts
@@ -1,0 +1,96 @@
+/**
+ * Host-side bookkeeping for the deferred `endGame` message.
+ *
+ * The host may not send `endGame` the moment the game is over. The server marks
+ * the room FINISHED on `endGame` and then rejects every relay (409), while the
+ * authoritative end-of-game stats record — the one all seats display — is only
+ * produced a render later, when the stats recorder observes the final view. So
+ * `endGame` is *armed* when the game ends and only *flushed* once the record is
+ * on the wire.
+ *
+ * Two rules make the room always reach FINISHED without ever double-signalling:
+ *
+ * - A fallback timer flushes anyway if the record never materializes (e.g. the
+ *   recorder never opened one after a host reconnect).
+ * - `endGame` goes out at most once per game: arming is refused after a flush,
+ *   and a flush with nothing armed is a no-op. A record arriving *after* the
+ *   timer already fired must not send a second `endGame`.
+ */
+
+/**
+ * How long the host waits for its own end-of-game stats record before sending
+ * `endGame` anyway. The record normally arrives on the very next render; this
+ * is only the safety net that guarantees the room reaches FINISHED.
+ */
+export const END_GAME_STATS_GRACE_MS = 3000;
+
+export interface EndGameSignal {
+  /**
+   * Defer `endGame` for `winnerSeatIndex` and start the fallback timer.
+   * No-op once armed or once already sent, so it is safe to call on every
+   * authority push while the game sits finished.
+   */
+  arm(winnerSeatIndex: number | null): void;
+  /**
+   * Send the armed `endGame` now and cancel the fallback timer. No-op when
+   * nothing is armed — including after a previous flush.
+   */
+  flush(): void;
+  /** Clear the fallback timer without sending (unmount). */
+  dispose(): void;
+  /** Whether an `endGame` is armed and not yet sent. Exposed for assertions. */
+  isArmed(): boolean;
+  /** Whether `endGame` has already gone out. Exposed for assertions. */
+  isSent(): boolean;
+}
+
+export interface EndGameSignalOptions {
+  /**
+   * Sends the `endGame` message. Called at most once per signal. Declared as a
+   * property rather than a method so destructuring it does not trip
+   * `@typescript-eslint/unbound-method`.
+   */
+  send: (winnerSeatIndex: number | null) => void;
+  /** Fallback delay; defaults to {@link END_GAME_STATS_GRACE_MS}. */
+  graceMs?: number;
+}
+
+export const createEndGameSignal = ({
+  send,
+  graceMs = END_GAME_STATS_GRACE_MS,
+}: EndGameSignalOptions): EndGameSignal => {
+  let pending: { winnerSeatIndex: number | null } | null = null;
+  let timeoutId: number | null = null;
+  let sent = false;
+
+  const clearTimer = () => {
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+
+  const flush = () => {
+    if (!pending) return;
+    const { winnerSeatIndex } = pending;
+    pending = null;
+    clearTimer();
+    sent = true;
+    send(winnerSeatIndex);
+  };
+
+  return {
+    arm: (winnerSeatIndex) => {
+      if (sent || pending) return;
+      pending = { winnerSeatIndex };
+      timeoutId = window.setTimeout(() => {
+        timeoutId = null;
+        flush();
+      }, graceMs);
+    },
+    flush,
+    dispose: clearTimer,
+    isArmed: () => pending !== null,
+    isSent: () => sent,
+  };
+};


### PR DESCRIPTION
Behaviour-preserving extraction from `useOnlineSkipBoGame`, following the shape already set by `createViewEchoTracker`.

## Scope correction

I'd originally flagged the optimistic-update / echo-reconciliation logic as the seam worth pulling out. **That's already done on main** — `viewEchoes.ts` and `lobbyState.ts` landed since I looked. So this targets the largest remaining inline concern instead.

## What moved

The end-of-game deferral was spread across the hook as three refs (`pendingEndGameRef`, `endGameTimeoutRef`, `endGameSentRef`), a flush callback, an unmount effect, and an arming branch inside `pushAuthority`. The rules it encodes are genuinely subtle:

- a FINISHED room rejects every relay (409), so `endGame` must trail the stats record rather than race it;
- a fallback timer guarantees the room reaches FINISHED even if the record never materializes;
- `endGame` must go out **exactly once** — including when the record arrives *after* the timer already fired.

All of that now lives in `endGameSignal.ts` as `createEndGameSignal`. Arming is idempotent, so `pushAuthority` no longer has to restate the `!sent && pending === null` guard — it just calls `arm()` while the game is over. Three refs collapse to one.

## Why it's worth doing

Those ordering rules were only reachable by mounting the entire hook against a fake socket. They're now directly testable: **9 new unit tests, no React**, including the flush-after-timer-fired case that the hook-level suite only covers indirectly.

`useOnlineSkipBoGame.ts` goes 623 → 605 lines. The line count isn't the point — the point is that the trickiest timing logic in the file is now isolated and pinned.

## Verification

- `pnpm test` — **544** web tests pass (was 535), including all four existing hook-level `endGame` tests unchanged
- `pnpm lint`, `pnpm typecheck` clean
- `playwright test tests/ui/online-multiplayer.spec.ts tests/ui/online-smoke.spec.ts` — 5 pass, covering the real host/guest end-to-end game, which is the path that actually fires this code

`END_GAME_STATS_GRACE_MS` moved into the new module but is still re-exported from `useOnlineSkipBoGame`, so the existing test import is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)