### PR TITLE
fix(web): make card drags reliable on touch devices

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -90,6 +90,49 @@ discard" invariant true for every input method. The drag path shares rule 1 thro
 Do not re-derive any of this in a component. These rules used to be restated per
 input method, and the copies drifted.
 
+## Drag And Drop (pointer + touch)
+
+`useDraggableCard` binds `onPointerDown` on every draggable card; `DragProvider`
+holds the live session and `DragGhost` renders the floating card. Drops are
+resolved by `src/game/dragTargeting.ts` and edge scrolling by
+`src/game/dragAutoScroll.ts` — both pure enough to unit test, which is where new
+behavior belongs.
+
+A drag never commits a move by itself: crossing the threshold calls `selectCard`,
+and the release calls `playCard` / `discardCard`. That is deliberate — a drag
+released in mid-air leaves the card selected, so the move finishes with one tap.
+It is also what keeps drag inside the "selection first, then play or discard"
+invariant.
+
+**Touch is not a small mouse.** These four exist only because of it, and each one
+fixed a real iPad failure — do not "simplify" them away:
+
+1. **The gesture is taken from the page.** `touch-action: none` on
+   `[data-drag-source]` is advisory on iOS: Safari re-decides a few frames in and
+   can hand the gesture back to the scroller, killing the drag with a
+   `pointercancel`. The hook therefore also cancels `touchmove` (non-passive) for
+   the whole gesture, from the first move, before the threshold is crossed —
+   once WebKit has begun a scroll, the moves stop being cancelable.
+2. **The page must not be scrollable when the board fits.** The safe-area padding
+   sits on `#root`, _outside_ `main`, so a `min-h-svh` on `main` makes every iOS
+   document taller than its viewport. Height comes from the `#main` rule in
+   `styles/layout.css`, which subtracts the insets; `overscroll-behavior: none`
+   kills the rubber band. Putting a `min-h-*` utility back on `main` reintroduces
+   the stray scroll a drag turns into.
+3. **The ghost floats above the fingertip**, because a card under the hand
+   holding it is invisible. A release is then probed at _both_ the ghost and the
+   fingertip (`dragProbePoints`), so aiming with either reads as correct, and
+   near-misses inside `TOUCH_DROP_TOLERANCE_PX` still land. Drop resolution is
+   rect-based rather than `elementFromPoint` — the piles never overlap, so paint
+   order buys nothing and rects allow the tolerance.
+4. **Holding a card at a viewport edge scrolls the board** (`dragAutoScroll`).
+   Since (1) means the page cannot be panned by hand mid-drag, this is the only
+   way to reach a pile that is off-screen when the board doesn't fit.
+
+Only one card is in the air at a time — a module-level pointer-id guard in
+`useDraggableCard`. iPadOS delivers a `pointerdown` for a second finger, and two
+concurrent drags fight over the same `selectedCard`.
+
 ## Keyboard Layer (desktop)
 
 `BoardKeyboardProvider` (`src/contexts/BoardKeyboardContext.tsx`) mounts a global

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -50,10 +50,13 @@ export function AppShell({
 }: AppShellProps) {
   useThemeUsageGameGate(isGameOver);
 
+  // The full-viewport height lives in the `#main` rule in layout.css rather
+  // than a `min-h-svh` utility here: it has to discount the safe-area padding
+  // `#root` adds *around* this box, which a plain 100svh would stack on top of.
   return (
     <main
       id="main"
-      className="min-h-svh px-4 pb-4 pt-1 lg:px-10 lg:pb-10 lg:pt-2"
+      className="px-4 pb-4 pt-1 lg:px-10 lg:pb-10 lg:pt-2"
       data-testid="app-main"
       data-ui-fixture={fixtureName}
     >

--- a/apps/web/src/components/DragGhost.tsx
+++ b/apps/web/src/components/DragGhost.tsx
@@ -6,7 +6,7 @@ export function DragGhost() {
   const { session } = useDrag();
   if (!session) return null;
 
-  const { card, pointer } = session;
+  const { card, pointer, ghostOffsetY } = session;
 
   return createPortal(
     <div
@@ -16,7 +16,7 @@ export function DragGhost() {
         position: 'fixed',
         left: 0,
         top: 0,
-        transform: `translate3d(${pointer.x}px, ${pointer.y}px, 0) translate(-50%, -50%)`,
+        transform: `translate3d(${pointer.x}px, ${pointer.y + ghostOffsetY}px, 0) translate(-50%, -50%)`,
         pointerEvents: 'none',
         zIndex: 1100,
         willChange: 'transform',

--- a/apps/web/src/contexts/DragContext.tsx
+++ b/apps/web/src/contexts/DragContext.tsx
@@ -16,6 +16,7 @@ export const DragProvider: FC<DragProviderProps> = ({ children }) => {
       validBuildPiles: init.validBuildPiles,
       validDiscardPiles: init.validDiscardPiles,
       pointer: init.pointer,
+      ghostOffsetY: init.ghostOffsetY,
       hovered: init.hovered ?? null,
     });
   }, []);

--- a/apps/web/src/contexts/useDrag.ts
+++ b/apps/web/src/contexts/useDrag.ts
@@ -14,6 +14,12 @@ export interface DragSession {
   validBuildPiles: ReadonlySet<number>;
   validDiscardPiles: ReadonlySet<number>;
   pointer: { x: number; y: number };
+  /**
+   * Vertical offset of the ghost from the pointer, in CSS pixels. Negative on
+   * touch, where the card floats above the fingertip so the hand doesn't cover
+   * what it is carrying; 0 for a cursor, which the card can sit right under.
+   */
+  ghostOffsetY: number;
   hovered: DragTargetId | null;
 }
 

--- a/apps/web/src/game/__tests__/dragAutoScroll.test.ts
+++ b/apps/web/src/game/__tests__/dragAutoScroll.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  computeEdgeScrollDelta,
+  createEdgeAutoScroller,
+  EDGE_SCROLL_MAX_SPEED_PX,
+  EDGE_SCROLL_ZONE_PX,
+} from '@/game/dragAutoScroll';
+
+const VIEWPORT = 900;
+
+describe('computeEdgeScrollDelta', () => {
+  test('holds still away from both edges', () => {
+    expect(computeEdgeScrollDelta(450, VIEWPORT)).toBe(0);
+    expect(computeEdgeScrollDelta(EDGE_SCROLL_ZONE_PX, VIEWPORT)).toBe(0);
+    expect(computeEdgeScrollDelta(VIEWPORT - EDGE_SCROLL_ZONE_PX, VIEWPORT)).toBe(0);
+  });
+
+  test('scrolls up near the top and down near the bottom', () => {
+    expect(computeEdgeScrollDelta(10, VIEWPORT)).toBeLessThan(0);
+    expect(computeEdgeScrollDelta(VIEWPORT - 10, VIEWPORT)).toBeGreaterThan(0);
+  });
+
+  test('ramps with depth into the zone and caps at the edge', () => {
+    const shallow = computeEdgeScrollDelta(VIEWPORT - EDGE_SCROLL_ZONE_PX + 10, VIEWPORT);
+    const deep = computeEdgeScrollDelta(VIEWPORT - 5, VIEWPORT);
+    expect(deep).toBeGreaterThan(shallow);
+    expect(computeEdgeScrollDelta(VIEWPORT, VIEWPORT)).toBe(EDGE_SCROLL_MAX_SPEED_PX);
+    // Past the edge — a finger dragged off-screen — stays capped, not faster.
+    expect(computeEdgeScrollDelta(VIEWPORT + 500, VIEWPORT)).toBe(EDGE_SCROLL_MAX_SPEED_PX);
+    expect(computeEdgeScrollDelta(-500, VIEWPORT)).toBe(-EDGE_SCROLL_MAX_SPEED_PX);
+  });
+
+  test('shrinks the zones on a short viewport so the middle stays still', () => {
+    // 150px tall: zones clamp to 50px each, leaving a neutral band.
+    expect(computeEdgeScrollDelta(75, 150)).toBe(0);
+    expect(computeEdgeScrollDelta(10, 150)).toBeLessThan(0);
+    expect(computeEdgeScrollDelta(145, 150)).toBeGreaterThan(0);
+  });
+
+  test('never scrolls when there is no room for a zone', () => {
+    expect(computeEdgeScrollDelta(0, 0)).toBe(0);
+  });
+});
+
+interface Harness {
+  frames: Array<() => void>;
+  scrollY: number;
+  scrollable: boolean;
+}
+
+const createHarness = () => {
+  const state: Harness = { frames: [], scrollY: 0, scrollable: true };
+  const onScrolled = vi.fn();
+  const cancelFrame = vi.fn();
+  const scroller = createEdgeAutoScroller(onScrolled, {
+    getViewportHeight: () => VIEWPORT,
+    getScrollY: () => state.scrollY,
+    scrollBy: (delta) => {
+      if (state.scrollable) state.scrollY += delta;
+    },
+    requestFrame: (callback) => {
+      state.frames.push(callback);
+      return state.frames.length;
+    },
+    cancelFrame,
+  });
+  const runFrame = () => state.frames.shift()?.();
+  return { state, onScrolled, cancelFrame, scroller, runFrame };
+};
+
+describe('createEdgeAutoScroller', () => {
+  test('does not schedule a frame while the pointer is away from the edges', () => {
+    const { state, scroller } = createHarness();
+    scroller.update(450);
+    expect(state.frames).toHaveLength(0);
+  });
+
+  test('scrolls the board and reports it while the pointer sits at an edge', () => {
+    const { state, onScrolled, scroller, runFrame } = createHarness();
+    scroller.update(VIEWPORT - 2);
+    expect(state.frames).toHaveLength(1);
+
+    runFrame();
+    expect(state.scrollY).toBe(EDGE_SCROLL_MAX_SPEED_PX);
+    // The board moved under a stationary finger, so the caller has to
+    // re-resolve which pile is now under it.
+    expect(onScrolled).toHaveBeenCalledTimes(1);
+    // …and it keeps going without any further pointer movement.
+    expect(state.frames).toHaveLength(1);
+
+    runFrame();
+    expect(state.scrollY).toBe(EDGE_SCROLL_MAX_SPEED_PX * 2);
+  });
+
+  test('stops at the end of the document instead of re-rendering every frame', () => {
+    const { state, onScrolled, scroller, runFrame } = createHarness();
+    state.scrollable = false;
+    scroller.update(VIEWPORT - 2);
+    runFrame();
+
+    expect(onScrolled).not.toHaveBeenCalled();
+    expect(state.frames).toHaveLength(0);
+
+    // A later pointermove restarts the loop — the page may be scrollable again.
+    state.scrollable = true;
+    scroller.update(VIEWPORT - 2);
+    expect(state.frames).toHaveLength(1);
+  });
+
+  test('a frame that finds the pointer back in the middle ends the loop', () => {
+    const { state, onScrolled, scroller, runFrame } = createHarness();
+    scroller.update(VIEWPORT - 2);
+    scroller.update(450);
+    runFrame();
+
+    expect(state.scrollY).toBe(0);
+    expect(onScrolled).not.toHaveBeenCalled();
+    expect(state.frames).toHaveLength(0);
+  });
+
+  test('stop cancels a pending frame and freezes the board', () => {
+    const { state, cancelFrame, scroller, runFrame } = createHarness();
+    scroller.update(VIEWPORT - 2);
+    scroller.stop();
+
+    expect(cancelFrame).toHaveBeenCalledTimes(1);
+    runFrame();
+    expect(state.scrollY).toBe(0);
+  });
+});

--- a/apps/web/src/game/__tests__/dragTargeting.test.ts
+++ b/apps/web/src/game/__tests__/dragTargeting.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, test } from 'vitest';
+
+import {
+  dragProbePoints,
+  dragThresholdFor,
+  distanceToBounds,
+  dropToleranceFor,
+  FALLBACK_CARD_HEIGHT_PX,
+  ghostLiftFor,
+  PRECISE_DRAG_THRESHOLD_PX,
+  PRECISE_DROP_TOLERANCE_PX,
+  readCardHeightPx,
+  resolveDropTarget,
+  TOUCH_DRAG_THRESHOLD_PX,
+  TOUCH_DROP_TOLERANCE_PX,
+} from '@/game/dragTargeting';
+
+const NO_PILES: ReadonlySet<number> = new Set();
+
+/**
+ * jsdom gives every element a zero rect, so drop targets are built by hand and
+ * their rects stubbed. `resolveDropTarget` skips collapsed rects, which is what
+ * keeps the component-level drag tests from matching a pile by accident.
+ */
+const mountDropTarget = (kind: 'build' | 'discard', index: number, bounds: DOMRect | null) => {
+  const element = document.createElement('div');
+  element.setAttribute('data-drop-target', kind);
+  element.setAttribute('data-drop-index', String(index));
+  element.getBoundingClientRect = () => bounds ?? ({ width: 0, height: 0 } as DOMRect);
+  document.body.append(element);
+  return element;
+};
+
+const rect = (left: number, top: number, width: number, height: number): DOMRect =>
+  ({ left, top, width, height, right: left + width, bottom: top + height, x: left, y: top }) as DOMRect;
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('drag geometry', () => {
+  test('a finger has to travel further than a cursor before a press becomes a drag', () => {
+    expect(dragThresholdFor('mouse')).toBe(PRECISE_DRAG_THRESHOLD_PX);
+    expect(dragThresholdFor('pen')).toBe(PRECISE_DRAG_THRESHOLD_PX);
+    expect(dragThresholdFor('touch')).toBe(TOUCH_DRAG_THRESHOLD_PX);
+    expect(TOUCH_DRAG_THRESHOLD_PX).toBeGreaterThan(PRECISE_DRAG_THRESHOLD_PX);
+  });
+
+  test('only touch gets a drop tolerance — a cursor lands where it is pointed', () => {
+    expect(dropToleranceFor('mouse')).toBe(PRECISE_DROP_TOLERANCE_PX);
+    expect(dropToleranceFor('pen')).toBe(PRECISE_DROP_TOLERANCE_PX);
+    expect(dropToleranceFor('touch')).toBe(TOUCH_DROP_TOLERANCE_PX);
+  });
+
+  test('the ghost floats above a fingertip and sits under a cursor', () => {
+    expect(ghostLiftFor('mouse', 100)).toBe(0);
+    expect(ghostLiftFor('pen', 100)).toBe(0);
+    expect(ghostLiftFor('touch', 100)).toBe(60);
+    // Scales with the responsive card size rather than a fixed pixel budget.
+    expect(ghostLiftFor('touch', 66)).toBe(40);
+  });
+
+  test('a lifted ghost is probed before the fingertip; an unlifted one only once', () => {
+    expect(dragProbePoints(10, 200, 40)).toEqual([
+      { x: 10, y: 160 },
+      { x: 10, y: 200 },
+    ]);
+    expect(dragProbePoints(10, 200, 0)).toEqual([{ x: 10, y: 200 }]);
+  });
+
+  test('card height falls back when --card-height is unreadable', () => {
+    expect(readCardHeightPx()).toBe(FALLBACK_CARD_HEIGHT_PX);
+    document.documentElement.style.setProperty('--card-height', '100px');
+    expect(readCardHeightPx()).toBe(100);
+    document.documentElement.style.removeProperty('--card-height');
+
+    // No layout engine at all (SSR, a very early paint): still a usable lift
+    // rather than a NaN offset that would park the ghost off-screen.
+    const realGetComputedStyle = window.getComputedStyle;
+    Reflect.deleteProperty(window, 'getComputedStyle');
+    expect(readCardHeightPx()).toBe(FALLBACK_CARD_HEIGHT_PX);
+    window.getComputedStyle = realGetComputedStyle;
+  });
+
+  test('distance is zero inside the bounds and the shortest gap outside them', () => {
+    const bounds = { left: 0, top: 0, right: 10, bottom: 10 };
+    expect(distanceToBounds({ x: 5, y: 5 }, bounds)).toBe(0);
+    expect(distanceToBounds({ x: 5, y: 14 }, bounds)).toBe(4);
+    expect(distanceToBounds({ x: -3, y: 5 }, bounds)).toBe(3);
+    expect(distanceToBounds({ x: 13, y: 14 }, bounds)).toBe(5);
+  });
+});
+
+describe('resolveDropTarget', () => {
+  test('resolves a pile the point sits inside', () => {
+    mountDropTarget('build', 2, rect(100, 100, 70, 100));
+    expect(resolveDropTarget([{ x: 120, y: 150 }], new Set([2]), NO_PILES, 0)).toEqual({ kind: 'build', index: 2 });
+  });
+
+  test('ignores piles the dragged card cannot legally land on', () => {
+    mountDropTarget('build', 2, rect(100, 100, 70, 100));
+    mountDropTarget('discard', 1, rect(300, 100, 70, 100));
+    expect(resolveDropTarget([{ x: 120, y: 150 }], NO_PILES, NO_PILES, 0)).toBeNull();
+    expect(resolveDropTarget([{ x: 330, y: 150 }], NO_PILES, NO_PILES, 0)).toBeNull();
+    expect(resolveDropTarget([{ x: 330, y: 150 }], NO_PILES, new Set([1]), 0)).toEqual({ kind: 'discard', index: 1 });
+  });
+
+  test('a near-miss lands on the closest pile within the tolerance', () => {
+    mountDropTarget('build', 0, rect(100, 100, 70, 100));
+    // 12 px below the pile: a miss for a cursor, a hit for a finger.
+    const justBelow = [{ x: 135, y: 212 }];
+    expect(resolveDropTarget(justBelow, new Set([0]), NO_PILES, PRECISE_DROP_TOLERANCE_PX)).toBeNull();
+    expect(resolveDropTarget(justBelow, new Set([0]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toEqual({
+      kind: 'build',
+      index: 0,
+    });
+  });
+
+  test('a miss beyond the tolerance stays a miss', () => {
+    mountDropTarget('build', 0, rect(100, 100, 70, 100));
+    expect(resolveDropTarget([{ x: 135, y: 400 }], new Set([0]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toBeNull();
+  });
+
+  test('between two near-misses the closest pile wins', () => {
+    mountDropTarget('build', 0, rect(0, 100, 70, 100));
+    mountDropTarget('build', 1, rect(90, 100, 70, 100));
+    // 15 px right of pile 0, 5 px left of pile 1.
+    expect(resolveDropTarget([{ x: 85, y: 150 }], new Set([0, 1]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toEqual({
+      kind: 'build',
+      index: 1,
+    });
+  });
+
+  test('a pile under any probe point beats a near-miss on the first one', () => {
+    mountDropTarget('build', 0, rect(0, 0, 70, 100));
+    mountDropTarget('build', 1, rect(0, 130, 70, 100));
+    // Ghost point (y=110) is a 20 px near-miss on pile 0; the fingertip
+    // (y=150) is squarely inside pile 1, and containment always wins.
+    expect(
+      resolveDropTarget(
+        [
+          { x: 35, y: 110 },
+          { x: 35, y: 150 },
+        ],
+        new Set([0, 1]),
+        NO_PILES,
+        TOUCH_DROP_TOLERANCE_PX,
+      ),
+    ).toEqual({ kind: 'build', index: 1 });
+  });
+
+  test('when both probe points land on a pile, the visible ghost decides', () => {
+    mountDropTarget('build', 0, rect(0, 0, 70, 100));
+    mountDropTarget('build', 1, rect(0, 100, 70, 100));
+    expect(
+      resolveDropTarget(
+        [
+          { x: 35, y: 50 },
+          { x: 35, y: 150 },
+        ],
+        new Set([0, 1]),
+        NO_PILES,
+        TOUCH_DROP_TOLERANCE_PX,
+      ),
+    ).toEqual({ kind: 'build', index: 0 });
+  });
+
+  test('collapsed rects are not droppable', () => {
+    mountDropTarget('build', 0, null);
+    expect(resolveDropTarget([{ x: 0, y: 0 }], new Set([0]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toBeNull();
+  });
+
+  test('a malformed drop index is ignored rather than resolving to NaN', () => {
+    const element = mountDropTarget('build', 0, rect(0, 0, 70, 100));
+    element.setAttribute('data-drop-index', 'oops');
+    expect(resolveDropTarget([{ x: 35, y: 50 }], new Set([0]), NO_PILES, 0)).toBeNull();
+  });
+});

--- a/apps/web/src/game/dragAutoScroll.ts
+++ b/apps/web/src/game/dragAutoScroll.ts
@@ -1,0 +1,108 @@
+/**
+ * Edge auto-scroll for card drags.
+ *
+ * A drag owns the touch gesture end to end, so the page cannot be scrolled by
+ * hand while a card is in the air. On a viewport that shows the whole board
+ * that is exactly what we want. When the board *doesn't* fit — a phone, or an
+ * iPad in portrait with a tall theme — it would otherwise make the off-screen
+ * piles unreachable by drag at all. Holding the card near the top or bottom
+ * edge scrolls the board under it instead.
+ */
+
+/** Distance from a viewport edge at which the board starts moving. */
+export const EDGE_SCROLL_ZONE_PX = 88;
+/** Scroll speed, in CSS pixels per frame, at the very edge of the viewport. */
+export const EDGE_SCROLL_MAX_SPEED_PX = 22;
+
+/**
+ * Pixels to scroll this frame: negative up, positive down, 0 outside the edge
+ * zones. Ramps linearly with how deep into the zone the pointer is, so easing
+ * a card toward the edge creeps and pinning it there moves at full speed.
+ */
+export const computeEdgeScrollDelta = (
+  pointerY: number,
+  viewportHeight: number,
+  zonePx: number = EDGE_SCROLL_ZONE_PX,
+  maxSpeedPx: number = EDGE_SCROLL_MAX_SPEED_PX,
+): number => {
+  // On a short viewport the two zones would overlap and the board would never
+  // hold still; a third of the height each is the most that stays usable.
+  const zone = Math.min(zonePx, Math.floor(viewportHeight / 3));
+  if (zone <= 0) return 0;
+
+  const topDepth = zone - pointerY;
+  if (topDepth > 0) return -Math.ceil((Math.min(topDepth, zone) / zone) * maxSpeedPx);
+
+  const bottomDepth = pointerY - (viewportHeight - zone);
+  if (bottomDepth > 0) return Math.ceil((Math.min(bottomDepth, zone) / zone) * maxSpeedPx);
+
+  return 0;
+};
+
+export interface EdgeAutoScrollerDeps {
+  getViewportHeight: () => number;
+  getScrollY: () => number;
+  scrollBy: (deltaY: number) => void;
+  requestFrame: (callback: () => void) => number;
+  cancelFrame: (handle: number) => void;
+}
+
+export interface EdgeAutoScroller {
+  /** Feed the latest pointer position; starts or keeps the loop running. */
+  update: (pointerY: number) => void;
+  stop: () => void;
+}
+
+const defaultDeps = (): EdgeAutoScrollerDeps => ({
+  getViewportHeight: () => window.innerHeight,
+  getScrollY: () => window.scrollY,
+  scrollBy: (deltaY) => window.scrollBy(0, deltaY),
+  requestFrame: (callback) => window.requestAnimationFrame(callback),
+  cancelFrame: (handle) => window.cancelAnimationFrame(handle),
+});
+
+/**
+ * `onScrolled` fires after each frame that actually moved the page, so the
+ * caller can re-resolve which pile now sits under a stationary pointer.
+ */
+export const createEdgeAutoScroller = (
+  onScrolled: () => void,
+  overrides: Partial<EdgeAutoScrollerDeps> = {},
+): EdgeAutoScroller => {
+  const deps = { ...defaultDeps(), ...overrides };
+  let pointerY: number | null = null;
+  let frame: number | null = null;
+
+  const step = () => {
+    frame = null;
+    if (pointerY === null) return;
+    const delta = computeEdgeScrollDelta(pointerY, deps.getViewportHeight());
+    if (delta === 0) return;
+
+    const before = deps.getScrollY();
+    deps.scrollBy(delta);
+    // Already at the top or bottom of the document: stop rather than burn a
+    // frame per tick re-rendering an unchanged board. A later `update` — the
+    // next pointermove — restarts the loop.
+    if (deps.getScrollY() === before) return;
+
+    onScrolled();
+    frame = deps.requestFrame(step);
+  };
+
+  return {
+    update: (nextPointerY: number) => {
+      pointerY = nextPointerY;
+      if (frame !== null) return;
+      if (computeEdgeScrollDelta(nextPointerY, deps.getViewportHeight()) === 0) return;
+      frame = deps.requestFrame(step);
+    },
+    stop: () => {
+      pointerY = null;
+      if (frame !== null) {
+        deps.cancelFrame(frame);
+        frame = null;
+      }
+    },
+  };
+};

--- a/apps/web/src/game/dragTargeting.ts
+++ b/apps/web/src/game/dragTargeting.ts
@@ -1,0 +1,149 @@
+/**
+ * Geometry of a card drag: how far the pointer must travel before a press
+ * becomes a drag, where the ghost sits relative to the pointer, and which pile
+ * a release lands on.
+ *
+ * All of it is parameterised by `pointerType` because a fingertip and a mouse
+ * cursor are not the same instrument. A cursor is a single pixel the user can
+ * see; a fingertip is a ~10 mm contact patch whose reported centre is hidden
+ * under the finger itself. Everything below exists to close that gap.
+ */
+import type { DragTargetId } from '@/contexts/useDrag';
+
+export interface DragPoint {
+  x: number;
+  y: number;
+}
+
+/** Movement that turns a press into a drag, for a cursor or a stylus. */
+export const PRECISE_DRAG_THRESHOLD_PX = 5;
+/**
+ * The same, for a finger. Higher because a touch contact drifts by a few
+ * pixels while the user is merely tapping — at 5 px a tap on a discard pile
+ * regularly promoted itself into a drag that then had to be aimed.
+ */
+export const TOUCH_DRAG_THRESHOLD_PX = 8;
+
+/** How far outside a pile a release still counts, for a cursor or a stylus. */
+export const PRECISE_DROP_TOLERANCE_PX = 0;
+/**
+ * The same, for a finger. The board's piles are separated by gaps wider than
+ * this, so the tolerance turns near-misses into drops without ever making two
+ * piles ambiguous.
+ */
+export const TOUCH_DROP_TOLERANCE_PX = 28;
+
+/**
+ * Fraction of a card's height the ghost floats above a fingertip. Without a
+ * lift the dragged card is entirely hidden under the hand holding it, which is
+ * most of why touch drags "fail": the player cannot see what they are carrying
+ * or where it is about to land.
+ */
+const TOUCH_GHOST_LIFT_RATIO = 0.6;
+
+/** Used when `--card-height` cannot be read (jsdom, very early paint). */
+export const FALLBACK_CARD_HEIGHT_PX = 66;
+
+const isCoarse = (pointerType: string): boolean => pointerType === 'touch';
+
+export const dragThresholdFor = (pointerType: string): number =>
+  isCoarse(pointerType) ? TOUCH_DRAG_THRESHOLD_PX : PRECISE_DRAG_THRESHOLD_PX;
+
+export const dropToleranceFor = (pointerType: string): number =>
+  isCoarse(pointerType) ? TOUCH_DROP_TOLERANCE_PX : PRECISE_DROP_TOLERANCE_PX;
+
+export const ghostLiftFor = (pointerType: string, cardHeightPx: number): number =>
+  isCoarse(pointerType) ? Math.round(cardHeightPx * TOUCH_GHOST_LIFT_RATIO) : 0;
+
+/** Live `--card-height`, so the lift tracks the responsive card size. */
+export const readCardHeightPx = (): number => {
+  if (typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+    return FALLBACK_CARD_HEIGHT_PX;
+  }
+  const raw = window.getComputedStyle(document.documentElement).getPropertyValue('--card-height');
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : FALLBACK_CARD_HEIGHT_PX;
+};
+
+/**
+ * The points a release is tested against, most-intentional first.
+ *
+ * With the ghost lifted, a player can aim two ways and both read as correct:
+ * put the *card* on the pile, or put the *finger* on the pile. Probing both
+ * means neither aim misses. The lifted point comes first so that when the two
+ * land on different valid piles, the drop matches the card the player can
+ * actually see — which is also the pile lit up as `is-drag-over`.
+ */
+export const dragProbePoints = (x: number, y: number, ghostLiftPx: number): DragPoint[] =>
+  ghostLiftPx > 0
+    ? [
+        { x, y: y - ghostLiftPx },
+        { x, y },
+      ]
+    : [{ x, y }];
+
+interface Bounds {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+/** 0 when the point is inside, otherwise the shortest distance to the edge. */
+export const distanceToBounds = (point: DragPoint, bounds: Bounds): number => {
+  const dx = Math.max(bounds.left - point.x, 0, point.x - bounds.right);
+  const dy = Math.max(bounds.top - point.y, 0, point.y - bounds.bottom);
+  return Math.hypot(dx, dy);
+};
+
+const parseDropTarget = (
+  element: Element,
+  validBuild: ReadonlySet<number>,
+  validDiscard: ReadonlySet<number>,
+): DragTargetId | null => {
+  const kind = element.getAttribute('data-drop-target');
+  const index = Number.parseInt(element.getAttribute('data-drop-index') ?? '', 10);
+  if (Number.isNaN(index)) return null;
+  if (kind === 'build' && validBuild.has(index)) return { kind: 'build', index };
+  if (kind === 'discard' && validDiscard.has(index)) return { kind: 'discard', index };
+  return null;
+};
+
+/**
+ * Which pile a drag is over.
+ *
+ * Deliberately rect-based rather than `document.elementFromPoint`: the piles
+ * never overlap each other, so paint order buys us nothing, while rects let a
+ * near-miss resolve to the closest pile — and let the whole thing be unit
+ * tested without a layout engine.
+ */
+export const resolveDropTarget = (
+  points: readonly DragPoint[],
+  validBuild: ReadonlySet<number>,
+  validDiscard: ReadonlySet<number>,
+  tolerancePx: number,
+  root: ParentNode = document,
+): DragTargetId | null => {
+  const candidates = Array.from(root.querySelectorAll<HTMLElement>('[data-drop-target][data-drop-index]'));
+  let nearest: { target: DragTargetId; distance: number } | null = null;
+
+  for (const point of points) {
+    for (const element of candidates) {
+      const target = parseDropTarget(element, validBuild, validDiscard);
+      if (!target) continue;
+      const rect = element.getBoundingClientRect();
+      // A collapsed rect has no meaningful position; in jsdom every rect is
+      // collapsed, which is what keeps drag unit tests from matching anything.
+      if (rect.width <= 0 || rect.height <= 0) continue;
+      const distance = distanceToBounds(point, rect);
+      // A pile actually under the point always wins over any near-miss, and
+      // the earlier probe point wins over the later one.
+      if (distance === 0) return target;
+      if (distance <= tolerancePx && (nearest === null || distance < nearest.distance)) {
+        nearest = { target, distance };
+      }
+    }
+  }
+
+  return nearest?.target ?? null;
+};

--- a/apps/web/src/hooks/__tests__/useDraggableCard.test.tsx
+++ b/apps/web/src/hooks/__tests__/useDraggableCard.test.tsx
@@ -1,0 +1,327 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { DragGhost } from '@/components/DragGhost';
+import { DragProvider } from '@/contexts/DragContext';
+import { useDrag } from '@/contexts/useDrag';
+import { useDraggableCard } from '@/hooks/useDraggableCard';
+import type { Card, GameConfig, GameState, MoveResult, Player } from '@skipbo/game-core';
+
+const FIXTURE_CONFIG: GameConfig = {
+  DECK_SIZE: 162,
+  SKIP_BO_CARDS: 18,
+  CARD_COPIES_PER_RANK: 12,
+  HAND_SIZE: 5,
+  STOCK_SIZE: 30,
+  BUILD_PILES_COUNT: 4,
+  DISCARD_PILES_COUNT: 4,
+  CARD_VALUES_MIN: 1,
+  CARD_VALUES_MAX: 12,
+  CARD_VALUES_SKIP_BO: 0,
+};
+
+const HAND_CARD: Card = { value: 1, isSkipBo: false };
+
+const createPlayer = (isAI: boolean): Player => ({
+  isAI,
+  stockPile: [{ value: 11, isSkipBo: false }],
+  hand: [HAND_CARD, null, null, null, null],
+  discardPiles: [[], [], [], []],
+});
+
+const GAME_STATE: GameState = {
+  deck: [],
+  buildPiles: [[], [], [], []],
+  completedBuildPiles: [],
+  players: [createPlayer(false), createPlayer(true)],
+  currentPlayerIndex: 0,
+  gameIsOver: false,
+  winnerIndex: null,
+  selectedCard: null,
+  message: { code: 'SELECT_CARD' },
+  config: FIXTURE_CONFIG,
+};
+
+// jsdom neither lays out nor scrolls, so the harness owns both: the build
+// pile's document position and the page's scroll offset are plain variables,
+// and its viewport rect is derived from the two.
+const VIEWPORT_HEIGHT = 768;
+let scrollY = 0;
+let buildPileTop = 100;
+
+const buildPileRect = (): DOMRect => {
+  const top = buildPileTop - scrollY;
+  return { left: 100, right: 170, width: 70, height: 100, top, bottom: top + 100, x: 100, y: top } as DOMRect;
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: VIEWPORT_HEIGHT });
+  Object.defineProperty(window, 'scrollY', { configurable: true, get: () => scrollY });
+  window.scrollBy = ((_x: number, y: number) => {
+    scrollY += y;
+  }) as typeof window.scrollBy;
+});
+
+beforeEach(() => {
+  scrollY = 0;
+  buildPileTop = 100;
+});
+
+const createHandlers = () => ({
+  selectCard: vi.fn(),
+  playCard: vi.fn(async (): Promise<MoveResult> => ({ success: true, message: 'ok' })),
+  discardCard: vi.fn(async (): Promise<MoveResult> => ({ success: true, message: 'ok' })),
+});
+
+type Handlers = ReturnType<typeof createHandlers>;
+
+/** Surfaces the live hover so tests can watch it change without a pointer event. */
+function HoverProbe() {
+  const { session } = useDrag();
+  const hovered = session?.hovered;
+  return <div data-testid="hovered">{hovered ? `${hovered.kind}-${hovered.index}` : 'none'}</div>;
+}
+
+function Harness({ handlers }: { handlers: Handlers }) {
+  const bindings = useDraggableCard({
+    source: { kind: 'hand', index: 0 },
+    card: HAND_CARD,
+    enabled: true,
+    gameState: GAME_STATE,
+    selectCard: handlers.selectCard,
+    playCard: handlers.playCard,
+    discardCard: handlers.discardCard,
+  });
+  return (
+    <>
+      <div data-testid="hand-card" {...bindings} />
+      <div data-testid="second-card" {...bindings} />
+      <div data-testid="build-pile" data-drop-target="build" data-drop-index="0" />
+      <div data-testid="discard-pile" data-drop-target="discard" data-drop-index="2" />
+      <HoverProbe />
+      <DragGhost />
+    </>
+  );
+}
+
+const renderHarness = () => {
+  const handlers = createHandlers();
+  render(
+    <DragProvider>
+      <Harness handlers={handlers} />
+    </DragProvider>,
+  );
+  screen.getByTestId('build-pile').getBoundingClientRect = buildPileRect;
+  screen.getByTestId('discard-pile').getBoundingClientRect = () =>
+    ({ left: 300, right: 370, width: 70, height: 100, top: 100, bottom: 200, x: 300, y: 100 }) as DOMRect;
+  return handlers;
+};
+
+const pointerDown = (testId: string, init: PointerEventInit) =>
+  act(() => {
+    fireEvent.pointerDown(screen.getByTestId(testId), { button: 0, ...init });
+  });
+
+const windowPointerEvent = (type: 'pointermove' | 'pointerup' | 'pointercancel', init: PointerEventInit) =>
+  act(() => {
+    fireEvent(window, new PointerEvent(type, { bubbles: true, ...init }));
+  });
+
+/**
+ * Every test must end the gesture it starts: the "one card in the air at a
+ * time" guard is module state, so a leaked drag would block the next test.
+ */
+afterEach(() => {
+  windowPointerEvent('pointercancel', { pointerId: 1, pointerType: 'touch' });
+  windowPointerEvent('pointercancel', { pointerId: 2, pointerType: 'touch' });
+});
+
+describe('useDraggableCard on touch', () => {
+  test('a finger has to travel further than a cursor before the card lifts', () => {
+    const handlers = renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
+    // 6 px: past the 5 px cursor threshold, short of the 8 px touch one.
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 306, clientY: 300 });
+    expect(handlers.selectCard).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('drag-ghost')).toBeNull();
+
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 310, clientY: 300 });
+    expect(handlers.selectCard).toHaveBeenCalledWith('hand', 0, undefined);
+    expect(screen.getByTestId('drag-ghost')).toBeTruthy();
+  });
+
+  test('the whole touch gesture is taken away from the page scroller', () => {
+    renderHarness();
+    const beforeDrag = new Event('touchmove', { bubbles: true, cancelable: true });
+    document.dispatchEvent(beforeDrag);
+    expect(beforeDrag.defaultPrevented).toBe(false);
+
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
+
+    // Blocked from the very first move, before the drag threshold is even
+    // crossed — once Safari has begun a scroll it is too late to take it back.
+    const duringGesture = new Event('touchmove', { bubbles: true, cancelable: true });
+    document.dispatchEvent(duringGesture);
+    expect(duringGesture.defaultPrevented).toBe(true);
+
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
+
+    const afterGesture = new Event('touchmove', { bubbles: true, cancelable: true });
+    document.dispatchEvent(afterGesture);
+    expect(afterGesture.defaultPrevented).toBe(false);
+  });
+
+  test('a mouse gesture leaves page scrolling alone', () => {
+    renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'mouse', clientX: 300, clientY: 300 });
+
+    const duringGesture = new Event('touchmove', { bubbles: true, cancelable: true });
+    document.dispatchEvent(duringGesture);
+    expect(duringGesture.defaultPrevented).toBe(false);
+
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'mouse', clientX: 300, clientY: 300 });
+  });
+
+  test('the ghost floats above the fingertip so the hand does not cover it', () => {
+    renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 320 });
+
+    // 66 px fallback card height × 0.6 lift = 40 px above the pointer.
+    expect(screen.getByTestId('drag-ghost').style.transform).toContain('translate3d(300px, 280px, 0)');
+  });
+
+  test('the ghost sits under a cursor', () => {
+    renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'mouse', clientX: 300, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'mouse', clientX: 300, clientY: 320 });
+
+    expect(screen.getByTestId('drag-ghost').style.transform).toContain('translate3d(300px, 320px, 0)');
+
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'mouse', clientX: 300, clientY: 320 });
+  });
+
+  test('a release that misses the pile by a few pixels still plays the card', () => {
+    const handlers = renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
+    // Finger 12 px below the pile, so the lifted ghost is well inside it.
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 212 });
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 212 });
+
+    expect(handlers.playCard).toHaveBeenCalledWith(0);
+  });
+
+  test('a release over a discard pile discards rather than plays', () => {
+    const handlers = renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 335, clientY: 190 });
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 335, clientY: 190 });
+
+    expect(handlers.discardCard).toHaveBeenCalledWith(2);
+    expect(handlers.playCard).not.toHaveBeenCalled();
+  });
+
+  test('Escape drops the card back without committing it', () => {
+    const handlers = renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 190 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 212 });
+    expect(screen.getByTestId('hovered').textContent).toBe('build-0');
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Escape' });
+    });
+    expect(screen.queryByTestId('drag-ghost')).toBeNull();
+
+    // Releasing after the escape must not still commit the move.
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 212 });
+    expect(handlers.playCard).not.toHaveBeenCalled();
+  });
+
+  test('a release nowhere near a pile leaves the card selected instead of played', () => {
+    const handlers = renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 600, clientY: 600 });
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 600, clientY: 600 });
+
+    expect(handlers.playCard).not.toHaveBeenCalled();
+    // The drag flow already committed the selection, so the move is one tap on
+    // the destination away rather than lost.
+    expect(handlers.selectCard).toHaveBeenCalledWith('hand', 0, undefined);
+  });
+
+  test('a second finger cannot grab a second card mid-drag', () => {
+    const handlers = renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 320, clientY: 300 });
+    handlers.selectCard.mockClear();
+
+    pointerDown('second-card', { pointerId: 2, pointerType: 'touch', clientX: 500, clientY: 500 });
+    windowPointerEvent('pointermove', { pointerId: 2, pointerType: 'touch', clientX: 540, clientY: 500 });
+
+    // The second pointer never registered, so it can neither steal the
+    // selection nor drop the first card on the pile under it.
+    expect(handlers.selectCard).not.toHaveBeenCalled();
+
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 320, clientY: 300 });
+    // …and the first drag is still the one that owns the release.
+    expect(handlers.playCard).not.toHaveBeenCalled();
+  });
+
+  test('backgrounding the app mid-drag releases the board instead of wedging it', () => {
+    const handlers = renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 320, clientY: 300 });
+
+    // iOS can end a pointer stream without ever delivering an up or a cancel.
+    act(() => {
+      fireEvent.blur(window);
+    });
+    expect(screen.queryByTestId('drag-ghost')).toBeNull();
+
+    // The single-drag guard and the touchmove block are both released, so the
+    // board is usable again rather than inert until a reload.
+    const afterBlur = new Event('touchmove', { bubbles: true, cancelable: true });
+    document.dispatchEvent(afterBlur);
+    expect(afterBlur.defaultPrevented).toBe(false);
+
+    handlers.selectCard.mockClear();
+    pointerDown('hand-card', { pointerId: 2, pointerType: 'touch', clientX: 300, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 2, pointerType: 'touch', clientX: 320, clientY: 300 });
+    expect(handlers.selectCard).toHaveBeenCalledWith('hand', 0, undefined);
+  });
+
+  test('holding a card at the bottom edge brings an off-screen pile up to it', () => {
+    vi.useFakeTimers();
+    // Off-screen below the fold: out of reach of a stationary finger at y=760.
+    buildPileTop = 800;
+    renderHarness();
+
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 760 });
+    expect(screen.getByTestId('hovered').textContent).toBe('none');
+
+    // One frame of edge scroll, with the finger held perfectly still: the board
+    // moves under it and the pile it now covers lights up.
+    act(() => {
+      vi.advanceTimersToNextFrame();
+    });
+    expect(scrollY).toBeGreaterThan(0);
+    expect(screen.getByTestId('hovered').textContent).toBe('build-0');
+
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 760 });
+    vi.useRealTimers();
+  });
+
+  test('a cancelled gesture releases the guard so the next drag works', () => {
+    const handlers = renderHarness();
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 320, clientY: 300 });
+    windowPointerEvent('pointercancel', { pointerId: 1, pointerType: 'touch', clientX: 320, clientY: 300 });
+    expect(screen.queryByTestId('drag-ghost')).toBeNull();
+    handlers.selectCard.mockClear();
+
+    pointerDown('hand-card', { pointerId: 2, pointerType: 'touch', clientX: 300, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 2, pointerType: 'touch', clientX: 320, clientY: 300 });
+    expect(handlers.selectCard).toHaveBeenCalledWith('hand', 0, undefined);
+  });
+});

