### PR TITLE
fix(web): drop the card back under the pointer during a drag

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -119,12 +119,18 @@ fixed a real iPad failure — do not "simplify" them away:
    `styles/layout.css`, which subtracts the insets; `overscroll-behavior: none`
    kills the rubber band. Putting a `min-h-*` utility back on `main` reintroduces
    the stray scroll a drag turns into.
-3. **The ghost floats above the fingertip**, because a card under the hand
-   holding it is invisible. A release is then probed at _both_ the ghost and the
-   fingertip (`dragProbePoints`), so aiming with either reads as correct, and
-   near-misses inside `TOUCH_DROP_TOLERANCE_PX` still land. Drop resolution is
-   rect-based rather than `elementFromPoint` — the piles never overlap, so paint
-   order buys nothing and rects allow the tolerance.
+3. **A near-miss still lands**, within `TOUCH_DROP_TOLERANCE_PX` of the pile,
+   because a fingertip is a contact patch and the piles sit further apart than
+   the tolerance. Drop resolution is rect-based rather than `elementFromPoint` —
+   the piles never overlap, so paint order buys nothing and rects are what allow
+   a tolerance at all.
+
+   **The card rides directly under the pointer, with no offset.** Floating it
+   above the fingertip so the hand doesn't cover it was tried and reverted: the
+   card then shows somewhere other than where it will land, and players aim at
+   the card they see, so they start targeting below the pile. If you reintroduce
+   a lift to make the card visible, the drop point has to move with it.
+
 4. **Holding a card at a viewport edge scrolls the board** (`dragAutoScroll`).
    Since (1) means the page cannot be panned by hand mid-drag, this is the only
    way to reach a pile that is off-screen when the board doesn't fit.

--- a/apps/web/src/components/DragGhost.tsx
+++ b/apps/web/src/components/DragGhost.tsx
@@ -6,7 +6,7 @@ export function DragGhost() {
   const { session } = useDrag();
   if (!session) return null;
 
-  const { card, pointer, ghostOffsetY } = session;
+  const { card, pointer } = session;
 
   return createPortal(
     <div
@@ -16,7 +16,7 @@ export function DragGhost() {
         position: 'fixed',
         left: 0,
         top: 0,
-        transform: `translate3d(${pointer.x}px, ${pointer.y + ghostOffsetY}px, 0) translate(-50%, -50%)`,
+        transform: `translate3d(${pointer.x}px, ${pointer.y}px, 0) translate(-50%, -50%)`,
         pointerEvents: 'none',
         zIndex: 1100,
         willChange: 'transform',

--- a/apps/web/src/contexts/DragContext.tsx
+++ b/apps/web/src/contexts/DragContext.tsx
@@ -16,7 +16,6 @@ export const DragProvider: FC<DragProviderProps> = ({ children }) => {
       validBuildPiles: init.validBuildPiles,
       validDiscardPiles: init.validDiscardPiles,
       pointer: init.pointer,
-      ghostOffsetY: init.ghostOffsetY,
       hovered: init.hovered ?? null,
     });
   }, []);

--- a/apps/web/src/contexts/useDrag.ts
+++ b/apps/web/src/contexts/useDrag.ts
@@ -14,12 +14,6 @@ export interface DragSession {
   validBuildPiles: ReadonlySet<number>;
   validDiscardPiles: ReadonlySet<number>;
   pointer: { x: number; y: number };
-  /**
-   * Vertical offset of the ghost from the pointer, in CSS pixels. Negative on
-   * touch, where the card floats above the fingertip so the hand doesn't cover
-   * what it is carrying; 0 for a cursor, which the card can sit right under.
-   */
-  ghostOffsetY: number;
   hovered: DragTargetId | null;
 }
 