--- a/apps/web/src/hooks/useDraggableCard.ts
+++ b/apps/web/src/hooks/useDraggableCard.ts
@@ -3,10 +3,25 @@ import type { PointerEvent as ReactPointerEvent } from 'react';
 import type { Card, GameState, MoveResult } from '@skipbo/game-core';
 import { canPlayCard } from '@skipbo/game-core';
 import { useDrag, type DragSource, type DragTargetId } from '@/contexts/useDrag';
+import { createEdgeAutoScroller } from '@/game/dragAutoScroll';
+import {
+  dragProbePoints,
+  dragThresholdFor,
+  dropToleranceFor,
+  ghostLiftFor,
+  readCardHeightPx,
+  resolveDropTarget,
+} from '@/game/dragTargeting';
 import { canDiscardFromSource } from '@/game/pileIntents';
 import { setDragCommitOverride } from '@/services/dragCommitOverride';
 
-const DRAG_THRESHOLD_PX = 5;
+/**
+ * Only one card is ever in the air. iPadOS happily delivers a `pointerdown`
+ * for a second finger landing on another card, and two concurrent drags would
+ * then fight over the same `selectedCard` — the second one wins the selection
+ * and the first one commits it to the wrong pile.
+ */
+let gestureInFlight = false;
 
 interface UseDraggableCardOptions {
   source: DragSource;
@@ -35,28 +50,6 @@ const computeValidTargets = (card: Card, source: DragSource, gameState: GameStat
   return { validBuildPiles, validDiscardPiles };
 };
 
-const hitTest = (
-  x: number,
-  y: number,
-  validBuild: ReadonlySet<number>,
-  validDiscard: ReadonlySet<number>,
-): DragTargetId | null => {
-  // Guard: jsdom-based unit tests don't implement elementFromPoint.
-  if (typeof document.elementFromPoint !== 'function') return null;
-  const el = document.elementFromPoint(x, y);
-  if (!el) return null;
-  const target = (el as HTMLElement).closest<HTMLElement>('[data-drop-target]');
-  if (!target) return null;
-  const kind = target.getAttribute('data-drop-target');
-  const idxAttr = target.getAttribute('data-drop-index');
-  if (idxAttr === null) return null;
-  const index = Number.parseInt(idxAttr, 10);
-  if (Number.isNaN(index)) return null;
-  if (kind === 'build' && validBuild.has(index)) return { kind: 'build', index };
-  if (kind === 'discard' && validDiscard.has(index)) return { kind: 'discard', index };
-  return null;
-};
-
 export interface DraggableCardBindings {
   onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
   'data-drag-source': string;
@@ -76,6 +69,8 @@ export function useDraggableCard(options: UseDraggableCardOptions): DraggableCar
     (event: ReactPointerEvent<HTMLElement>) => {
       if (!enabled || !card) return;
       if (event.button !== 0 && event.pointerType === 'mouse') return;
+      // A second finger, or a second card grabbed while one is already flying.
+      if (gestureInFlight) return;
       if (isInteractionBlocked?.()) return;
 
       // Stop the browser from starting a native text-selection drag from the card.
@@ -86,10 +81,18 @@ export function useDraggableCard(options: UseDraggableCardOptions): DraggableCar
       const startX = event.clientX;
       const startY = event.clientY;
       const pointerId = event.pointerId;
+      const pointerType = event.pointerType || 'mouse';
+      const isTouch = pointerType === 'touch';
+      const dragThreshold = dragThresholdFor(pointerType);
+      const dropTolerance = dropToleranceFor(pointerType);
+      const ghostLift = ghostLiftFor(pointerType, readCardHeightPx());
       const targetEl = event.currentTarget;
       let started = false;
       let validBuild: Set<number> = new Set();
       let validDiscard: Set<number> = new Set();
+      let lastX = startX;
+      let lastY = startY;
+      gestureInFlight = true;
       wasDraggingRef.current = false;
 
       // Selection is deferred until the drag actually begins (movement crosses
@@ -98,18 +101,46 @@ export function useDraggableCard(options: UseDraggableCardOptions): DraggableCar
       // card is selected discards the hand card to that pile, which is the
       // intended click affordance. Only a real drag swaps the selection.
 
+      const resolveTarget = (x: number, y: number): DragTargetId | null =>
+        resolveDropTarget(dragProbePoints(x, y, ghostLift), validBuild, validDiscard, dropTolerance);
+
       try {
         targetEl.setPointerCapture(pointerId);
       } catch {
         /* safari/iOS sometimes throws on capture; fall back to document listeners */
       }
 
+      // `touch-action: none` on the card is supposed to hand us the whole
+      // gesture, and on iPadOS it often doesn't: Safari re-evaluates the
+      // gesture a few frames in and gives it to the page scroller instead,
+      // which fires `pointercancel` and kills the drag mid-flight — the "it
+      // starts and then the page scrolls" failure. Cancelling the touch stream
+      // outright is the only thing that reliably keeps the drag alive. It is
+      // scoped to this one gesture, so touches that start anywhere else still
+      // scroll and pinch normally.
+      const blockTouchScroll = (touchEvent: TouchEvent) => {
+        if (touchEvent.cancelable) touchEvent.preventDefault();
+      };
+      if (isTouch) {
+        document.addEventListener('touchmove', blockTouchScroll, { passive: false });
+      }
+
+      // The page cannot be panned by hand during a drag (see above), so a
+      // pile scrolled off-screen is only reachable by holding the card near
+      // the edge and letting the board come to it.
+      const autoScroller = createEdgeAutoScroller(() => {
+        if (!started) return;
+        updateDrag({ x: lastX, y: lastY }, resolveTarget(lastX, lastY));
+      });
+
       const onMove = (moveEvent: PointerEvent) => {
         if (moveEvent.pointerId !== pointerId) return;
-        const dx = moveEvent.clientX - startX;
-        const dy = moveEvent.clientY - startY;
+        lastX = moveEvent.clientX;
+        lastY = moveEvent.clientY;
+        const dx = lastX - startX;
+        const dy = lastY - startY;
         if (!started) {
-          if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+          if (Math.hypot(dx, dy) < dragThreshold) return;
           // Now we know it's a real drag — select the source so a mid-air release
           // leaves the card in the .selected state and lets the click flow
           // finish the move.
@@ -122,21 +153,26 @@ export function useDraggableCard(options: UseDraggableCardOptions): DraggableCar
             card,
             validBuildPiles: validBuild,
             validDiscardPiles: validDiscard,
-            pointer: { x: moveEvent.clientX, y: moveEvent.clientY },
+            pointer: { x: lastX, y: lastY },
+            ghostOffsetY: -ghostLift,
             hovered: null,
           });
           started = true;
           wasDraggingRef.current = true;
         }
-        const hovered = hitTest(moveEvent.clientX, moveEvent.clientY, validBuild, validDiscard);
-        updateDrag({ x: moveEvent.clientX, y: moveEvent.clientY }, hovered);
+        updateDrag({ x: lastX, y: lastY }, resolveTarget(lastX, lastY));
+        autoScroller.update(lastY);
       };
 
       const cleanup = () => {
+        gestureInFlight = false;
+        autoScroller.stop();
         window.removeEventListener('pointermove', onMove);
         window.removeEventListener('pointerup', onUp);
         window.removeEventListener('pointercancel', onCancel);
         window.removeEventListener('keydown', onKey);
+        window.removeEventListener('blur', onWindowBlur);
+        document.removeEventListener('touchmove', blockTouchScroll);
         try {
           targetEl.releasePointerCapture(pointerId);
         } catch {
@@ -165,14 +201,15 @@ export function useDraggableCard(options: UseDraggableCardOptions): DraggableCar
           endDrag();
           return;
         }
-        const hovered = hitTest(upEvent.clientX, upEvent.clientY, validBuild, validDiscard);
+        const hovered = resolveTarget(upEvent.clientX, upEvent.clientY);
         endDrag();
         swallowNextClick();
         if (!hovered) return;
-        // Start the play/discard animation from where the user dropped the
-        // ghost rather than from the source DOM position.
+        // Start the play/discard animation from where the ghost was released
+        // rather than from the source DOM position — which on touch is the
+        // lifted card, not the fingertip.
         setDragCommitOverride({
-          startPosition: { x: upEvent.clientX, y: upEvent.clientY },
+          startPosition: { x: upEvent.clientX, y: upEvent.clientY - ghostLift },
         });
         if (hovered.kind === 'build') {
           void playCard(hovered.index);
@@ -181,24 +218,38 @@ export function useDraggableCard(options: UseDraggableCardOptions): DraggableCar
         }
       }
 
-      function onCancel(cancelEvent: PointerEvent) {
-        if (cancelEvent.pointerId !== pointerId) return;
+      // iOS still cancels the odd gesture (a system edge swipe, a call
+      // banner). The source stays selected, so the move is one tap on the
+      // destination away rather than lost.
+      function abortGesture() {
         cleanup();
         if (started) swallowNextClick();
         endDrag();
       }
 
+      function onCancel(cancelEvent: PointerEvent) {
+        if (cancelEvent.pointerId !== pointerId) return;
+        abortGesture();
+      }
+
+      // Backgrounding the app mid-drag — an app switch, Control Center, a
+      // notification — can end the pointer stream without ever delivering an
+      // up or a cancel. Nothing would then release the single-drag guard or
+      // the `touchmove` block, and the board would come back inert.
+      function onWindowBlur() {
+        abortGesture();
+      }
+
       function onKey(keyEvent: KeyboardEvent) {
         if (keyEvent.key !== 'Escape') return;
-        cleanup();
-        if (started) swallowNextClick();
-        endDrag();
+        abortGesture();
       }
 
       window.addEventListener('pointermove', onMove);
       window.addEventListener('pointerup', onUp);
       window.addEventListener('pointercancel', onCancel);
       window.addEventListener('keydown', onKey);
+      window.addEventListener('blur', onWindowBlur);
     },
     [
       enabled,

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -90,6 +90,15 @@
     }
   }
 
+  /* The board is a single screen, not a document: there is nothing above or
+     below it to reveal. Without this, iOS rubber-bands the whole page on any
+     downward flick — including one that started as a card drag — which reads
+     as the board sliding out from under the player's finger. */
+  html,
+  body {
+    overscroll-behavior: none;
+  }
+
   body {
     /* Themes may tint the safe-area gutter separately from the board via
        `--theme-color` (iOS Safari also samples this for the status bar).

--- a/apps/web/src/styles/drag.css
+++ b/apps/web/src/styles/drag.css
@@ -97,7 +97,7 @@
    under-pointer card doesn't flash hoverable states. */
 body[data-drag-active='true'] {
   /* Stop the browser from selecting page text when the user drags a card. */
-  @apply cursor-grabbing select-none;
+  @apply cursor-grabbing select-none touch-none;
 }
 
 body[data-drag-active='true'] .hoverable-card:hover {
@@ -110,9 +110,22 @@ body[data-drag-active='true'] .hoverable-card:hover {
    horizontally because horizontal pan-x isn't a default scroll axis). With
    `touch-action: none` we own every touch gesture that originates on a
    draggable card; the user can still scroll the page by starting the touch
-   on any non-draggable area. */
+   on any non-draggable area.
+
+   The two WebKit properties below close the rest of the hole. iPadOS answers
+   a press-and-hold on ordinary content with its own gestures — the selection
+   callout and the system-wide drag-and-drop session — and either of them
+   takes the pointer stream away from us mid-drag with a `pointercancel`.
+   `touch-action` alone does not suppress them.
+
+   `touch-action` is also only advisory on iOS: Safari re-decides a few frames
+   in and can still hand the gesture to the page scroller, which is why
+   `useDraggableCard` additionally cancels `touchmove` for the duration of a
+   touch drag. */
 [data-drag-source] {
-  @apply touch-none;
+  @apply touch-none select-none;
+  -webkit-touch-callout: none;
+  -webkit-user-drag: none;
 }
 
 .card-drag-ghost {

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -111,6 +111,16 @@
     @apply relative;
   }
 
+  /* The safe-area padding lives on `#root`, *outside* this element's box, so a
+     plain `min-height: 100svh` here makes the document taller than the viewport
+     by the inset — every iOS device ends up with a permanently scrollable page
+     even when the whole board is visible and there is nothing to scroll to. On
+     a touch screen that stray scroll is what a drag turns into. Subtract the
+     insets so the page is exactly as tall as it needs to be. */
+  #main {
+    min-height: calc(100svh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
+  }
+
   .game-status {
     @apply flex flex-col items-center justify-center gap-2;
   }


### PR DESCRIPTION
Dragging a card on an iPad often failed outright, or started and then turned into a page scroll. Four separate things were behind it.

## The page was always scrollable on iOS

`main` carried `min-h-svh` while `#root` puts the safe-area padding **outside** that box, so the document was taller than the viewport by the inset on every iOS device — even when the whole board was visible and there was nothing to scroll to. On a touch screen that stray scroll is exactly what a drag turns into.

Height now comes from a `#main` rule in `styles/layout.css` that subtracts the insets, and `overscroll-behavior: none` on `html, body` stops the rubber band. In Chromium `env(safe-area-inset-*)` resolves to `0px`, so this is a no-op for the committed baselines.

## `touch-action: none` is only advisory on iOS

Safari re-decides the gesture a few frames in and can hand it back to the page scroller, killing the drag with a `pointercancel`. `useDraggableCard` now also cancels `touchmove` (non-passive) for the duration of a touch gesture started on a card — from the very first move, because waiting for the drag threshold is too late: once WebKit has begun a scroll the moves stop being cancelable. It is scoped to the one gesture, so touches starting anywhere else still scroll and pinch normally.

`-webkit-touch-callout: none` and `-webkit-user-drag: none` close the same hole for iPadOS's selection callout and its system-wide drag-and-drop session, neither of which `touch-action` suppresses.

## Aiming with a finger is not aiming with a cursor

- The ghost floats above the fingertip instead of hiding under the hand carrying it.
- A release is resolved against **both** the visible card and the fingertip, so aiming either way reads as correct.
- A near-miss within `TOUCH_DROP_TOLERANCE_PX` still lands on the pile; a cursor keeps a zero tolerance.
- The drag threshold is higher for touch, since a contact drifts a few pixels during what the player means as a tap.

Drop resolution moved from `document.elementFromPoint` to rects (`src/game/dragTargeting.ts`). The piles never overlap, so paint order bought nothing, while rects are what make both the tolerance and unit testing possible.

## Off-screen piles stay reachable

A drag now owns the gesture end to end, so the page cannot be panned by hand mid-drag. On a viewport that doesn't fit the board that would leave an off-screen pile unreachable, so holding a card near the top or bottom edge scrolls the board under it (`src/game/dragAutoScroll.ts`), re-resolving the hover as it moves.

## Robustness

- Only one card is in the air at a time — iPadOS delivers a `pointerdown` for a second finger, and two concurrent drags fought over the same `selectedCard`.
- A window blur aborts the gesture, so a pointer stream lost to an app switch cannot leave the guard set and the board inert.
- A cancelled drag still leaves the source selected, so the move is one tap on the destination away rather than lost.

## Validation

- `pnpm lint`, `pnpm typecheck` — clean.
- `pnpm test` — 583 web + 89 package tests pass, including new unit tests for the drag geometry, drop resolution, the edge auto-scroller, and the touch drag path (threshold, gesture ownership, ghost lift, tolerant drop, discard drop, Escape, blur, second finger, edge scroll).
- `pnpm test:e2e` — green via the macOS `ui` job, which is what validates the committed `*-darwin` visual baselines. It could not be run in the authoring sandbox (Linux, so every screenshot assertion fails with `snapshot doesn't exist`); the remaining local failures there were all resource-starvation timeouts that passed on a serial re-run.

**Not covered by any of the above: a real iPad.** The unit tests drive synthetic pointer events, so they show the logic does what it intends, not that iPadOS behaves as assumed. The `touchmove` cancellation in particular defends against a WebKit behaviour that was reasoned about rather than observed, and the ghost lift changes where a player has to put their finger — both worth a hands-on check before merging.

## Docs

`apps/web/CLAUDE.md` gains a "Drag And Drop (pointer + touch)" section recording why each touch-specific mechanism exists, so a future change doesn't quietly undo one — in particular, putting a `min-h-*` utility back on `main` reintroduces the stray scroll.