--- a/apps/web/src/game/__tests__/dragTargeting.test.ts
+++ b/apps/web/src/game/__tests__/dragTargeting.test.ts
@@ -1,15 +1,11 @@
 import { afterEach, describe, expect, test } from 'vitest';
 
 import {
-  dragProbePoints,
   dragThresholdFor,
   distanceToBounds,
   dropToleranceFor,
-  FALLBACK_CARD_HEIGHT_PX,
-  ghostLiftFor,
   PRECISE_DRAG_THRESHOLD_PX,
   PRECISE_DROP_TOLERANCE_PX,
-  readCardHeightPx,
   resolveDropTarget,
   TOUCH_DRAG_THRESHOLD_PX,
   TOUCH_DROP_TOLERANCE_PX,
@@ -52,36 +48,6 @@ describe('drag geometry', () => {
     expect(dropToleranceFor('touch')).toBe(TOUCH_DROP_TOLERANCE_PX);
   });
 
-  test('the ghost floats above a fingertip and sits under a cursor', () => {
-    expect(ghostLiftFor('mouse', 100)).toBe(0);
-    expect(ghostLiftFor('pen', 100)).toBe(0);
-    expect(ghostLiftFor('touch', 100)).toBe(60);
-    // Scales with the responsive card size rather than a fixed pixel budget.
-    expect(ghostLiftFor('touch', 66)).toBe(40);
-  });
-
-  test('a lifted ghost is probed before the fingertip; an unlifted one only once', () => {
-    expect(dragProbePoints(10, 200, 40)).toEqual([
-      { x: 10, y: 160 },
-      { x: 10, y: 200 },
-    ]);
-    expect(dragProbePoints(10, 200, 0)).toEqual([{ x: 10, y: 200 }]);
-  });
-
-  test('card height falls back when --card-height is unreadable', () => {
-    expect(readCardHeightPx()).toBe(FALLBACK_CARD_HEIGHT_PX);
-    document.documentElement.style.setProperty('--card-height', '100px');
-    expect(readCardHeightPx()).toBe(100);
-    document.documentElement.style.removeProperty('--card-height');
-
-    // No layout engine at all (SSR, a very early paint): still a usable lift
-    // rather than a NaN offset that would park the ghost off-screen.
-    const realGetComputedStyle = window.getComputedStyle;
-    Reflect.deleteProperty(window, 'getComputedStyle');
-    expect(readCardHeightPx()).toBe(FALLBACK_CARD_HEIGHT_PX);
-    window.getComputedStyle = realGetComputedStyle;
-  });
-
   test('distance is zero inside the bounds and the shortest gap outside them', () => {
     const bounds = { left: 0, top: 0, right: 10, bottom: 10 };
     expect(distanceToBounds({ x: 5, y: 5 }, bounds)).toBe(0);
@@ -94,21 +60,21 @@ describe('drag geometry', () => {
 describe('resolveDropTarget', () => {
   test('resolves a pile the point sits inside', () => {
     mountDropTarget('build', 2, rect(100, 100, 70, 100));
-    expect(resolveDropTarget([{ x: 120, y: 150 }], new Set([2]), NO_PILES, 0)).toEqual({ kind: 'build', index: 2 });
+    expect(resolveDropTarget({ x: 120, y: 150 }, new Set([2]), NO_PILES, 0)).toEqual({ kind: 'build', index: 2 });
   });
 
   test('ignores piles the dragged card cannot legally land on', () => {
     mountDropTarget('build', 2, rect(100, 100, 70, 100));
     mountDropTarget('discard', 1, rect(300, 100, 70, 100));
-    expect(resolveDropTarget([{ x: 120, y: 150 }], NO_PILES, NO_PILES, 0)).toBeNull();
-    expect(resolveDropTarget([{ x: 330, y: 150 }], NO_PILES, NO_PILES, 0)).toBeNull();
-    expect(resolveDropTarget([{ x: 330, y: 150 }], NO_PILES, new Set([1]), 0)).toEqual({ kind: 'discard', index: 1 });
+    expect(resolveDropTarget({ x: 120, y: 150 }, NO_PILES, NO_PILES, 0)).toBeNull();
+    expect(resolveDropTarget({ x: 330, y: 150 }, NO_PILES, NO_PILES, 0)).toBeNull();
+    expect(resolveDropTarget({ x: 330, y: 150 }, NO_PILES, new Set([1]), 0)).toEqual({ kind: 'discard', index: 1 });
   });
 
   test('a near-miss lands on the closest pile within the tolerance', () => {
     mountDropTarget('build', 0, rect(100, 100, 70, 100));
     // 12 px below the pile: a miss for a cursor, a hit for a finger.
-    const justBelow = [{ x: 135, y: 212 }];
+    const justBelow = { x: 135, y: 212 };
     expect(resolveDropTarget(justBelow, new Set([0]), NO_PILES, PRECISE_DROP_TOLERANCE_PX)).toBeNull();
     expect(resolveDropTarget(justBelow, new Set([0]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toEqual({
       kind: 'build',
@@ -118,61 +84,27 @@ describe('resolveDropTarget', () => {
 
   test('a miss beyond the tolerance stays a miss', () => {
     mountDropTarget('build', 0, rect(100, 100, 70, 100));
-    expect(resolveDropTarget([{ x: 135, y: 400 }], new Set([0]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toBeNull();
+    expect(resolveDropTarget({ x: 135, y: 400 }, new Set([0]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toBeNull();
   });
 
   test('between two near-misses the closest pile wins', () => {
     mountDropTarget('build', 0, rect(0, 100, 70, 100));
     mountDropTarget('build', 1, rect(90, 100, 70, 100));
     // 15 px right of pile 0, 5 px left of pile 1.
-    expect(resolveDropTarget([{ x: 85, y: 150 }], new Set([0, 1]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toEqual({
+    expect(resolveDropTarget({ x: 85, y: 150 }, new Set([0, 1]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toEqual({
       kind: 'build',
       index: 1,
     });
   });
 
-  test('a pile under any probe point beats a near-miss on the first one', () => {
-    mountDropTarget('build', 0, rect(0, 0, 70, 100));
-    mountDropTarget('build', 1, rect(0, 130, 70, 100));
-    // Ghost point (y=110) is a 20 px near-miss on pile 0; the fingertip
-    // (y=150) is squarely inside pile 1, and containment always wins.
-    expect(
-      resolveDropTarget(
-        [
-          { x: 35, y: 110 },
-          { x: 35, y: 150 },
-        ],
-        new Set([0, 1]),
-        NO_PILES,
-        TOUCH_DROP_TOLERANCE_PX,
-      ),
-    ).toEqual({ kind: 'build', index: 1 });
-  });
-
-  test('when both probe points land on a pile, the visible ghost decides', () => {
-    mountDropTarget('build', 0, rect(0, 0, 70, 100));
-    mountDropTarget('build', 1, rect(0, 100, 70, 100));
-    expect(
-      resolveDropTarget(
-        [
-          { x: 35, y: 50 },
-          { x: 35, y: 150 },
-        ],
-        new Set([0, 1]),
-        NO_PILES,
-        TOUCH_DROP_TOLERANCE_PX,
-      ),
-    ).toEqual({ kind: 'build', index: 0 });
-  });
-
   test('collapsed rects are not droppable', () => {
     mountDropTarget('build', 0, null);
-    expect(resolveDropTarget([{ x: 0, y: 0 }], new Set([0]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toBeNull();
+    expect(resolveDropTarget({ x: 0, y: 0 }, new Set([0]), NO_PILES, TOUCH_DROP_TOLERANCE_PX)).toBeNull();
   });
 
   test('a malformed drop index is ignored rather than resolving to NaN', () => {
     const element = mountDropTarget('build', 0, rect(0, 0, 70, 100));
     element.setAttribute('data-drop-index', 'oops');
-    expect(resolveDropTarget([{ x: 35, y: 50 }], new Set([0]), NO_PILES, 0)).toBeNull();
+    expect(resolveDropTarget({ x: 35, y: 50 }, new Set([0]), NO_PILES, 0)).toBeNull();
   });
 });

--- a/apps/web/src/game/dragTargeting.ts
+++ b/apps/web/src/game/dragTargeting.ts
@@ -1,12 +1,13 @@
 /**
  * Geometry of a card drag: how far the pointer must travel before a press
- * becomes a drag, where the ghost sits relative to the pointer, and which pile
- * a release lands on.
+ * becomes a drag, and which pile a release lands on.
  *
- * All of it is parameterised by `pointerType` because a fingertip and a mouse
- * cursor are not the same instrument. A cursor is a single pixel the user can
- * see; a fingertip is a ~10 mm contact patch whose reported centre is hidden
- * under the finger itself. Everything below exists to close that gap.
+ * Both are parameterised by `pointerType` because a fingertip and a mouse
+ * cursor are not the same instrument: a cursor is a single pixel the user aims
+ * exactly, a fingertip is a ~10 mm contact patch reported as its centre. The
+ * card itself always rides directly under the pointer, whichever it is — an
+ * offset ghost would show the card somewhere other than where it will land,
+ * and players aim at the card they can see.
  */
 import type { DragTargetId } from '@/contexts/useDrag';
 
@@ -33,17 +34,6 @@ export const PRECISE_DROP_TOLERANCE_PX = 0;
  */
 export const TOUCH_DROP_TOLERANCE_PX = 28;
 
-/**
- * Fraction of a card's height the ghost floats above a fingertip. Without a
- * lift the dragged card is entirely hidden under the hand holding it, which is
- * most of why touch drags "fail": the player cannot see what they are carrying
- * or where it is about to land.
- */
-const TOUCH_GHOST_LIFT_RATIO = 0.6;
-
-/** Used when `--card-height` cannot be read (jsdom, very early paint). */
-export const FALLBACK_CARD_HEIGHT_PX = 66;
-
 const isCoarse = (pointerType: string): boolean => pointerType === 'touch';
 
 export const dragThresholdFor = (pointerType: string): number =>
@@ -51,36 +41,6 @@ export const dragThresholdFor = (pointerType: string): number =>
 
 export const dropToleranceFor = (pointerType: string): number =>
   isCoarse(pointerType) ? TOUCH_DROP_TOLERANCE_PX : PRECISE_DROP_TOLERANCE_PX;
-
-export const ghostLiftFor = (pointerType: string, cardHeightPx: number): number =>
-  isCoarse(pointerType) ? Math.round(cardHeightPx * TOUCH_GHOST_LIFT_RATIO) : 0;
-
-/** Live `--card-height`, so the lift tracks the responsive card size. */
-export const readCardHeightPx = (): number => {
-  if (typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
-    return FALLBACK_CARD_HEIGHT_PX;
-  }
-  const raw = window.getComputedStyle(document.documentElement).getPropertyValue('--card-height');
-  const parsed = Number.parseFloat(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : FALLBACK_CARD_HEIGHT_PX;
-};
-
-/**
- * The points a release is tested against, most-intentional first.
- *
- * With the ghost lifted, a player can aim two ways and both read as correct:
- * put the *card* on the pile, or put the *finger* on the pile. Probing both
- * means neither aim misses. The lifted point comes first so that when the two
- * land on different valid piles, the drop matches the card the player can
- * actually see — which is also the pile lit up as `is-drag-over`.
- */
-export const dragProbePoints = (x: number, y: number, ghostLiftPx: number): DragPoint[] =>
-  ghostLiftPx > 0
-    ? [
-        { x, y: y - ghostLiftPx },
-        { x, y },
-      ]
-    : [{ x, y }];
 
 interface Bounds {
   left: number;
@@ -118,30 +78,26 @@ const parseDropTarget = (
  * tested without a layout engine.
  */
 export const resolveDropTarget = (
-  points: readonly DragPoint[],
+  point: DragPoint,
   validBuild: ReadonlySet<number>,
   validDiscard: ReadonlySet<number>,
   tolerancePx: number,
   root: ParentNode = document,
 ): DragTargetId | null => {
-  const candidates = Array.from(root.querySelectorAll<HTMLElement>('[data-drop-target][data-drop-index]'));
   let nearest: { target: DragTargetId; distance: number } | null = null;
 
-  for (const point of points) {
-    for (const element of candidates) {
-      const target = parseDropTarget(element, validBuild, validDiscard);
-      if (!target) continue;
-      const rect = element.getBoundingClientRect();
-      // A collapsed rect has no meaningful position; in jsdom every rect is
-      // collapsed, which is what keeps drag unit tests from matching anything.
-      if (rect.width <= 0 || rect.height <= 0) continue;
-      const distance = distanceToBounds(point, rect);
-      // A pile actually under the point always wins over any near-miss, and
-      // the earlier probe point wins over the later one.
-      if (distance === 0) return target;
-      if (distance <= tolerancePx && (nearest === null || distance < nearest.distance)) {
-        nearest = { target, distance };
-      }
+  for (const element of root.querySelectorAll<HTMLElement>('[data-drop-target][data-drop-index]')) {
+    const target = parseDropTarget(element, validBuild, validDiscard);
+    if (!target) continue;
+    const rect = element.getBoundingClientRect();
+    // A collapsed rect has no meaningful position; in jsdom every rect is
+    // collapsed, which is what keeps drag unit tests from matching anything.
+    if (rect.width <= 0 || rect.height <= 0) continue;
+    const distance = distanceToBounds(point, rect);
+    // A pile actually under the pointer always wins over any near-miss.
+    if (distance === 0) return target;
+    if (distance <= tolerancePx && (nearest === null || distance < nearest.distance)) {
+      nearest = { target, distance };
     }
   }
 

--- a/apps/web/src/hooks/__tests__/useDraggableCard.test.tsx
+++ b/apps/web/src/hooks/__tests__/useDraggableCard.test.tsx
@@ -182,29 +182,23 @@ describe('useDraggableCard on touch', () => {
     windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'mouse', clientX: 300, clientY: 300 });
   });
 
-  test('the ghost floats above the fingertip so the hand does not cover it', () => {
+  // The card rides the pointer with no offset, for a finger exactly as for a
+  // cursor. A lifted ghost was tried and reverted: showing the card somewhere
+  // other than where it would land made players aim below their target.
+  test.each([['touch'], ['mouse']])('the card rides directly under a %s pointer', (pointerType) => {
     renderHarness();
-    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
-    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 320 });
-
-    // 66 px fallback card height × 0.6 lift = 40 px above the pointer.
-    expect(screen.getByTestId('drag-ghost').style.transform).toContain('translate3d(300px, 280px, 0)');
-  });
-
-  test('the ghost sits under a cursor', () => {
-    renderHarness();
-    pointerDown('hand-card', { pointerId: 1, pointerType: 'mouse', clientX: 300, clientY: 300 });
-    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'mouse', clientX: 300, clientY: 320 });
+    pointerDown('hand-card', { pointerId: 1, pointerType, clientX: 300, clientY: 300 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType, clientX: 300, clientY: 320 });
 
     expect(screen.getByTestId('drag-ghost').style.transform).toContain('translate3d(300px, 320px, 0)');
 
-    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'mouse', clientX: 300, clientY: 320 });
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType, clientX: 300, clientY: 320 });
   });
 
   test('a release that misses the pile by a few pixels still plays the card', () => {
     const handlers = renderHarness();
     pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
-    // Finger 12 px below the pile, so the lifted ghost is well inside it.
+    // 12 px below the pile — inside the touch tolerance, outside the pile.
     windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 212 });
     windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 212 });
 
@@ -214,8 +208,8 @@ describe('useDraggableCard on touch', () => {
   test('a release over a discard pile discards rather than plays', () => {
     const handlers = renderHarness();
     pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 300, clientY: 300 });
-    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 335, clientY: 190 });
-    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 335, clientY: 190 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 335, clientY: 150 });
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 335, clientY: 150 });
 
     expect(handlers.discardCard).toHaveBeenCalledWith(2);
     expect(handlers.playCard).not.toHaveBeenCalled();
@@ -223,8 +217,8 @@ describe('useDraggableCard on touch', () => {
 
   test('Escape drops the card back without committing it', () => {
     const handlers = renderHarness();
-    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 190 });
-    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 212 });
+    pointerDown('hand-card', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 120 });
+    windowPointerEvent('pointermove', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 150 });
     expect(screen.getByTestId('hovered').textContent).toBe('build-0');
 
     act(() => {
@@ -233,7 +227,7 @@ describe('useDraggableCard on touch', () => {
     expect(screen.queryByTestId('drag-ghost')).toBeNull();
 
     // Releasing after the escape must not still commit the move.
-    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 212 });
+    windowPointerEvent('pointerup', { pointerId: 1, pointerType: 'touch', clientX: 135, clientY: 150 });
     expect(handlers.playCard).not.toHaveBeenCalled();
   });
 
@@ -292,7 +286,8 @@ describe('useDraggableCard on touch', () => {
 
   test('holding a card at the bottom edge brings an off-screen pile up to it', () => {
     vi.useFakeTimers();
-    // Off-screen below the fold: out of reach of a stationary finger at y=760.
+    // Off-screen below the fold: out of reach of a stationary finger at y=760,
+    // tolerance included.
     buildPileTop = 800;
     renderHarness();
 

--- a/apps/web/src/hooks/useDraggableCard.ts
+++ b/apps/web/src/hooks/useDraggableCard.ts
@@ -4,14 +4,7 @@ import type { Card, GameState, MoveResult } from '@skipbo/game-core';
 import { canPlayCard } from '@skipbo/game-core';
 import { useDrag, type DragSource, type DragTargetId } from '@/contexts/useDrag';
 import { createEdgeAutoScroller } from '@/game/dragAutoScroll';
-import {
-  dragProbePoints,
-  dragThresholdFor,
-  dropToleranceFor,
-  ghostLiftFor,
-  readCardHeightPx,
-  resolveDropTarget,
-} from '@/game/dragTargeting';
+import { dragThresholdFor, dropToleranceFor, resolveDropTarget } from '@/game/dragTargeting';
 import { canDiscardFromSource } from '@/game/pileIntents';
 import { setDragCommitOverride } from '@/services/dragCommitOverride';
 
@@ -85,7 +78,6 @@ export function useDraggableCard(options: UseDraggableCardOptions): DraggableCar
       const isTouch = pointerType === 'touch';
       const dragThreshold = dragThresholdFor(pointerType);
       const dropTolerance = dropToleranceFor(pointerType);
-      const ghostLift = ghostLiftFor(pointerType, readCardHeightPx());
       const targetEl = event.currentTarget;
       let started = false;
       let validBuild: Set<number> = new Set();
@@ -102,7 +94,7 @@ export function useDraggableCard(options: UseDraggableCardOptions): DraggableCar
       // intended click affordance. Only a real drag swaps the selection.
 
       const resolveTarget = (x: number, y: number): DragTargetId | null =>
-        resolveDropTarget(dragProbePoints(x, y, ghostLift), validBuild, validDiscard, dropTolerance);
+        resolveDropTarget({ x, y }, validBuild, validDiscard, dropTolerance);
 
       try {
         targetEl.setPointerCapture(pointerId);
@@ -154,7 +146,6 @@ export function useDraggableCard(options: UseDraggableCardOptions): DraggableCar
             validBuildPiles: validBuild,
             validDiscardPiles: validDiscard,
             pointer: { x: lastX, y: lastY },
-            ghostOffsetY: -ghostLift,
             hovered: null,
           });
           started = true;
@@ -205,11 +196,10 @@ export function useDraggableCard(options: UseDraggableCardOptions): DraggableCar
         endDrag();
         swallowNextClick();
         if (!hovered) return;
-        // Start the play/discard animation from where the ghost was released
-        // rather than from the source DOM position — which on touch is the
-        // lifted card, not the fingertip.
+        // Start the play/discard animation from where the user released the
+        // card rather than from the source DOM position.
         setDragCommitOverride({
-          startPosition: { x: upEvent.clientX, y: upEvent.clientY - ghostLift },
+          startPosition: { x: upEvent.clientX, y: upEvent.clientY },
         });
         if (hovered.kind === 'build') {
           void playCard(hovered.index);


### PR DESCRIPTION
Follow-up to #251, from playing it on the device.

## The problem

The touch drag ghost floated 0.6 card-heights above the fingertip, so the hand wouldn't cover the card it was carrying. In use that reads as **the card jumping away the moment the drag starts** — and because players aim at the card they can see, it makes them target *below* the pile they actually want.

#251 tried to absorb that by resolving a release against **both** the lifted card and the fingertip, so either aim would work. That does keep both aims functional, but it cannot fix the thing that is actually wrong: whichever of the two points wins, the card is still drawn somewhere other than where it will land. An offset ghost and an honest drop point are not reconcilable.

## The fix

The ghost rides the pointer exactly, for a finger as for a cursor. What you see is where it drops.

With the offset gone, everything that existed to support it goes too:

- `TOUCH_GHOST_LIFT_RATIO`, `ghostLiftFor`, `readCardHeightPx`, `FALLBACK_CARD_HEIGHT_PX`
- `dragProbePoints` and the multi-point loop in `resolveDropTarget`, which collapses back to a single point
- `ghostOffsetY` on `DragSession`

`setDragCommitOverride` goes back to starting the play/discard animation at the release point rather than at the lifted card.

## What is deliberately kept

Everything else from #251 stands — this touches only the ghost offset:

- the `touchmove` cancellation that stops Safari handing a drag back to the page scroller
- the `#main` height fix and `overscroll-behavior: none`
- **`TOUCH_DROP_TOLERANCE_PX`**, which now carries fingertip imprecision on its own. It was always the part doing the real work; the lift was only ever about visibility.
- rect-based drop resolution, the edge auto-scroller, the single-gesture guard, the blur abort

The card is partly under the finger again, which is the cost of the offset going away. That is the trade #251 got backwards: seeing the whole card matters less than the card being where you are pointing.

## Validation

- `pnpm lint`, `pnpm typecheck` — clean.
- `pnpm test` — 582 web + 89 package tests pass. The two ghost-position tests became one parameterised case asserting no offset for either pointer type, and the drop tests now aim at the piles directly instead of via the lift.
- 100% line coverage on every changed file.
- E2E/visual run on the macOS `ui` job as usual; the authoring sandbox is Linux and has no `*-darwin` baselines.

## Docs

The "Drag And Drop (pointer + touch)" section in `apps/web/CLAUDE.md` now records the lift as tried-and-reverted, with the reason — so the next person tempted by "the finger covers the card" knows the drop point has to move with it, or not to move it at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01485yGBawjcEVC4xBhQqgMY)_